### PR TITLE
feat(surveillance): enforce DNA-bound aggregate publication

### DIFF
--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -41,6 +41,17 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          EXPECTED="${{ github.event.pull_request.head.sha || github.sha }}"
+          ACTUAL="$(git rev-parse HEAD)"
+          test "$ACTUAL" = "$EXPECTED"
+          echo "QUALIFIED_SOURCE_HEAD=$ACTUAL"
 
       # Cargo resolves the whole workspace graph. Recreate the sibling paths
       # expected when mycelix-health is checked out inside the parent mycelix repo,

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -61,9 +61,9 @@ jobs:
           rm -rf /tmp/mycelix-parent
 
       - name: Install pinned Rust
+        # This pinned rust-toolchain action revision itself selects Rust 1.96.0.
         uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e
         with:
-          toolchain: 1.96.0
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
 

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -31,8 +31,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  # Path dependencies are not content-pinned by Cargo.lock. Freeze the exact
-  # parent workspace source used to recreate mycelix-health's sibling layout.
   PARENT_MYCELIX_REF: 7daefcbfa6c4427809e9d8dc24a039bb024da5e9
 
 jobs:
@@ -40,7 +38,7 @@ jobs:
     name: Policy-bound publication qualification
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5 / node24
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
@@ -53,9 +51,6 @@ jobs:
           test "$ACTUAL" = "$EXPECTED"
           echo "QUALIFIED_SOURCE_HEAD=$ACTUAL"
 
-      # Cargo resolves the whole workspace graph. Recreate the sibling paths
-      # expected when mycelix-health is checked out inside the parent mycelix repo,
-      # but never from a moving parent branch.
       - name: Check out pinned parent workspace dependencies
         shell: bash
         run: |
@@ -72,7 +67,6 @@ jobs:
           rm -rf /tmp/mycelix-parent
 
       - name: Install pinned Rust
-        # This pinned rust-toolchain action revision itself selects Rust 1.96.0.
         uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e
         with:
           components: rustfmt, clippy
@@ -96,8 +90,8 @@ jobs:
             zomes/surveillance/coordinator/Cargo.toml
           if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
 
-      - name: Verify committed lock graph
-        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+      - name: Verify complete committed lock graph
+        run: cargo metadata --locked --format-version 1 > /dev/null
 
       - name: Check formatting
         run: cargo fmt -p surveillance_integrity -p surveillance -- --check

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -10,6 +10,7 @@ on:
       - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-dna.yml"
   push:
     branches: [main]
@@ -19,6 +20,7 @@ on:
       - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-dna.yml"
   workflow_dispatch:
 
@@ -36,9 +38,9 @@ env:
 jobs:
   surveillance-dna:
     name: Policy-bound publication qualification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # Cargo resolves the whole workspace graph. Recreate the sibling paths
       # expected when mycelix-health is checked out inside the parent mycelix repo,
@@ -59,8 +61,9 @@ jobs:
           rm -rf /tmp/mycelix-parent
 
       - name: Install pinned Rust
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e
         with:
+          toolchain: 1.96.0
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
 
@@ -68,6 +71,19 @@ jobs:
         id: host
         shell: bash
         run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Record qualification environment
+        shell: bash
+        run: |
+          echo "HEAD=$(git rev-parse HEAD)"
+          echo "PARENT_MYCELIX_REF=$PARENT_MYCELIX_REF"
+          rustc -vV
+          cargo -Vv
+          sha256sum Cargo.toml Cargo.lock \
+            crates/health-surveillance-core/Cargo.toml \
+            zomes/surveillance/integrity/Cargo.toml \
+            zomes/surveillance/coordinator/Cargo.toml
+          if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
 
       - name: Verify committed lock graph
         run: cargo metadata --locked --format-version 1 --no-deps > /dev/null

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -22,9 +22,16 @@ on:
       - ".github/workflows/surveillance-dna.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Path dependencies are not content-pinned by Cargo.lock. Freeze the exact
+  # parent workspace source used to recreate mycelix-health's sibling layout.
+  PARENT_MYCELIX_REF: 7daefcbfa6c4427809e9d8dc24a039bb024da5e9
 
 jobs:
   surveillance-dna:
@@ -34,10 +41,17 @@ jobs:
       - uses: actions/checkout@v4
 
       # Cargo resolves the whole workspace graph. Recreate the sibling paths
-      # expected when mycelix-health is checked out inside the parent mycelix repo.
-      - name: Check out parent workspace dependencies
+      # expected when mycelix-health is checked out inside the parent mycelix repo,
+      # but never from a moving parent branch.
+      - name: Check out pinned parent workspace dependencies
+        shell: bash
         run: |
-          git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
+          git init /tmp/mycelix-parent
+          git -C /tmp/mycelix-parent remote add origin https://github.com/Luminous-Dynamics/mycelix.git
+          git -C /tmp/mycelix-parent fetch --depth 1 origin "$PARENT_MYCELIX_REF"
+          git -C /tmp/mycelix-parent checkout --detach FETCH_HEAD
+          test "$(git -C /tmp/mycelix-parent rev-parse HEAD)" = "$PARENT_MYCELIX_REF"
+
           mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
           cp -r /tmp/mycelix-parent/crates/. ../crates/
           cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
@@ -54,6 +68,9 @@ jobs:
         id: host
         shell: bash
         run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Verify committed lock graph
+        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
 
       - name: Check formatting
         run: cargo fmt -p surveillance_integrity -p surveillance -- --check

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -1,8 +1,9 @@
 name: Public Health Surveillance DNA
 
 on:
+  # Intentionally allow stacked PR bases. This tranche is expected to target the
+  # evidence-core feature branch until #10 lands, then be retargeted to main.
   pull_request:
-    branches: [main]
     paths:
       - "crates/health-surveillance-core/**"
       - "zomes/surveillance/**"

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -1,0 +1,73 @@
+name: Public Health Surveillance DNA
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/health-surveillance-core/**"
+      - "zomes/surveillance/**"
+      - "dna/surveillance/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/surveillance-dna.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/health-surveillance-core/**"
+      - "zomes/surveillance/**"
+      - "dna/surveillance/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/surveillance-dna.yml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  surveillance-dna:
+    name: Policy-bound publication qualification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Cargo resolves the whole workspace graph. Recreate the sibling paths
+      # expected when mycelix-health is checked out inside the parent mycelix repo.
+      - name: Check out parent workspace dependencies
+        run: |
+          git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
+          mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
+          cp -r /tmp/mycelix-parent/crates/. ../crates/
+          cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
+          cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-workspace/mycelix-core/
+          rm -rf /tmp/mycelix-parent
+
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Resolve host target
+        id: host
+        shell: bash
+        run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Check formatting
+        run: cargo fmt -p surveillance_integrity -p surveillance -- --check
+
+      - name: Run integrity host tests
+        run: cargo test -p surveillance_integrity --target "${{ steps.host.outputs.triple }}"
+
+      - name: Run coordinator host tests
+        run: cargo test -p surveillance --target "${{ steps.host.outputs.triple }}"
+
+      - name: Run host Clippy
+        run: cargo clippy -p surveillance_integrity -p surveillance --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+
+      - name: Check integrity WASM compatibility
+        run: cargo check -p surveillance_integrity --target wasm32-unknown-unknown
+
+      - name: Check coordinator WASM compatibility
+        run: cargo check -p surveillance --target wasm32-unknown-unknown

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -59,16 +59,16 @@ jobs:
         run: cargo fmt -p surveillance_integrity -p surveillance -- --check
 
       - name: Run integrity host tests
-        run: cargo test -p surveillance_integrity --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p surveillance_integrity --target "${{ steps.host.outputs.triple }}"
 
       - name: Run coordinator host tests
-        run: cargo test -p surveillance --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p surveillance --target "${{ steps.host.outputs.triple }}"
 
       - name: Run host Clippy
-        run: cargo clippy -p surveillance_integrity -p surveillance --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+        run: cargo clippy --locked -p surveillance_integrity -p surveillance --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
 
       - name: Check integrity WASM compatibility
-        run: cargo check -p surveillance_integrity --target wasm32-unknown-unknown
+        run: cargo check --locked -p surveillance_integrity --target wasm32-unknown-unknown
 
       - name: Check coordinator WASM compatibility
-        run: cargo check -p surveillance --target wasm32-unknown-unknown
+        run: cargo check --locked -p surveillance --target wasm32-unknown-unknown

--- a/.github/workflows/surveillance-lock-apply-once.yml
+++ b/.github/workflows/surveillance-lock-apply-once.yml
@@ -1,0 +1,87 @@
+name: One-shot Surveillance Cargo.lock Applicator
+
+on:
+  push:
+    branches:
+      - feat/public-health-surveillance-dna-v1
+    paths:
+      - ".github/workflows/surveillance-lock-apply-once.yml"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  PARENT_MYCELIX_REF: 7daefcbfa6c4427809e9d8dc24a039bb024da5e9
+  EXPECTED_PARENT_HEAD: ec3ab97113ac2f19877eadde5f099c14823d376c
+  EXPECTED_LOCK_SHA256: 6d0699c82c9d876fb386555893a8e293407245abc27c1154552ab1b71d137a04
+  SELF_PATH: .github/workflows/surveillance-lock-apply-once.yml
+
+jobs:
+  apply-reviewed-lock:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5 / node24
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: true
+
+      - name: Prove one-shot source envelope
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD^)" = "$EXPECTED_PARENT_HEAD"
+          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+          CHANGED="$(git diff --name-only HEAD^ HEAD)"
+          test "$CHANGED" = "$SELF_PATH"
+          test "$(git status --porcelain=v1 --untracked-files=all)" = ""
+
+      - name: Check out pinned parent workspace dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init /tmp/mycelix-parent
+          git -C /tmp/mycelix-parent remote add origin https://github.com/Luminous-Dynamics/mycelix.git
+          git -C /tmp/mycelix-parent fetch --depth 1 origin "$PARENT_MYCELIX_REF"
+          git -C /tmp/mycelix-parent checkout --detach FETCH_HEAD
+          test "$(git -C /tmp/mycelix-parent rev-parse HEAD)" = "$PARENT_MYCELIX_REF"
+
+          mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
+          cp -r /tmp/mycelix-parent/crates/. ../crates/
+          cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
+          cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-workspace/mycelix-core/
+          rm -rf /tmp/mycelix-parent
+
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e
+
+      - name: Regenerate and prove reviewed Cargo.lock
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo metadata --format-version 1 > /dev/null
+          ACTUAL_LOCK_SHA256="$(sha256sum Cargo.lock | awk '{print $1}')"
+          test "$ACTUAL_LOCK_SHA256" = "$EXPECTED_LOCK_SHA256"
+          cargo metadata --locked --format-version 1 > /dev/null
+          git diff --check -- Cargo.lock
+          git diff --quiet -- Cargo.lock && {
+            echo "Expected Cargo.lock to change from the reviewed parent." >&2
+            exit 1
+          }
+
+      - name: Commit only reviewed lock and self-delete applicator
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm "$SELF_PATH"
+          git add Cargo.lock "$SELF_PATH"
+          test "$(git diff --cached --name-only | sort)" = $'.github/workflows/surveillance-lock-apply-once.yml\nCargo.lock'
+          test "$(sha256sum Cargo.lock | awk '{print $1}')" = "$EXPECTED_LOCK_SHA256"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(surveillance): apply Cargo-produced lock refresh"
+          git push origin HEAD:feat/public-health-surveillance-dna-v1

--- a/.github/workflows/surveillance-lock-refresh.yml
+++ b/.github/workflows/surveillance-lock-refresh.yml
@@ -2,15 +2,18 @@ name: Public Health Surveillance Lock Refresh Evidence
 
 on:
   pull_request:
-    branches: [main]
     paths:
-      - "crates/health-surveillance-core/**"
+      - "crates/health-surveillance-*/**"
+      - "zomes/surveillance/**"
+      - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"
-      - ".github/workflows/surveillance-lock-refresh.yml"
-      - ".github/workflows/surveillance-core.yml"
+      - ".github/workflows/surveillance-*.yml"
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -68,7 +71,12 @@ jobs:
             rustc -vV
             cargo -Vv
             echo "--- committed hashes ---"
-            sha256sum Cargo.toml Cargo.lock crates/health-surveillance-core/Cargo.toml
+            sha256sum Cargo.toml Cargo.lock
+            find crates zomes -type f -name Cargo.toml \
+              | grep -E '(^crates/health-surveillance-|^zomes/surveillance/)' \
+              | sort \
+              | xargs -r sha256sum
+            if [[ -f dna/surveillance/dna.yaml ]]; then sha256sum dna/surveillance/dna.yaml; fi
             if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
           } > lock-refresh-evidence/environment.txt
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,10 @@ members = [
     "crates/health-validation",
     "crates/health-surveillance-core",
 
+    # ── Public Health Surveillance (separate aggregate-only DNA) ──
+    "zomes/surveillance/integrity",
+    "zomes/surveillance/coordinator",
+
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",
     "zomes/mental_health/coordinator",
@@ -94,7 +98,6 @@ mycelix-bridge-common = { path = "../crates/mycelix-bridge-common" }
 # Utilities
 chrono = "0.4"
 thiserror = "1.0"
-
 derive_more = "0.99"
 
 # WASM compatibility
@@ -120,4 +123,3 @@ todo = "deny"
 unimplemented = "deny"
 eq_op = "deny"
 cast_ptr_alignment = "deny"
-

--- a/dna/surveillance/README.md
+++ b/dna/surveillance/README.md
@@ -1,0 +1,94 @@
+# Health Surveillance DNA
+
+This DNA is the public, aggregate-only publication boundary for Mycelix Health surveillance evidence.
+
+It is intentionally separate from the patient/clinical Health DNA. Patient records, consent records, individual FHIR resources, raw laboratory records, exact locations, and other sensitive clinical data do not belong in this network.
+
+## Default behavior: publication disabled
+
+`dna.yaml` ships with:
+
+```yaml
+properties:
+  release_policy: ~
+```
+
+That is deliberate. With no configured release policy, the integrity zome rejects surveillance publication. A deployment must create/instantiate a DNA whose properties contain a governance-approved policy revision and non-zero structural release thresholds.
+
+The project does **not** provide universal privacy thresholds. Appropriate cohort size, aggregation windows, geographic precision, differential-privacy requirements, and legal/governance review depend on the deployment and source pipeline.
+
+## Integrity model
+
+For every `ReleasedSurveillanceObservation`, every validating peer independently checks:
+
+1. the publisher field equals the Holochain action author;
+2. the entry's `policy_revision` equals the revision frozen into DNA properties;
+3. the underlying `SurveillanceObservation` satisfies the evidence-core invariants;
+4. the DNA's release policy deterministically reassesses the observation;
+5. the observation passes that policy;
+6. the stored `ReleaseAssessment` exactly equals the recomputed assessment.
+
+Released observations are append-only in v1. Updates and deletes are rejected.
+
+No links are publishable in v1. Indexing/query semantics will be designed separately so convenience indexes cannot become an unreviewed evidence-authority layer.
+
+## What publisher binding means
+
+The Holochain action author authenticates the agent key that published an entry to this DHT. It does **not** prove that the observation's human-readable producer/protocol/upstream provenance is institutionally authentic.
+
+A later authenticated-provenance tranche must bind those claims to Mycelix/Xenia identity and credential evidence. Until then, producer and independence-lineage metadata remain evidence claims carried by the observation, not verified institutional attestations.
+
+## Non-goals
+
+This DNA does not:
+
+- store patient-level medical records;
+- diagnose disease;
+- identify or engineer pathogens;
+- declare outbreaks;
+- recommend treatment;
+- issue public-health orders;
+- grant emergency privileges;
+- give Symthaea autonomous response authority.
+
+It only creates a stronger distributed publication boundary for aggregate evidence.
+
+## Intended stack
+
+```text
+private source systems / Health DNA
+            |
+      source-specific aggregation
+            |
+      stronger privacy mechanisms
+       where source requires them
+            |
+            v
+   health-surveillance-core
+            |
+      DNA-bound release gate
+            |
+            v
+     Health Surveillance DNA
+            |
+   authenticated provenance (next)
+            |
+            v
+     Symthaea health-resilience
+   evidence analysis / hypotheses
+            |
+            v
+    human / institutional authority
+```
+
+## Building
+
+The zomes are workspace members:
+
+```bash
+cargo build --release -p surveillance_integrity -p surveillance
+```
+
+The repository's `.cargo/config.toml` targets `wasm32-unknown-unknown` by default, matching Holochain zome deployment.
+
+To package the DNA after selecting deployment properties, use the Holochain `hc dna pack` flow appropriate to the pinned Holochain 0.6 toolchain. Do not deploy the default null-policy manifest expecting publication to work; it is intentionally fail-closed.

--- a/dna/surveillance/README.md
+++ b/dna/surveillance/README.md
@@ -17,16 +17,25 @@ That is deliberate. With no configured release policy, the integrity zome reject
 
 The project does **not** provide universal privacy thresholds. Appropriate cohort size, aggregation windows, geographic precision, differential-privacy requirements, and legal/governance review depend on the deployment and source pipeline.
 
+## Policy identity
+
+`policy_revision` is a human/audit label, not the immutable identity of a release policy.
+
+The integrity zome derives a domain-separated `ReleasePolicyId` over the exact revision label plus cohort threshold, aggregation-window threshold, and maximum geographic precision. Every released observation carries both the readable revision and this exact policy commitment.
+
+Reusing the same revision label with different thresholds therefore creates a different policy identity and cannot be silently substituted into an existing released entry.
+
 ## Integrity model
 
 For every `ReleasedSurveillanceObservation`, every validating peer independently checks:
 
 1. the publisher field equals the Holochain action author;
 2. the entry's `policy_revision` equals the revision frozen into DNA properties;
-3. the underlying `SurveillanceObservation` satisfies the evidence-core invariants;
-4. the DNA's release policy deterministically reassesses the observation;
-5. the observation passes that policy;
-6. the stored `ReleaseAssessment` exactly equals the recomputed assessment.
+3. the entry's `policy_id` equals the immutable commitment derived from those exact DNA properties;
+4. the underlying `SurveillanceObservation` satisfies the evidence-core invariants;
+5. the DNA's release policy deterministically reassesses the observation;
+6. the observation passes that policy;
+7. the stored `ReleaseAssessment` exactly equals the recomputed assessment.
 
 Released observations are append-only in v1. Updates and deletes are rejected.
 

--- a/dna/surveillance/dna.yaml
+++ b/dna/surveillance/dna.yaml
@@ -1,0 +1,18 @@
+---
+manifest_version: "0"
+name: health-surveillance
+integrity:
+  network_seed: ~
+  properties:
+    # Fail closed by default. A deployment must create a DNA with an explicit,
+    # governance-approved non-zero aggregate release policy before publication.
+    release_policy: ~
+  zomes:
+    - name: surveillance_integrity
+      path: ../../target/wasm32-unknown-unknown/release/surveillance_integrity.wasm
+coordinator:
+  zomes:
+    - name: surveillance
+      path: ../../target/wasm32-unknown-unknown/release/surveillance.wasm
+      dependencies:
+        - name: surveillance_integrity

--- a/zomes/surveillance/coordinator/Cargo.toml
+++ b/zomes/surveillance/coordinator/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "surveillance"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Coordinator zome for policy-bound aggregate public-health surveillance releases"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "surveillance"
+
+[dependencies]
+hdk.workspace = true
+serde.workspace = true
+holochain_serialized_bytes.workspace = true
+surveillance_integrity = { path = "../integrity" }

--- a/zomes/surveillance/coordinator/src/lib.rs
+++ b/zomes/surveillance/coordinator/src/lib.rs
@@ -1,0 +1,110 @@
+#![deny(unsafe_code)]
+// Copyright (C) 2024-2026 Tristan Stoltz / Luminous Dynamics
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Commercial licensing: see COMMERCIAL_LICENSE.md at repository root
+//! Coordinator API for policy-bound aggregate public-health surveillance.
+//!
+//! The coordinator performs the same release-policy evaluation as the integrity
+//! callback for fast caller feedback, but integrity validation remains the source
+//! of truth. No function in this zome diagnoses disease, declares an outbreak, or
+//! creates emergency authority.
+
+use hdk::prelude::*;
+use surveillance_integrity::*;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubmitSurveillanceObservationInput {
+    pub observation: SurveillanceObservation,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubmitSurveillanceObservationOutput {
+    pub action_hash: ActionHash,
+    pub observation_id: ObservationId,
+    pub policy_revision: CanonicalId,
+    pub publisher: AgentPubKey,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ReleasePolicyView {
+    pub policy_revision: CanonicalId,
+    pub policy: AggregateReleasePolicy,
+}
+
+/// Return the release policy frozen into this DNA's integrity properties.
+/// Fails closed when publication is disabled or the property contract is invalid.
+#[hdk_extern]
+pub fn get_release_policy(_: ()) -> ExternResult<ReleasePolicyView> {
+    let configured = configured_release_policy()?;
+    Ok(ReleasePolicyView {
+        policy_revision: configured.policy_revision,
+        policy: configured.policy,
+    })
+}
+
+/// Submit one aggregate surveillance observation.
+///
+/// This performs a coordinator-side preflight. Every peer independently repeats
+/// the same policy evaluation in the integrity callback before accepting the DHT
+/// operation.
+#[hdk_extern]
+pub fn submit_surveillance_observation(
+    input: SubmitSurveillanceObservationInput,
+) -> ExternResult<SubmitSurveillanceObservationOutput> {
+    let configured = configured_release_policy()?;
+    let assessment = configured.policy.assess(&input.observation).map_err(|e| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Invalid surveillance observation: {e}"
+        )))
+    })?;
+
+    if !assessment.eligible_for_release() {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Observation withheld by DNA release policy: {:?}",
+            assessment.reasons()
+        ))));
+    }
+
+    let publisher = agent_info()?.agent_initial_pubkey;
+    let observation_id = input.observation.id().map_err(|e| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Could not derive observation identity: {e}"
+        )))
+    })?;
+
+    let entry = ReleasedSurveillanceObservation {
+        observation: input.observation,
+        release_assessment: assessment,
+        policy_revision: configured.policy_revision.clone(),
+        publisher: publisher.clone(),
+    };
+
+    let action_hash = create_entry(&EntryTypes::ReleasedSurveillanceObservation(entry))?;
+
+    Ok(SubmitSurveillanceObservationOutput {
+        action_hash,
+        observation_id,
+        policy_revision: configured.policy_revision,
+        publisher,
+    })
+}
+
+/// Fetch one released aggregate observation by its action hash.
+#[hdk_extern]
+pub fn get_surveillance_observation(
+    action_hash: ActionHash,
+) -> ExternResult<Option<ReleasedSurveillanceObservation>> {
+    let record = match get(action_hash, GetOptions::default())? {
+        Some(record) => record,
+        None => return Ok(None),
+    };
+
+    record
+        .entry()
+        .to_app_option::<ReleasedSurveillanceObservation>()
+        .map_err(|e| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Stored record is not a released surveillance observation: {e}"
+            )))
+        })
+}

--- a/zomes/surveillance/coordinator/src/lib.rs
+++ b/zomes/surveillance/coordinator/src/lib.rs
@@ -22,12 +22,14 @@ pub struct SubmitSurveillanceObservationOutput {
     pub action_hash: ActionHash,
     pub observation_id: ObservationId,
     pub policy_revision: CanonicalId,
+    pub policy_id: ReleasePolicyId,
     pub publisher: AgentPubKey,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ReleasePolicyView {
     pub policy_revision: CanonicalId,
+    pub policy_id: ReleasePolicyId,
     pub policy: AggregateReleasePolicy,
 }
 
@@ -38,6 +40,7 @@ pub fn get_release_policy(_: ()) -> ExternResult<ReleasePolicyView> {
     let configured = configured_release_policy()?;
     Ok(ReleasePolicyView {
         policy_revision: configured.policy_revision,
+        policy_id: configured.policy_id,
         policy: configured.policy,
     })
 }
@@ -76,6 +79,7 @@ pub fn submit_surveillance_observation(
         observation: input.observation,
         release_assessment: assessment,
         policy_revision: configured.policy_revision.clone(),
+        policy_id: configured.policy_id,
         publisher: publisher.clone(),
     };
 
@@ -85,6 +89,7 @@ pub fn submit_surveillance_observation(
         action_hash,
         observation_id,
         policy_revision: configured.policy_revision,
+        policy_id: configured.policy_id,
         publisher,
     })
 }

--- a/zomes/surveillance/integrity/Cargo.toml
+++ b/zomes/surveillance/integrity/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "surveillance_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Integrity zome for policy-bound aggregate public-health surveillance releases"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "surveillance_integrity"
+
+[dependencies]
+hdi.workspace = true
+serde.workspace = true
+holochain_serialized_bytes.workspace = true
+health-surveillance-core = { path = "../../../crates/health-surveillance-core" }

--- a/zomes/surveillance/integrity/Cargo.toml
+++ b/zomes/surveillance/integrity/Cargo.toml
@@ -13,4 +13,5 @@ name = "surveillance_integrity"
 hdi.workspace = true
 serde.workspace = true
 holochain_serialized_bytes.workspace = true
+sha2 = "0.10"
 health-surveillance-core = { path = "../../../crates/health-surveillance-core" }

--- a/zomes/surveillance/integrity/src/lib.rs
+++ b/zomes/surveillance/integrity/src/lib.rs
@@ -1,0 +1,291 @@
+#![deny(unsafe_code)]
+// Copyright (C) 2024-2026 Tristan Stoltz / Luminous Dynamics
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Commercial licensing: see COMMERCIAL_LICENSE.md at repository root
+//! Policy-bound aggregate public-health surveillance integrity zome.
+//!
+//! This DNA stores only observations that have already crossed the aggregate
+//! evidence boundary defined by `health-surveillance-core`. Publication policy
+//! is a DNA property so every peer validates the same structural privacy floor.
+//! If no release policy is configured, publication fails closed.
+//!
+//! This zome does not authenticate the institutional meaning of a producer label,
+//! diagnose disease, declare an outbreak, recommend treatment, or authorize an
+//! emergency response.
+
+use hdi::prelude::*;
+pub use health_surveillance_core::*;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReleasePolicyProperties {
+    /// Human/audit identity for this exact deployment policy revision.
+    pub policy_revision: String,
+    pub min_cohort_size: u64,
+    pub min_window_s: u64,
+    pub max_geographic_precision: GeographicPrecision,
+}
+
+#[dna_properties]
+#[derive(Clone, Debug, PartialEq)]
+pub struct SurveillanceDnaProperties {
+    /// `None` intentionally disables publication. Deployments must choose and
+    /// pin a non-zero release policy before accepting aggregate evidence.
+    pub release_policy: Option<ReleasePolicyProperties>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConfiguredReleasePolicy {
+    pub policy_revision: CanonicalId,
+    pub policy: AggregateReleasePolicy,
+}
+
+pub fn configured_release_policy() -> ExternResult<ConfiguredReleasePolicy> {
+    let properties = SurveillanceDnaProperties::try_from_dna_properties()?;
+    let configured = properties.release_policy.ok_or_else(|| {
+        wasm_error!(WasmErrorInner::Guest(
+            "Public-health surveillance publication is disabled: no DNA release_policy is configured"
+                .to_string()
+        ))
+    })?;
+
+    configured_release_policy_from_properties(&configured).map_err(|message| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Invalid surveillance DNA release policy: {message}"
+        )))
+    })
+}
+
+pub fn configured_release_policy_from_properties(
+    properties: &ReleasePolicyProperties,
+) -> Result<ConfiguredReleasePolicy, String> {
+    let policy_revision = CanonicalId::new(properties.policy_revision.clone())
+        .map_err(|e| format!("invalid policy_revision: {e}"))?;
+    let policy = AggregateReleasePolicy::new(
+        properties.min_cohort_size,
+        properties.min_window_s,
+        properties.max_geographic_precision,
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(ConfiguredReleasePolicy {
+        policy_revision,
+        policy,
+    })
+}
+
+/// One aggregate observation admitted for publication by the policy frozen in
+/// this DNA's integrity properties.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct ReleasedSurveillanceObservation {
+    pub observation: SurveillanceObservation,
+    /// Exact release decision recomputed by every validating peer.
+    pub release_assessment: ReleaseAssessment,
+    /// Human/audit revision echoed from the DNA property contract.
+    pub policy_revision: CanonicalId,
+    /// Agent that authored this DHT entry. This authenticates only the Holochain
+    /// author key; it does not prove the institutional producer label in the
+    /// observation's provenance.
+    pub publisher: AgentPubKey,
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    ReleasedSurveillanceObservation(ReleasedSurveillanceObservation),
+}
+
+/// v1 intentionally exposes no index links. A future indexing tranche must
+/// define and validate query semantics separately rather than making links look
+/// more authoritative than the released entries they point to.
+#[hdk_link_types]
+pub enum LinkTypes {
+    Reserved,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => match app_entry {
+                EntryTypes::ReleasedSurveillanceObservation(entry) => {
+                    validate_released_entry(&action.author, &entry)
+                }
+            },
+            OpEntry::UpdateEntry { .. } => Ok(ValidateCallbackResult::Invalid(
+                "Released surveillance observations are append-only and cannot be updated".into(),
+            )),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterUpdate(_) => Ok(ValidateCallbackResult::Invalid(
+            "Released surveillance observations are append-only and cannot be updated".into(),
+        )),
+        FlatOp::RegisterDelete(_) => Ok(ValidateCallbackResult::Invalid(
+            "Released surveillance observations are evidence records and cannot be deleted".into(),
+        )),
+        FlatOp::RegisterCreateLink { .. } => Ok(ValidateCallbackResult::Invalid(
+            "Surveillance v1 defines no publishable link operations".into(),
+        )),
+        FlatOp::RegisterDeleteLink { .. } => Ok(ValidateCallbackResult::Invalid(
+            "Surveillance v1 defines no deletable link operations".into(),
+        )),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_released_entry(
+    action_author: &AgentPubKey,
+    entry: &ReleasedSurveillanceObservation,
+) -> ExternResult<ValidateCallbackResult> {
+    let configured = configured_release_policy()?;
+    match validate_released_entry_against_policy(action_author, entry, &configured) {
+        Ok(()) => Ok(ValidateCallbackResult::Valid),
+        Err(message) => Ok(ValidateCallbackResult::Invalid(message)),
+    }
+}
+
+pub fn validate_released_entry_against_policy(
+    action_author: &AgentPubKey,
+    entry: &ReleasedSurveillanceObservation,
+    configured: &ConfiguredReleasePolicy,
+) -> Result<(), String> {
+    if &entry.publisher != action_author {
+        return Err("publisher must equal the Holochain action author".to_string());
+    }
+    if entry.policy_revision != configured.policy_revision {
+        return Err("entry policy_revision does not match the DNA release policy".to_string());
+    }
+
+    entry
+        .observation
+        .validate()
+        .map_err(|e| format!("invalid surveillance observation: {e}"))?;
+
+    let expected = configured
+        .policy
+        .assess(&entry.observation)
+        .map_err(|e| format!("release assessment failed: {e}"))?;
+
+    if !expected.eligible_for_release() {
+        return Err(format!(
+            "observation does not satisfy the DNA release policy: {:?}",
+            expected.reasons()
+        ));
+    }
+    if entry.release_assessment != expected {
+        return Err(
+            "stored release assessment does not match deterministic policy evaluation".to_string(),
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn policy() -> ConfiguredReleasePolicy {
+        configured_release_policy_from_properties(&ReleasePolicyProperties {
+            policy_revision: "district-release-v1".to_string(),
+            min_cohort_size: 50,
+            min_window_s: 3_600,
+            max_geographic_precision: GeographicPrecision::District,
+        })
+        .unwrap()
+    }
+
+    fn observation(cohort_size: u64) -> SurveillanceObservation {
+        SurveillanceObservation::new(
+            SignalFamily::Respiratory,
+            SourceKind::LaboratoryAggregate,
+            "lab-feed-a",
+            IndependenceGroup::new("lab-lineage-a").unwrap(),
+            GeographicScope::new("health-district", "district-17", GeographicPrecision::District)
+                .unwrap(),
+            ObservationWindow::new(10_000, 13_600).unwrap(),
+            13_700,
+            cohort_size,
+            ObservedMetric::new(
+                MetricKind::FractionPositive,
+                0.20,
+                BoundedUncertainty::new(0.15, 0.25).unwrap(),
+                "fraction",
+            )
+            .unwrap(),
+            EvidenceProvenance::new(
+                "lab-a",
+                "aggregate-protocol-v1",
+                "rev-1",
+                Some("upstream-lab-a"),
+                SourceRecordDigest::sha256([7; 32]).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn agent(byte: u8) -> AgentPubKey {
+        AgentPubKey::from_raw_36(vec![byte; 36])
+    }
+
+    #[test]
+    fn missing_or_zero_policy_is_not_constructible_as_configured_policy() {
+        let result = configured_release_policy_from_properties(&ReleasePolicyProperties {
+            policy_revision: "policy-v1".to_string(),
+            min_cohort_size: 0,
+            min_window_s: 3_600,
+            max_geographic_precision: GeographicPrecision::District,
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn exact_policy_assessment_and_author_are_required() {
+        let configured = policy();
+        let observation = observation(100);
+        let assessment = configured.policy.assess(&observation).unwrap();
+        let publisher = agent(1);
+        let entry = ReleasedSurveillanceObservation {
+            observation,
+            release_assessment: assessment,
+            policy_revision: configured.policy_revision.clone(),
+            publisher: publisher.clone(),
+        };
+
+        assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_ok());
+        assert!(validate_released_entry_against_policy(&agent(2), &entry, &configured).is_err());
+    }
+
+    #[test]
+    fn undersized_aggregate_cannot_be_published_even_with_forged_pass_receipt() {
+        let configured = policy();
+        let good = observation(100);
+        let forged_assessment = configured.policy.assess(&good).unwrap();
+        let publisher = agent(1);
+        let entry = ReleasedSurveillanceObservation {
+            observation: observation(10),
+            release_assessment: forged_assessment,
+            policy_revision: configured.policy_revision.clone(),
+            publisher: publisher.clone(),
+        };
+
+        assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_err());
+    }
+
+    #[test]
+    fn policy_revision_substitution_is_rejected() {
+        let configured = policy();
+        let observation = observation(100);
+        let assessment = configured.policy.assess(&observation).unwrap();
+        let publisher = agent(1);
+        let entry = ReleasedSurveillanceObservation {
+            observation,
+            release_assessment: assessment,
+            policy_revision: CanonicalId::new("different-policy").unwrap(),
+            publisher: publisher.clone(),
+        };
+
+        assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_err());
+    }
+}

--- a/zomes/surveillance/integrity/src/lib.rs
+++ b/zomes/surveillance/integrity/src/lib.rs
@@ -64,7 +64,7 @@ pub struct ReleasePolicyProperties {
 }
 
 #[dna_properties]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct SurveillanceDnaProperties {
     /// `None` intentionally disables publication. Deployments must choose and
     /// pin a non-zero release policy before accepting aggregate evidence.

--- a/zomes/surveillance/integrity/src/lib.rs
+++ b/zomes/surveillance/integrity/src/lib.rs
@@ -15,10 +15,49 @@
 
 use hdi::prelude::*;
 pub use health_surveillance_core::*;
+use sha2::{Digest, Sha256};
+
+pub const RELEASE_POLICY_ID_DOMAIN_V1: &[u8] =
+    b"mycelix-health-surveillance-release-policy-v1\0";
+
+/// Immutable semantic identity of the exact release-policy authority configured
+/// into one surveillance DNA. A human revision label alone is not an identity.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct ReleasePolicyId([u8; 32]);
+
+impl ReleasePolicyId {
+    fn from_validated_properties(
+        policy_revision: &CanonicalId,
+        properties: &ReleasePolicyProperties,
+    ) -> Self {
+        let mut h = Sha256::new();
+        h.update(RELEASE_POLICY_ID_DOMAIN_V1);
+
+        let revision = policy_revision.as_str().as_bytes();
+        h.update((revision.len() as u32).to_be_bytes());
+        h.update(revision);
+        h.update(properties.min_cohort_size.to_be_bytes());
+        h.update(properties.min_window_s.to_be_bytes());
+        h.update([match properties.max_geographic_precision {
+            GeographicPrecision::Country => 0,
+            GeographicPrecision::Region => 1,
+            GeographicPrecision::District => 2,
+            GeographicPrecision::Facility => 3,
+        }]);
+
+        Self(h.finalize().into())
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct ReleasePolicyProperties {
-    /// Human/audit identity for this exact deployment policy revision.
+    /// Human/audit label. The immutable policy identity is `ReleasePolicyId`,
+    /// which also commits to all exact threshold values below.
     pub policy_revision: String,
     pub min_cohort_size: u64,
     pub min_window_s: u64,
@@ -36,6 +75,7 @@ pub struct SurveillanceDnaProperties {
 #[derive(Clone, Debug, PartialEq)]
 pub struct ConfiguredReleasePolicy {
     pub policy_revision: CanonicalId,
+    pub policy_id: ReleasePolicyId,
     pub policy: AggregateReleasePolicy,
 }
 
@@ -66,9 +106,11 @@ pub fn configured_release_policy_from_properties(
         properties.max_geographic_precision,
     )
     .map_err(|e| e.to_string())?;
+    let policy_id = ReleasePolicyId::from_validated_properties(&policy_revision, properties);
 
     Ok(ConfiguredReleasePolicy {
         policy_revision,
+        policy_id,
         policy,
     })
 }
@@ -83,6 +125,8 @@ pub struct ReleasedSurveillanceObservation {
     pub release_assessment: ReleaseAssessment,
     /// Human/audit revision echoed from the DNA property contract.
     pub policy_revision: CanonicalId,
+    /// Immutable commitment to the exact revision + threshold contract.
+    pub policy_id: ReleasePolicyId,
     /// Agent that authored this DHT entry. This authenticates only the Holochain
     /// author key; it does not prove the institutional producer label in the
     /// observation's provenance.
@@ -154,6 +198,9 @@ pub fn validate_released_entry_against_policy(
     }
     if entry.policy_revision != configured.policy_revision {
         return Err("entry policy_revision does not match the DNA release policy".to_string());
+    }
+    if entry.policy_id != configured.policy_id {
+        return Err("entry policy_id does not match the exact DNA release policy".to_string());
     }
 
     entry
@@ -229,6 +276,21 @@ mod tests {
         AgentPubKey::from_raw_36(vec![byte; 36])
     }
 
+    fn released_entry(
+        configured: &ConfiguredReleasePolicy,
+        observation: SurveillanceObservation,
+        publisher: AgentPubKey,
+    ) -> ReleasedSurveillanceObservation {
+        let assessment = configured.policy.assess(&observation).unwrap();
+        ReleasedSurveillanceObservation {
+            observation,
+            release_assessment: assessment,
+            policy_revision: configured.policy_revision.clone(),
+            policy_id: configured.policy_id,
+            publisher,
+        }
+    }
+
     #[test]
     fn missing_or_zero_policy_is_not_constructible_as_configured_policy() {
         let result = configured_release_policy_from_properties(&ReleasePolicyProperties {
@@ -241,17 +303,31 @@ mod tests {
     }
 
     #[test]
-    fn exact_policy_assessment_and_author_are_required() {
+    fn same_revision_with_different_thresholds_has_different_policy_identity() {
+        let a = configured_release_policy_from_properties(&ReleasePolicyProperties {
+            policy_revision: "policy-v1".to_string(),
+            min_cohort_size: 50,
+            min_window_s: 3_600,
+            max_geographic_precision: GeographicPrecision::District,
+        })
+        .unwrap();
+        let b = configured_release_policy_from_properties(&ReleasePolicyProperties {
+            policy_revision: "policy-v1".to_string(),
+            min_cohort_size: 100,
+            min_window_s: 3_600,
+            max_geographic_precision: GeographicPrecision::District,
+        })
+        .unwrap();
+
+        assert_eq!(a.policy_revision, b.policy_revision);
+        assert_ne!(a.policy_id, b.policy_id);
+    }
+
+    #[test]
+    fn exact_policy_assessment_author_and_policy_identity_are_required() {
         let configured = policy();
-        let observation = observation(100);
-        let assessment = configured.policy.assess(&observation).unwrap();
         let publisher = agent(1);
-        let entry = ReleasedSurveillanceObservation {
-            observation,
-            release_assessment: assessment,
-            policy_revision: configured.policy_revision.clone(),
-            publisher: publisher.clone(),
-        };
+        let entry = released_entry(&configured, observation(100), publisher.clone());
 
         assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_ok());
         assert!(validate_released_entry_against_policy(&agent(2), &entry, &configured).is_err());
@@ -267,6 +343,7 @@ mod tests {
             observation: observation(10),
             release_assessment: forged_assessment,
             policy_revision: configured.policy_revision.clone(),
+            policy_id: configured.policy_id,
             publisher: publisher.clone(),
         };
 
@@ -276,16 +353,28 @@ mod tests {
     #[test]
     fn policy_revision_substitution_is_rejected() {
         let configured = policy();
-        let observation = observation(100);
-        let assessment = configured.policy.assess(&observation).unwrap();
         let publisher = agent(1);
-        let entry = ReleasedSurveillanceObservation {
-            observation,
-            release_assessment: assessment,
-            policy_revision: CanonicalId::new("different-policy").unwrap(),
-            publisher: publisher.clone(),
-        };
+        let mut entry = released_entry(&configured, observation(100), publisher.clone());
+        entry.policy_revision = CanonicalId::new("different-policy").unwrap();
 
+        assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_err());
+    }
+
+    #[test]
+    fn same_revision_different_policy_id_substitution_is_rejected() {
+        let configured = policy();
+        let other = configured_release_policy_from_properties(&ReleasePolicyProperties {
+            policy_revision: configured.policy_revision.as_str().to_string(),
+            min_cohort_size: 100,
+            min_window_s: 3_600,
+            max_geographic_precision: GeographicPrecision::District,
+        })
+        .unwrap();
+        let publisher = agent(1);
+        let mut entry = released_entry(&configured, observation(100), publisher.clone());
+        entry.policy_id = other.policy_id;
+
+        assert_ne!(configured.policy_id, other.policy_id);
         assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_err());
     }
 }

--- a/zomes/surveillance/integrity/src/lib.rs
+++ b/zomes/surveillance/integrity/src/lib.rs
@@ -17,8 +17,7 @@ use hdi::prelude::*;
 pub use health_surveillance_core::*;
 use sha2::{Digest, Sha256};
 
-pub const RELEASE_POLICY_ID_DOMAIN_V1: &[u8] =
-    b"mycelix-health-surveillance-release-policy-v1\0";
+pub const RELEASE_POLICY_ID_DOMAIN_V1: &[u8] = b"mycelix-health-surveillance-release-policy-v1\0";
 
 /// Immutable semantic identity of the exact release-policy authority configured
 /// into one surveillance DNA. A human revision label alone is not an identity.
@@ -248,8 +247,12 @@ mod tests {
             SourceKind::LaboratoryAggregate,
             "lab-feed-a",
             IndependenceGroup::new("lab-lineage-a").unwrap(),
-            GeographicScope::new("health-district", "district-17", GeographicPrecision::District)
-                .unwrap(),
+            GeographicScope::new(
+                "health-district",
+                "district-17",
+                GeographicPrecision::District,
+            )
+            .unwrap(),
             ObservationWindow::new(10_000, 13_600).unwrap(),
             13_700,
             cohort_size,

--- a/zomes/surveillance/integrity/tests/identity_vectors.rs
+++ b/zomes/surveillance/integrity/tests/identity_vectors.rs
@@ -1,0 +1,30 @@
+use surveillance_integrity::{
+    GeographicPrecision, ReleasePolicyProperties, configured_release_policy_from_properties,
+};
+
+fn hex(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    out
+}
+
+#[test]
+fn release_policy_id_v1_golden_vector() {
+    let configured = configured_release_policy_from_properties(&ReleasePolicyProperties {
+        policy_revision: "district-release-v1".to_string(),
+        min_cohort_size: 50,
+        min_window_s: 3_600,
+        max_geographic_precision: GeographicPrecision::District,
+    })
+    .unwrap();
+
+    // Independently recomputed from the v1 domain-separated policy encoding.
+    // A different value requires an explicit release-policy identity version.
+    assert_eq!(
+        hex(configured.policy_id.as_bytes()),
+        "881c02d0b10d921a2983790a48bbfd281e8a801295c5ce5d698fb7e8d26158ea"
+    );
+}


### PR DESCRIPTION
## Summary

Stack on #10 and add the first distributed publication boundary for aggregate public-health surveillance evidence while keeping the public aggregate Surveillance DNA separate from patient/clinical records.

No outbreak detection, diagnosis, treatment advice, emergency authority, or autonomous Symthaea control.

## Exact head / dependency state

Current #10 prerequisite head: `753e2f4c71f57cf1aebd1967eae291711b6dc42a`.

Current #11 head: `5c74f9c80ab0ebbf98e2fb5402f229da53b69c0a`.

#10's focused exact-head `Public Health Surveillance Core` and lock-evidence lanes are green. Its repository-wide integration `CI` is still queued, so #10 remains draft and is not yet called fully merge-qualified.

#11 is now a **real descendant** of that exact #10 head through two-parent restack commit `5c74f9c80ab0ebbf98e2fb5402f229da53b69c0a`.

Comparing exact #10 → exact #11 yields only the nine #11-owned publication/DNA files. The #10 rustfmt-only identity-vector repair does not leak into this PR's review diff.

The current exact #11 `Public Health Surveillance DNA` run is queued. Keep draft and do not call #11 qualified until that exact head passes its focused gate and appropriate integration evidence is available.

## Publication integrity

The separate aggregate Surveillance DNA fails closed when no release policy is configured. `ReleasePolicyId` content-addresses the human revision plus exact structural policy thresholds so a reused friendly label cannot silently substitute different policy authority.

Every validating peer independently requires the publisher to equal the Holochain action author, the entry policy revision/ID to match DNA properties, the underlying #10 observation to revalidate, and the stored release assessment to exactly match deterministic reassessment under the configured policy.

Released observations are append-only; updates/deletes are rejected. v1 intentionally publishes no index links.

The publisher binding authenticates only the Holochain action author key. It does not yet prove producer/protocol/upstream/independence claims are institutionally authentic; later producer-authority and lineage tranches own that.

## Reproducible qualification environment

The focused DNA workflow freezes:

- exact PR feature-head checkout and assertion;
- Rust `1.96.0`;
- `ubuntu-24.04` runner family;
- committed lock graph through complete `cargo metadata --locked` plus `--locked` on Cargo gates;
- exact parent Mycelix path source `7daefcbfa6c4427809e9d8dc24a039bb024da5e9` rather than moving `main`;
- exact `actions/checkout` and `dtolnay/rust-toolchain` revisions;
- source/parent/toolchain/manifest/lock identities in qualification logs;
- same-workflow/ref concurrency cancellation.

An earlier executable run progressed past formatting and exposed Holochain `E0119` because `#[dna_properties]` already supplied `Debug`; the redundant derive was fixed. Earlier results do not qualify this current synchronized head.

## Privacy / safety non-claims

No differential-privacy claim, formal k-anonymity claim, universal re-identification claim, HIPAA/GDPR claim, diagnosis, outbreak declaration, emergency authority, patient-level data, raw genome/pathogen payload, or pathogen-design functionality.

## Merge rule

Dependency closure is now structurally repaired: exact #10 is an ancestor of exact #11.

A green #11 run still cannot upgrade unresolved parent integration evidence, and downstream #12–#14 cannot qualify this PR by implication. Qualification remains bottom-up and exact-head-specific under issue #17.