### PR TITLE
feat(surveillance): verify DNA-trusted producer authority

### DIFF
--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -41,6 +41,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          EXPECTED="${{ github.event.pull_request.head.sha || github.sha }}"
+          ACTUAL="$(git rev-parse HEAD)"
+          test "$ACTUAL" = "$EXPECTED"
+          echo "QUALIFIED_SOURCE_HEAD=$ACTUAL"
 
       - name: Check out pinned parent workspace dependencies
         shell: bash

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -1,11 +1,11 @@
 name: Public Health Surveillance DNA
 
 on:
-  # Intentionally allow stacked PR bases. This tranche is expected to target the
-  # evidence-core feature branch until #10 lands, then be retargeted to main.
+  # Intentionally allow stacked PR bases while the surveillance stack is staged.
   pull_request:
     paths:
       - "crates/health-surveillance-core/**"
+      - "crates/health-surveillance-authority/**"
       - "zomes/surveillance/**"
       - "dna/surveillance/**"
       - "Cargo.toml"
@@ -15,6 +15,7 @@ on:
     branches: [main]
     paths:
       - "crates/health-surveillance-core/**"
+      - "crates/health-surveillance-authority/**"
       - "zomes/surveillance/**"
       - "dna/surveillance/**"
       - "Cargo.toml"
@@ -28,7 +29,7 @@ env:
 
 jobs:
   surveillance-dna:
-    name: Policy-bound publication qualification
+    name: Policy + producer authority qualification
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -10,6 +10,7 @@ on:
       - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-dna.yml"
   push:
     branches: [main]
@@ -20,25 +21,36 @@ on:
       - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-dna.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  PARENT_MYCELIX_REF: 7daefcbfa6c4427809e9d8dc24a039bb024da5e9
 
 jobs:
   surveillance-dna:
     name: Policy + producer authority qualification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      # Cargo resolves the whole workspace graph. Recreate the sibling paths
-      # expected when mycelix-health is checked out inside the parent mycelix repo.
-      - name: Check out parent workspace dependencies
+      - name: Check out pinned parent workspace dependencies
+        shell: bash
         run: |
-          git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
+          git init /tmp/mycelix-parent
+          git -C /tmp/mycelix-parent remote add origin https://github.com/Luminous-Dynamics/mycelix.git
+          git -C /tmp/mycelix-parent fetch --depth 1 origin "$PARENT_MYCELIX_REF"
+          git -C /tmp/mycelix-parent checkout --detach FETCH_HEAD
+          test "$(git -C /tmp/mycelix-parent rev-parse HEAD)" = "$PARENT_MYCELIX_REF"
+
           mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
           cp -r /tmp/mycelix-parent/crates/. ../crates/
           cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
@@ -46,7 +58,7 @@ jobs:
           rm -rf /tmp/mycelix-parent
 
       - name: Install pinned Rust
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e
         with:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
@@ -56,20 +68,37 @@ jobs:
         shell: bash
         run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
 
+      - name: Record qualification environment
+        shell: bash
+        run: |
+          echo "HEAD=$(git rev-parse HEAD)"
+          echo "PARENT_MYCELIX_REF=$PARENT_MYCELIX_REF"
+          rustc -vV
+          cargo -Vv
+          sha256sum Cargo.toml Cargo.lock \
+            crates/health-surveillance-core/Cargo.toml \
+            crates/health-surveillance-authority/Cargo.toml \
+            zomes/surveillance/integrity/Cargo.toml \
+            zomes/surveillance/coordinator/Cargo.toml
+          if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
+
+      - name: Verify committed lock graph
+        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+
       - name: Check formatting
         run: cargo fmt -p surveillance_integrity -p surveillance -- --check
 
       - name: Run integrity host tests
-        run: cargo test -p surveillance_integrity --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p surveillance_integrity --target "${{ steps.host.outputs.triple }}"
 
       - name: Run coordinator host tests
-        run: cargo test -p surveillance --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p surveillance --target "${{ steps.host.outputs.triple }}"
 
       - name: Run host Clippy
-        run: cargo clippy -p surveillance_integrity -p surveillance --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+        run: cargo clippy --locked -p surveillance_integrity -p surveillance --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
 
       - name: Check integrity WASM compatibility
-        run: cargo check -p surveillance_integrity --target wasm32-unknown-unknown
+        run: cargo check --locked -p surveillance_integrity --target wasm32-unknown-unknown
 
       - name: Check coordinator WASM compatibility
-        run: cargo check -p surveillance --target wasm32-unknown-unknown
+        run: cargo check --locked -p surveillance --target wasm32-unknown-unknown

--- a/.github/workflows/surveillance-dna.yml
+++ b/.github/workflows/surveillance-dna.yml
@@ -1,7 +1,6 @@
 name: Public Health Surveillance DNA
 
 on:
-  # Intentionally allow stacked PR bases while the surveillance stack is staged.
   pull_request:
     paths:
       - "crates/health-surveillance-core/**"
@@ -40,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5 / node24
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
@@ -93,8 +92,8 @@ jobs:
             zomes/surveillance/coordinator/Cargo.toml
           if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
 
-      - name: Verify committed lock graph
-        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+      - name: Verify complete committed lock graph
+        run: cargo metadata --locked --format-version 1 > /dev/null
 
       - name: Check formatting
         run: cargo fmt -p surveillance_integrity -p surveillance -- --check

--- a/dna/surveillance/README.md
+++ b/dna/surveillance/README.md
@@ -35,17 +35,19 @@ The DNA also freezes:
 
 v1 issuer DIDs use `did:mycelix:<AgentPubKey>`. The issuer signs the exact domain-separated transcript defined by `health-surveillance-authority`; every validating peer verifies that detached Ed25519 signature locally with Holochain's raw signature-verification host function.
 
-The subject DID inside the signed grant must equal the DHT publisher's `did:mycelix` identity. The grant must also cover the observation's exact producer, source kind, signal family, source instance, acquisition protocol, geography, and observation/publication time.
+The subject DID inside the signed grant must equal the DHT publisher's `did:mycelix` identity. The grant must also cover the observation's exact producer, source kind, signal family, source instance, acquisition protocol, geography, and signed/declared time fields.
 
 This means a valid signature for one publisher/feed/protocol/district cannot be replayed as authority for another.
 
-## Why grants are finite
+## Time and revocation boundary
 
-The surveillance integrity callback must be deterministic across peers and should not depend on a live mutable lookup into another DNA's revocation registry.
+Grant validity is encoded as a finite signed interval and the DNA caps its duration. The current integrity path compares that interval against the observation's declared time and the Holochain action timestamp.
 
-v1 therefore requires a DNA-governed maximum grant lifetime. This bounds exposure if an issuer needs to withdraw authority while we build the stronger follow-up: signed, content-addressed credential-status snapshots suitable for deterministic consensus verification.
+Those timestamps are authenticated/chain-ordered claims, **not a globally trusted wall clock**. A finite grant therefore limits the semantic validity interval of the signed authority but must not be advertised as equivalent to real-time credential expiration or revocation.
 
-Finite lifetime is **not** claimed to be equivalent to real-time revocation.
+The stronger follow-up is an issuer-signed, exact-observation endorsement/status receipt that commits to the grant ID, observation ID, release-policy ID, and publisher after the issuer has checked current credential status. A revoked producer then cannot obtain authorization for a new observation, while DHT validation can remain deterministic and self-contained.
+
+A later trusted-time evidence profile can additionally support claim-bearing real-time freshness/expiry statements. Until then, v1's time fields are explicit evidence claims with bounded semantics, not global-time proof.
 
 ## Integrity model
 
@@ -55,7 +57,7 @@ For every `ReleasedSurveillanceObservation`, every validating peer independently
 2. release-policy revision and exact `ReleasePolicyId` match DNA properties;
 3. the aggregate observation revalidates and passes the release policy;
 4. the stored release assessment exactly matches recomputation;
-5. the producer grant is structurally valid and within the DNA maximum lifetime;
+5. the producer grant is structurally valid and within the DNA maximum declared lifetime;
 6. grant subject DID equals the publisher DID;
 7. grant issuer/security-domain/schema tuple is trusted by this DNA;
 8. the observation lies inside the exact claimed grant scope;
@@ -71,9 +73,10 @@ A trusted producer grant establishes permission for a subject to publish a defin
 - that `IndependenceGroup` is truthful;
 - that an observation's measurements are scientifically correct;
 - that an institution should be trusted for unrelated purposes;
+- real-time credential/revocation status;
 - any authority to issue medical/public-health orders.
 
-Lineage-independence attestation and scientific evidence quality remain separate evidence problems.
+Lineage-independence attestation, credential-status evidence, trusted-time evidence, and scientific evidence quality remain separate problems.
 
 ## Relationship to Mycelix Identity and Xenia
 
@@ -115,7 +118,8 @@ private source systems / Health DNA
  release + publisher + issuer proof
             |
             v
- lineage/status evidence upgrades
+ exact-observation status endorsement
+ + lineage/time evidence upgrades
             |
             v
  Symthaea health-resilience

--- a/dna/surveillance/README.md
+++ b/dna/surveillance/README.md
@@ -6,46 +6,82 @@ It is intentionally separate from the patient/clinical Health DNA. Patient recor
 
 ## Default behavior: publication disabled
 
-`dna.yaml` ships with:
+`dna.yaml` ships with both authority surfaces disabled:
 
 ```yaml
 properties:
   release_policy: ~
+  producer_authority_policy: ~
 ```
 
-That is deliberate. With no configured release policy, the integrity zome rejects surveillance publication. A deployment must create/instantiate a DNA whose properties contain a governance-approved policy revision and non-zero structural release thresholds.
+That is deliberate. A deployment must explicitly pin both a governance-approved aggregate release policy and a producer-authority trust policy before the DHT accepts surveillance publication.
 
-The project does **not** provide universal privacy thresholds. Appropriate cohort size, aggregation windows, geographic precision, differential-privacy requirements, and legal/governance review depend on the deployment and source pipeline.
+The project does **not** provide universal privacy thresholds or a universal institutional trust list.
 
-## Policy identity
+## Release-policy identity
 
 `policy_revision` is a human/audit label, not the immutable identity of a release policy.
 
 The integrity zome derives a domain-separated `ReleasePolicyId` over the exact revision label plus cohort threshold, aggregation-window threshold, and maximum geographic precision. Every released observation carries both the readable revision and this exact policy commitment.
 
-Reusing the same revision label with different thresholds therefore creates a different policy identity and cannot be silently substituted into an existing released entry.
+Reusing the same revision label with different thresholds therefore creates a different policy identity and cannot be silently substituted.
+
+## Producer-authority policy
+
+The DNA also freezes:
+
+- a non-zero maximum producer-grant lifetime;
+- one or more exact trusted `(security_domain, issuer_did, credential_schema_id)` tuples.
+
+v1 issuer DIDs use `did:mycelix:<AgentPubKey>`. The issuer signs the exact domain-separated transcript defined by `health-surveillance-authority`; every validating peer verifies that detached Ed25519 signature locally with Holochain's raw signature-verification host function.
+
+The subject DID inside the signed grant must equal the DHT publisher's `did:mycelix` identity. The grant must also cover the observation's exact producer, source kind, signal family, source instance, acquisition protocol, geography, and observation/publication time.
+
+This means a valid signature for one publisher/feed/protocol/district cannot be replayed as authority for another.
+
+## Why grants are finite
+
+The surveillance integrity callback must be deterministic across peers and should not depend on a live mutable lookup into another DNA's revocation registry.
+
+v1 therefore requires a DNA-governed maximum grant lifetime. This bounds exposure if an issuer needs to withdraw authority while we build the stronger follow-up: signed, content-addressed credential-status snapshots suitable for deterministic consensus verification.
+
+Finite lifetime is **not** claimed to be equivalent to real-time revocation.
 
 ## Integrity model
 
 For every `ReleasedSurveillanceObservation`, every validating peer independently checks:
 
-1. the publisher field equals the Holochain action author;
-2. the entry's `policy_revision` equals the revision frozen into DNA properties;
-3. the entry's `policy_id` equals the immutable commitment derived from those exact DNA properties;
-4. the underlying `SurveillanceObservation` satisfies the evidence-core invariants;
-5. the DNA's release policy deterministically reassesses the observation;
-6. the observation passes that policy;
-7. the stored `ReleaseAssessment` exactly equals the recomputed assessment.
+1. publisher equals the Holochain action author;
+2. release-policy revision and exact `ReleasePolicyId` match DNA properties;
+3. the aggregate observation revalidates and passes the release policy;
+4. the stored release assessment exactly matches recomputation;
+5. the producer grant is structurally valid and within the DNA maximum lifetime;
+6. grant subject DID equals the publisher DID;
+7. grant issuer/security-domain/schema tuple is trusted by this DNA;
+8. the observation lies inside the exact claimed grant scope;
+9. the detached signature is exactly 64-byte Ed25519 and verifies over the canonical signing transcript.
 
-Released observations are append-only in v1. Updates and deletes are rejected.
+Released observations remain append-only. Updates and deletes are rejected. v1 exposes no publishable links; indexing/query semantics remain a separate tranche.
 
-No links are publishable in v1. Indexing/query semantics will be designed separately so convenience indexes cannot become an unreviewed evidence-authority layer.
+## Identity boundaries that remain separate
 
-## What publisher binding means
+A trusted producer grant establishes permission for a subject to publish a defined aggregate feed under a defined producer identity. It does **not** establish:
 
-The Holochain action author authenticates the agent key that published an entry to this DHT. It does **not** prove that the observation's human-readable producer/protocol/upstream provenance is institutionally authentic.
+- that two feeds are statistically or causally independent;
+- that `IndependenceGroup` is truthful;
+- that an observation's measurements are scientifically correct;
+- that an institution should be trusted for unrelated purposes;
+- any authority to issue medical/public-health orders.
 
-A later authenticated-provenance tranche must bind those claims to Mycelix/Xenia identity and credential evidence. Until then, producer and independence-lineage metadata remain evidence claims carried by the observation, not verified institutional attestations.
+Lineage-independence attestation and scientific evidence quality remain separate evidence problems.
+
+## Relationship to Mycelix Identity and Xenia
+
+Mycelix Identity already provides DID, credential-schema, W3C verifiable credential/presentation, signature, challenge/domain, and revocation machinery. An Identity adapter can issue/present a credential whose claims commit to the exact `ProducerAuthorityGrant` transcript.
+
+Xenia demonstrates the complementary pattern used here: signer and verifier share one small crypto-free transcript definition rather than independently serializing what they think an authorization means.
+
+The surveillance DNA does not reuse Xenia's remote-session `Viewer/Approver/Operator/Admin` role hierarchy; those are unrelated to institutional public-health producer authority.
 
 ## Non-goals
 
@@ -60,39 +96,36 @@ This DNA does not:
 - grant emergency privileges;
 - give Symthaea autonomous response authority.
 
-It only creates a stronger distributed publication boundary for aggregate evidence.
-
 ## Intended stack
 
 ```text
 private source systems / Health DNA
             |
-      source-specific aggregation
-            |
-      stronger privacy mechanisms
-       where source requires them
+ source-specific aggregation/privacy
             |
             v
    health-surveillance-core
             |
-      DNA-bound release gate
+            v
+ health-surveillance-authority
+ canonical signed producer scope
             |
             v
-     Health Surveillance DNA
-            |
-   authenticated provenance (next)
-            |
-            v
-     Symthaea health-resilience
-   evidence analysis / hypotheses
+ Health Surveillance DNA
+ release + publisher + issuer proof
             |
             v
-    human / institutional authority
+ lineage/status evidence upgrades
+            |
+            v
+ Symthaea health-resilience
+ evidence analysis / hypotheses
+            |
+            v
+ human / institutional authority
 ```
 
 ## Building
-
-The zomes are workspace members:
 
 ```bash
 cargo build --release -p surveillance_integrity -p surveillance
@@ -100,4 +133,4 @@ cargo build --release -p surveillance_integrity -p surveillance
 
 The repository's `.cargo/config.toml` targets `wasm32-unknown-unknown` by default, matching Holochain zome deployment.
 
-To package the DNA after selecting deployment properties, use the Holochain `hc dna pack` flow appropriate to the pinned Holochain 0.6 toolchain. Do not deploy the default null-policy manifest expecting publication to work; it is intentionally fail-closed.
+Do not deploy the default null-policy manifest expecting publication to work; it is intentionally fail-closed.

--- a/dna/surveillance/dna.yaml
+++ b/dna/surveillance/dna.yaml
@@ -7,6 +7,11 @@ integrity:
     # Fail closed by default. A deployment must create a DNA with an explicit,
     # governance-approved non-zero aggregate release policy before publication.
     release_policy: ~
+    # Also fail closed until the deployment pins a finite grant-lifetime policy
+    # and exact trusted (security_domain, issuer_did, credential_schema_id) tuples.
+    # v1 producer proofs are detached Ed25519 signatures over the canonical
+    # health-surveillance-authority signing transcript.
+    producer_authority_policy: ~
   zomes:
     - name: surveillance_integrity
       path: ../../target/wasm32-unknown-unknown/release/surveillance_integrity.wasm

--- a/zomes/surveillance/coordinator/src/lib.rs
+++ b/zomes/surveillance/coordinator/src/lib.rs
@@ -2,12 +2,11 @@
 // Copyright (C) 2024-2026 Tristan Stoltz / Luminous Dynamics
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Commercial licensing: see COMMERCIAL_LICENSE.md at repository root
-//! Coordinator API for policy-bound aggregate public-health surveillance.
+//! Coordinator API for policy- and producer-authority-bound surveillance.
 //!
-//! The coordinator performs the same release-policy evaluation as the integrity
-//! callback for fast caller feedback, but integrity validation remains the source
-//! of truth. No function in this zome diagnoses disease, declares an outbreak, or
-//! creates emergency authority.
+//! Coordinator preflight exists for fast caller feedback only. Every DHT peer
+//! independently repeats release-policy, issuer-trust, grant-scope, subject, and
+//! detached-signature verification in the integrity callback.
 
 use hdk::prelude::*;
 use surveillance_integrity::*;
@@ -15,6 +14,10 @@ use surveillance_integrity::*;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SubmitSurveillanceObservationInput {
     pub observation: SurveillanceObservation,
+    pub authority_grant: ProducerAuthorityGrant,
+    /// Detached Ed25519 signature by the grant issuer over the exact shared
+    /// `ProducerAuthorityGrant::signing_transcript()` bytes.
+    pub authority_signature: Vec<u8>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -23,6 +26,7 @@ pub struct SubmitSurveillanceObservationOutput {
     pub observation_id: ObservationId,
     pub policy_revision: CanonicalId,
     pub policy_id: ReleasePolicyId,
+    pub authority_grant_id: ProducerAuthorityGrantId,
     pub publisher: AgentPubKey,
 }
 
@@ -33,8 +37,20 @@ pub struct ReleasePolicyView {
     pub policy: AggregateReleasePolicy,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TrustedAuthorityIssuerView {
+    pub security_domain: CanonicalId,
+    pub issuer_did: CanonicalId,
+    pub credential_schema_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProducerAuthorityPolicyView {
+    pub max_grant_lifetime_s: u64,
+    pub trusted_issuers: Vec<TrustedAuthorityIssuerView>,
+}
+
 /// Return the release policy frozen into this DNA's integrity properties.
-/// Fails closed when publication is disabled or the property contract is invalid.
 #[hdk_extern]
 pub fn get_release_policy(_: ()) -> ExternResult<ReleasePolicyView> {
     let configured = configured_release_policy()?;
@@ -45,51 +61,92 @@ pub fn get_release_policy(_: ()) -> ExternResult<ReleasePolicyView> {
     })
 }
 
-/// Submit one aggregate surveillance observation.
+/// Return the producer-authority trust contract frozen into DNA properties.
+#[hdk_extern]
+pub fn get_producer_authority_policy(_: ()) -> ExternResult<ProducerAuthorityPolicyView> {
+    let configured = configured_producer_authority_policy()?;
+    Ok(ProducerAuthorityPolicyView {
+        max_grant_lifetime_s: configured.max_grant_lifetime_s,
+        trusted_issuers: configured
+            .trusted_issuers
+            .into_iter()
+            .map(|issuer| TrustedAuthorityIssuerView {
+                security_domain: issuer.security_domain,
+                issuer_did: issuer.issuer_did,
+                credential_schema_id: issuer.credential_schema_id,
+            })
+            .collect(),
+    })
+}
+
+/// Submit one aggregate surveillance observation with a signed producer grant.
 ///
-/// This performs a coordinator-side preflight. Every peer independently repeats
-/// the same policy evaluation in the integrity callback before accepting the DHT
-/// operation.
+/// The caller supplies the external issuer proof; the local coordinator does not
+/// mint institutional authority. It only verifies the proof against DNA-bound
+/// trusted issuers before attempting the DHT write.
 #[hdk_extern]
 pub fn submit_surveillance_observation(
     input: SubmitSurveillanceObservationInput,
 ) -> ExternResult<SubmitSurveillanceObservationOutput> {
-    let configured = configured_release_policy()?;
-    let assessment = configured.policy.assess(&input.observation).map_err(|e| {
-        wasm_error!(WasmErrorInner::Guest(format!(
-            "Invalid surveillance observation: {e}"
-        )))
-    })?;
-
-    if !assessment.eligible_for_release() {
-        return Err(wasm_error!(WasmErrorInner::Guest(format!(
-            "Observation withheld by DNA release policy: {:?}",
-            assessment.reasons()
-        ))));
-    }
-
+    let release_policy = configured_release_policy()?;
+    let authority_policy = configured_producer_authority_policy()?;
     let publisher = agent_info()?.agent_initial_pubkey;
+    let now = sys_time()?;
+    let now_unix_s = now.as_micros().div_euclid(1_000_000);
+
+    let release_assessment = release_policy
+        .policy
+        .assess(&input.observation)
+        .map_err(|e| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Invalid surveillance observation: {e}"
+            )))
+        })?;
+
     let observation_id = input.observation.id().map_err(|e| {
         wasm_error!(WasmErrorInner::Guest(format!(
             "Could not derive observation identity: {e}"
         )))
     })?;
+    let authority_grant_id = input.authority_grant.id().map_err(|e| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Could not derive producer-authority identity: {e}"
+        )))
+    })?;
 
     let entry = ReleasedSurveillanceObservation {
         observation: input.observation,
-        release_assessment: assessment,
-        policy_revision: configured.policy_revision.clone(),
-        policy_id: configured.policy_id,
+        release_assessment,
+        policy_revision: release_policy.policy_revision.clone(),
+        policy_id: release_policy.policy_id,
+        authority_grant: input.authority_grant,
+        authority_signature: input.authority_signature,
         publisher: publisher.clone(),
     };
+
+    let plan = validate_released_entry_semantics(
+        &publisher,
+        now_unix_s,
+        &entry,
+        &release_policy,
+        &authority_policy,
+    )
+    .map_err(|message| wasm_error!(WasmErrorInner::Guest(message)))?;
+
+    if !verify_authority_signature(&plan, &entry.authority_signature)? {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "producer-authority signature verification failed".to_string()
+        )));
+    }
 
     let action_hash = create_entry(&EntryTypes::ReleasedSurveillanceObservation(entry))?;
 
     Ok(SubmitSurveillanceObservationOutput {
         action_hash,
         observation_id,
-        policy_revision: configured.policy_revision,
-        policy_id: configured.policy_id,
+        policy_revision: release_policy.policy_revision,
+        policy_id: release_policy.policy_id,
+        authority_grant_id,
         publisher,
     })
 }

--- a/zomes/surveillance/integrity/Cargo.toml
+++ b/zomes/surveillance/integrity/Cargo.toml
@@ -15,3 +15,4 @@ serde.workspace = true
 holochain_serialized_bytes.workspace = true
 sha2 = "0.10"
 health-surveillance-core = { path = "../../../crates/health-surveillance-core" }
+health-surveillance-authority = { path = "../../../crates/health-surveillance-authority" }

--- a/zomes/surveillance/integrity/src/lib.rs
+++ b/zomes/surveillance/integrity/src/lib.rs
@@ -2,23 +2,27 @@
 // Copyright (C) 2024-2026 Tristan Stoltz / Luminous Dynamics
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Commercial licensing: see COMMERCIAL_LICENSE.md at repository root
-//! Policy-bound aggregate public-health surveillance integrity zome.
+//! Policy- and authority-bound aggregate public-health surveillance integrity.
 //!
-//! This DNA stores only observations that have already crossed the aggregate
-//! evidence boundary defined by `health-surveillance-core`. Publication policy
-//! is a DNA property so every peer validates the same structural privacy floor.
-//! If no release policy is configured, publication fails closed.
+//! Publication is fail-closed unless the DNA defines both a structural release
+//! policy and a producer-authority policy. Every peer revalidates the aggregate,
+//! the exact release-policy identity, the publisher/subject binding, the trusted
+//! issuer tuple, the grant lifetime/scope, and the issuer's detached Ed25519
+//! signature over the shared canonical producer-authority transcript.
 //!
-//! This zome does not authenticate the institutional meaning of a producer label,
-//! diagnose disease, declare an outbreak, recommend treatment, or authorize an
-//! emergency response.
+//! This is publication authority only. It does not authenticate evidence-lineage
+//! independence, diagnose disease, declare outbreaks, recommend treatment, or
+//! authorize emergency response.
 
 use hdi::prelude::*;
+pub use health_surveillance_authority::*;
 pub use health_surveillance_core::*;
 use sha2::{Digest, Sha256};
 
 pub const RELEASE_POLICY_ID_DOMAIN_V1: &[u8] =
     b"mycelix-health-surveillance-release-policy-v1\0";
+const MAX_TRUSTED_AUTHORITY_ISSUERS: usize = 64;
+const ED25519_SIGNATURE_BYTES: usize = 64;
 
 /// Immutable semantic identity of the exact release-policy authority configured
 /// into one surveillance DNA. A human revision label alone is not an identity.
@@ -55,6 +59,7 @@ impl ReleasePolicyId {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct ReleasePolicyProperties {
     /// Human/audit label. The immutable policy identity is `ReleasePolicyId`,
     /// which also commits to all exact threshold values below.
@@ -64,12 +69,35 @@ pub struct ReleasePolicyProperties {
     pub max_geographic_precision: GeographicPrecision,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TrustedAuthorityIssuerProperties {
+    /// Identity/security domain in which this issuer is trusted.
+    pub security_domain: String,
+    /// Exact Mycelix DID of the issuer. v1 supports `did:mycelix:<AgentPubKey>`.
+    pub issuer_did: String,
+    /// Exact credential schema whose producer-authority semantics are accepted.
+    pub credential_schema_id: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ProducerAuthorityPolicyProperties {
+    /// Upper bound on one signed grant's lifetime. This bounds exposure while
+    /// mutable cross-DNA revocation/status snapshots are not yet in consensus.
+    pub max_grant_lifetime_s: u64,
+    /// Small DNA-bound issuer allowlist. Changing it intentionally changes the
+    /// DNA hash/network rather than changing trust underneath existing evidence.
+    pub trusted_issuers: Vec<TrustedAuthorityIssuerProperties>,
+}
+
 #[dna_properties]
 #[derive(Clone, Debug, PartialEq)]
 pub struct SurveillanceDnaProperties {
-    /// `None` intentionally disables publication. Deployments must choose and
-    /// pin a non-zero release policy before accepting aggregate evidence.
+    /// `None` intentionally disables aggregate publication.
     pub release_policy: Option<ReleasePolicyProperties>,
+    /// `None` intentionally disables authenticated producer publication.
+    pub producer_authority_policy: Option<ProducerAuthorityPolicyProperties>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -77,6 +105,28 @@ pub struct ConfiguredReleasePolicy {
     pub policy_revision: CanonicalId,
     pub policy_id: ReleasePolicyId,
     pub policy: AggregateReleasePolicy,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfiguredTrustedAuthorityIssuer {
+    pub security_domain: CanonicalId,
+    pub issuer_did: CanonicalId,
+    pub credential_schema_id: CanonicalId,
+    pub issuer_pubkey: AgentPubKey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfiguredProducerAuthorityPolicy {
+    pub max_grant_lifetime_s: u64,
+    pub trusted_issuers: Vec<ConfiguredTrustedAuthorityIssuer>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AuthorityVerificationPlan {
+    pub issuer_pubkey: AgentPubKey,
+    pub signing_transcript: Vec<u8>,
+    pub grant_id: ProducerAuthorityGrantId,
+    pub scope_assessment: ClaimedScopeAssessment,
 }
 
 pub fn configured_release_policy() -> ExternResult<ConfiguredReleasePolicy> {
@@ -91,6 +141,22 @@ pub fn configured_release_policy() -> ExternResult<ConfiguredReleasePolicy> {
     configured_release_policy_from_properties(&configured).map_err(|message| {
         wasm_error!(WasmErrorInner::Guest(format!(
             "Invalid surveillance DNA release policy: {message}"
+        )))
+    })
+}
+
+pub fn configured_producer_authority_policy() -> ExternResult<ConfiguredProducerAuthorityPolicy> {
+    let properties = SurveillanceDnaProperties::try_from_dna_properties()?;
+    let configured = properties.producer_authority_policy.ok_or_else(|| {
+        wasm_error!(WasmErrorInner::Guest(
+            "Public-health surveillance publication is disabled: no DNA producer_authority_policy is configured"
+                .to_string()
+        ))
+    })?;
+
+    configured_producer_authority_policy_from_properties(&configured).map_err(|message| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Invalid surveillance DNA producer authority policy: {message}"
         )))
     })
 }
@@ -115,21 +181,95 @@ pub fn configured_release_policy_from_properties(
     })
 }
 
-/// One aggregate observation admitted for publication by the policy frozen in
-/// this DNA's integrity properties.
+pub fn configured_producer_authority_policy_from_properties(
+    properties: &ProducerAuthorityPolicyProperties,
+) -> Result<ConfiguredProducerAuthorityPolicy, String> {
+    if properties.max_grant_lifetime_s == 0 {
+        return Err("max_grant_lifetime_s must be greater than zero".to_string());
+    }
+    if properties.trusted_issuers.is_empty() {
+        return Err("trusted_issuers must contain at least one issuer".to_string());
+    }
+    if properties.trusted_issuers.len() > MAX_TRUSTED_AUTHORITY_ISSUERS {
+        return Err(format!(
+            "trusted_issuers exceeds maximum of {MAX_TRUSTED_AUTHORITY_ISSUERS}"
+        ));
+    }
+
+    let mut trusted_issuers = Vec::with_capacity(properties.trusted_issuers.len());
+    for issuer in &properties.trusted_issuers {
+        let security_domain = CanonicalId::new(issuer.security_domain.clone())
+            .map_err(|e| format!("invalid authority security_domain: {e}"))?;
+        let issuer_did = CanonicalId::new(issuer.issuer_did.clone())
+            .map_err(|e| format!("invalid authority issuer_did: {e}"))?;
+        let credential_schema_id = CanonicalId::new(issuer.credential_schema_id.clone())
+            .map_err(|e| format!("invalid authority credential_schema_id: {e}"))?;
+        let issuer_pubkey = parse_mycelix_did_agent(&issuer_did)?;
+
+        let configured = ConfiguredTrustedAuthorityIssuer {
+            security_domain,
+            issuer_did,
+            credential_schema_id,
+            issuer_pubkey,
+        };
+        if trusted_issuers.iter().any(|existing| existing == &configured) {
+            return Err("trusted_issuers contains a duplicate issuer tuple".to_string());
+        }
+        trusted_issuers.push(configured);
+    }
+
+    trusted_issuers.sort_by(|a, b| {
+        (
+            a.security_domain.as_str(),
+            a.issuer_did.as_str(),
+            a.credential_schema_id.as_str(),
+        )
+            .cmp(&(
+                b.security_domain.as_str(),
+                b.issuer_did.as_str(),
+                b.credential_schema_id.as_str(),
+            ))
+    });
+
+    Ok(ConfiguredProducerAuthorityPolicy {
+        max_grant_lifetime_s: properties.max_grant_lifetime_s,
+        trusted_issuers,
+    })
+}
+
+fn parse_mycelix_did_agent(did: &CanonicalId) -> Result<AgentPubKey, String> {
+    let encoded = did
+        .as_str()
+        .strip_prefix("did:mycelix:")
+        .ok_or_else(|| "trusted producer-authority issuer must use did:mycelix".to_string())?;
+    AgentPubKey::try_from(encoded.to_string())
+        .map_err(|_| "could not parse did:mycelix issuer AgentPubKey".to_string())
+}
+
+fn expected_subject_did(author: &AgentPubKey) -> Result<CanonicalId, String> {
+    CanonicalId::new(format!("did:mycelix:{author}"))
+        .map_err(|e| format!("could not derive publisher DID: {e}"))
+}
+
+/// One aggregate observation admitted by both the release policy and a signed,
+/// DNA-trusted producer-authority grant.
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq)]
 pub struct ReleasedSurveillanceObservation {
     pub observation: SurveillanceObservation,
     /// Exact release decision recomputed by every validating peer.
     pub release_assessment: ReleaseAssessment,
-    /// Human/audit revision echoed from the DNA property contract.
+    /// Human/audit release-policy revision echoed from DNA properties.
     pub policy_revision: CanonicalId,
-    /// Immutable commitment to the exact revision + threshold contract.
+    /// Immutable commitment to the exact release-policy thresholds.
     pub policy_id: ReleasePolicyId,
-    /// Agent that authored this DHT entry. This authenticates only the Holochain
-    /// author key; it does not prove the institutional producer label in the
-    /// observation's provenance.
+    /// Signed claimed producer-authority payload.
+    pub authority_grant: ProducerAuthorityGrant,
+    /// Detached Ed25519 signature over `authority_grant.signing_transcript()`.
+    /// v1 deliberately supports one algorithm so unsupported/ambiguous proofs
+    /// fail rather than being negotiated inside the evidence record.
+    pub authority_signature: Vec<u8>,
+    /// Logical Holochain author of this DHT entry.
     pub publisher: AgentPubKey,
 }
 
@@ -140,8 +280,7 @@ pub enum EntryTypes {
 }
 
 /// v1 intentionally exposes no index links. A future indexing tranche must
-/// define and validate query semantics separately rather than making links look
-/// more authoritative than the released entries they point to.
+/// define and validate query semantics separately.
 #[hdk_link_types]
 pub enum LinkTypes {
     Reserved,
@@ -153,7 +292,7 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
         FlatOp::StoreEntry(store_entry) => match store_entry {
             OpEntry::CreateEntry { app_entry, action } => match app_entry {
                 EntryTypes::ReleasedSurveillanceObservation(entry) => {
-                    validate_released_entry(&action.author, &entry)
+                    validate_released_entry(&action.author, action.timestamp, &entry)
                 }
             },
             OpEntry::UpdateEntry { .. } => Ok(ValidateCallbackResult::Invalid(
@@ -179,66 +318,197 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
 
 fn validate_released_entry(
     action_author: &AgentPubKey,
+    action_timestamp: Timestamp,
     entry: &ReleasedSurveillanceObservation,
 ) -> ExternResult<ValidateCallbackResult> {
-    let configured = configured_release_policy()?;
-    match validate_released_entry_against_policy(action_author, entry, &configured) {
-        Ok(()) => Ok(ValidateCallbackResult::Valid),
-        Err(message) => Ok(ValidateCallbackResult::Invalid(message)),
+    let release_policy = configured_release_policy()?;
+    let authority_policy = configured_producer_authority_policy()?;
+    let authored_at_unix_s = action_timestamp.as_micros().div_euclid(1_000_000);
+
+    let plan = match validate_released_entry_semantics(
+        action_author,
+        authored_at_unix_s,
+        entry,
+        &release_policy,
+        &authority_policy,
+    ) {
+        Ok(plan) => plan,
+        Err(message) => return Ok(ValidateCallbackResult::Invalid(message)),
+    };
+
+    match verify_authority_signature(&plan, &entry.authority_signature)? {
+        true => Ok(ValidateCallbackResult::Valid),
+        false => Ok(ValidateCallbackResult::Invalid(
+            "producer-authority signature verification failed".to_string(),
+        )),
     }
 }
 
-pub fn validate_released_entry_against_policy(
+/// Perform every deterministic semantic check except the host cryptographic
+/// operation, returning the exact verification plan when all substitutions fail
+/// closed. This split keeps replay/scope/policy tests pure.
+pub fn validate_released_entry_semantics(
     action_author: &AgentPubKey,
+    authored_at_unix_s: i64,
     entry: &ReleasedSurveillanceObservation,
-    configured: &ConfiguredReleasePolicy,
-) -> Result<(), String> {
+    release_policy: &ConfiguredReleasePolicy,
+    authority_policy: &ConfiguredProducerAuthorityPolicy,
+) -> Result<AuthorityVerificationPlan, String> {
     if &entry.publisher != action_author {
         return Err("publisher must equal the Holochain action author".to_string());
     }
-    if entry.policy_revision != configured.policy_revision {
+    if entry.policy_revision != release_policy.policy_revision {
         return Err("entry policy_revision does not match the DNA release policy".to_string());
     }
-    if entry.policy_id != configured.policy_id {
+    if entry.policy_id != release_policy.policy_id {
         return Err("entry policy_id does not match the exact DNA release policy".to_string());
+    }
+    if entry.authority_signature.len() != ED25519_SIGNATURE_BYTES {
+        return Err(format!(
+            "producer-authority Ed25519 signature must be {ED25519_SIGNATURE_BYTES} bytes"
+        ));
     }
 
     entry
         .observation
         .validate()
         .map_err(|e| format!("invalid surveillance observation: {e}"))?;
+    entry
+        .authority_grant
+        .validate()
+        .map_err(|e| format!("invalid producer-authority grant: {e}"))?;
 
-    let expected = configured
+    let expected_release = release_policy
         .policy
         .assess(&entry.observation)
         .map_err(|e| format!("release assessment failed: {e}"))?;
-
-    if !expected.eligible_for_release() {
+    if !expected_release.eligible_for_release() {
         return Err(format!(
             "observation does not satisfy the DNA release policy: {:?}",
-            expected.reasons()
+            expected_release.reasons()
         ));
     }
-    if entry.release_assessment != expected {
+    if entry.release_assessment != expected_release {
         return Err(
             "stored release assessment does not match deterministic policy evaluation".to_string(),
         );
     }
 
-    Ok(())
+    let expected_subject = expected_subject_did(action_author)?;
+    if entry.authority_grant.subject_did() != &expected_subject {
+        return Err("producer-authority subject DID does not match DHT publisher".to_string());
+    }
+
+    let grant_lifetime_i64 = entry
+        .authority_grant
+        .valid_until_unix_s()
+        .checked_sub(entry.authority_grant.valid_from_unix_s())
+        .ok_or_else(|| "producer-authority grant lifetime overflow".to_string())?;
+    let grant_lifetime_s = u64::try_from(grant_lifetime_i64)
+        .map_err(|_| "producer-authority grant lifetime is invalid".to_string())?;
+    if grant_lifetime_s > authority_policy.max_grant_lifetime_s {
+        return Err(format!(
+            "producer-authority grant lifetime exceeds DNA maximum of {} seconds",
+            authority_policy.max_grant_lifetime_s
+        ));
+    }
+
+    let trusted_issuer = authority_policy
+        .trusted_issuers
+        .iter()
+        .find(|issuer| {
+            &issuer.security_domain == entry.authority_grant.security_domain()
+                && &issuer.issuer_did == entry.authority_grant.issuer_did()
+                && &issuer.credential_schema_id == entry.authority_grant.credential_schema_id()
+        })
+        .ok_or_else(|| {
+            "producer-authority issuer/security-domain/schema tuple is not trusted by this DNA"
+                .to_string()
+        })?;
+
+    let scope_assessment = entry
+        .authority_grant
+        .assess_claimed_scope(&entry.observation, authored_at_unix_s)
+        .map_err(|e| format!("producer-authority scope assessment failed: {e}"))?;
+    if !scope_assessment.permitted_by_claimed_scope {
+        return Err(format!(
+            "observation is outside producer-authority scope: {:?}",
+            scope_assessment.reasons
+        ));
+    }
+
+    let signing_transcript = entry
+        .authority_grant
+        .signing_transcript()
+        .map_err(|e| format!("could not construct producer-authority transcript: {e}"))?;
+
+    Ok(AuthorityVerificationPlan {
+        issuer_pubkey: trusted_issuer.issuer_pubkey.clone(),
+        signing_transcript,
+        grant_id: entry
+            .authority_grant
+            .id()
+            .map_err(|e| format!("could not derive producer-authority ID: {e}"))?,
+        scope_assessment,
+    })
+}
+
+/// Verify the detached v1 Ed25519 proof against literal canonical transcript
+/// bytes. There is no serialization or algorithm negotiation at this boundary.
+pub fn verify_authority_signature(
+    plan: &AuthorityVerificationPlan,
+    signature_bytes: &[u8],
+) -> ExternResult<bool> {
+    let raw: [u8; ED25519_SIGNATURE_BYTES] = match signature_bytes.try_into() {
+        Ok(raw) => raw,
+        Err(_) => return Ok(false),
+    };
+    let signature = Signature::from(raw);
+    verify_signature_raw(
+        plan.issuer_pubkey.clone(),
+        signature,
+        plan.signing_transcript.clone(),
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn policy() -> ConfiguredReleasePolicy {
+    fn id(value: &str) -> CanonicalId {
+        CanonicalId::new(value).unwrap()
+    }
+
+    fn agent(byte: u8) -> AgentPubKey {
+        AgentPubKey::from_raw_36(vec![byte; 36])
+    }
+
+    fn did(agent: &AgentPubKey) -> String {
+        format!("did:mycelix:{agent}")
+    }
+
+    fn release_policy() -> ConfiguredReleasePolicy {
         configured_release_policy_from_properties(&ReleasePolicyProperties {
             policy_revision: "district-release-v1".to_string(),
             min_cohort_size: 50,
             min_window_s: 3_600,
             max_geographic_precision: GeographicPrecision::District,
         })
+        .unwrap()
+    }
+
+    fn authority_policy(issuer: &AgentPubKey) -> ConfiguredProducerAuthorityPolicy {
+        configured_producer_authority_policy_from_properties(
+            &ProducerAuthorityPolicyProperties {
+                max_grant_lifetime_s: 86_400,
+                trusted_issuers: vec![TrustedAuthorityIssuerProperties {
+                    security_domain: "identity-domain:public-health-v1".to_string(),
+                    issuer_did: did(issuer),
+                    credential_schema_id:
+                        "mycelix:schema:health:surveillance-publisher:v1".to_string(),
+                }],
+            },
+        )
         .unwrap()
     }
 
@@ -272,109 +542,206 @@ mod tests {
         .unwrap()
     }
 
-    fn agent(byte: u8) -> AgentPubKey {
-        AgentPubKey::from_raw_36(vec![byte; 36])
+    fn grant(publisher: &AgentPubKey, issuer: &AgentPubKey) -> ProducerAuthorityGrant {
+        ProducerAuthorityGrant::new(
+            id("identity-domain:public-health-v1"),
+            id("mycelix:schema:health:surveillance-publisher:v1"),
+            id(&did(issuer)),
+            id(&did(publisher)),
+            id("lab-a"),
+            ProducerAuthorityScope::new(
+                vec![SourceKind::LaboratoryAggregate],
+                vec![SignalFamily::Respiratory],
+                vec![id("lab-feed-a")],
+                vec![id("aggregate-protocol-v1")],
+                vec![GeographicScope::new(
+                    "health-district",
+                    "district-17",
+                    GeographicPrecision::District,
+                )
+                .unwrap()],
+            )
+            .unwrap(),
+            9_000,
+            20_000,
+            [5; 32],
+        )
+        .unwrap()
     }
 
     fn released_entry(
-        configured: &ConfiguredReleasePolicy,
+        publisher: &AgentPubKey,
+        issuer: &AgentPubKey,
         observation: SurveillanceObservation,
-        publisher: AgentPubKey,
     ) -> ReleasedSurveillanceObservation {
-        let assessment = configured.policy.assess(&observation).unwrap();
+        let release = release_policy();
+        let assessment = release.policy.assess(&observation).unwrap();
         ReleasedSurveillanceObservation {
             observation,
             release_assessment: assessment,
-            policy_revision: configured.policy_revision.clone(),
-            policy_id: configured.policy_id,
-            publisher,
+            policy_revision: release.policy_revision,
+            policy_id: release.policy_id,
+            authority_grant: grant(publisher, issuer),
+            authority_signature: vec![1; ED25519_SIGNATURE_BYTES],
+            publisher: publisher.clone(),
         }
     }
 
     #[test]
-    fn missing_or_zero_policy_is_not_constructible_as_configured_policy() {
-        let result = configured_release_policy_from_properties(&ReleasePolicyProperties {
-            policy_revision: "policy-v1".to_string(),
-            min_cohort_size: 0,
-            min_window_s: 3_600,
-            max_geographic_precision: GeographicPrecision::District,
-        });
-        assert!(result.is_err());
+    fn zero_lifetime_or_empty_trusted_issuer_policy_fails_closed() {
+        let issuer = agent(3);
+        assert!(configured_producer_authority_policy_from_properties(
+            &ProducerAuthorityPolicyProperties {
+                max_grant_lifetime_s: 0,
+                trusted_issuers: vec![TrustedAuthorityIssuerProperties {
+                    security_domain: "identity-domain:public-health-v1".into(),
+                    issuer_did: did(&issuer),
+                    credential_schema_id:
+                        "mycelix:schema:health:surveillance-publisher:v1".into(),
+                }],
+            }
+        )
+        .is_err());
+        assert!(configured_producer_authority_policy_from_properties(
+            &ProducerAuthorityPolicyProperties {
+                max_grant_lifetime_s: 3600,
+                trusted_issuers: vec![],
+            }
+        )
+        .is_err());
     }
 
     #[test]
-    fn same_revision_with_different_thresholds_has_different_policy_identity() {
-        let a = configured_release_policy_from_properties(&ReleasePolicyProperties {
-            policy_revision: "policy-v1".to_string(),
+    fn exact_release_and_authority_semantics_produce_verification_plan() {
+        let publisher = agent(1);
+        let issuer = agent(3);
+        let entry = released_entry(&publisher, &issuer, observation(100));
+        let plan = validate_released_entry_semantics(
+            &publisher,
+            14_000,
+            &entry,
+            &release_policy(),
+            &authority_policy(&issuer),
+        )
+        .unwrap();
+        assert_eq!(plan.issuer_pubkey, issuer);
+        assert_eq!(plan.grant_id, entry.authority_grant.id().unwrap());
+        assert!(plan.scope_assessment.permitted_by_claimed_scope);
+    }
+
+    #[test]
+    fn publisher_subject_substitution_fails() {
+        let publisher = agent(1);
+        let other_publisher = agent(2);
+        let issuer = agent(3);
+        let entry = released_entry(&publisher, &issuer, observation(100));
+        assert!(validate_released_entry_semantics(
+            &other_publisher,
+            14_000,
+            &entry,
+            &release_policy(),
+            &authority_policy(&issuer),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn issuer_domain_or_schema_substitution_fails() {
+        let publisher = agent(1);
+        let issuer = agent(3);
+        let entry = released_entry(&publisher, &issuer, observation(100));
+
+        let other_domain = configured_producer_authority_policy_from_properties(
+            &ProducerAuthorityPolicyProperties {
+                max_grant_lifetime_s: 86_400,
+                trusted_issuers: vec![TrustedAuthorityIssuerProperties {
+                    security_domain: "identity-domain:other".into(),
+                    issuer_did: did(&issuer),
+                    credential_schema_id:
+                        "mycelix:schema:health:surveillance-publisher:v1".into(),
+                }],
+            },
+        )
+        .unwrap();
+        assert!(validate_released_entry_semantics(
+            &publisher,
+            14_000,
+            &entry,
+            &release_policy(),
+            &other_domain,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn overlong_grant_fails_even_when_issuer_tuple_is_trusted() {
+        let publisher = agent(1);
+        let issuer = agent(3);
+        let entry = released_entry(&publisher, &issuer, observation(100));
+        let mut policy = authority_policy(&issuer);
+        policy.max_grant_lifetime_s = 1_000;
+        assert!(validate_released_entry_semantics(
+            &publisher,
+            14_000,
+            &entry,
+            &release_policy(),
+            &policy,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn observation_scope_substitution_fails_before_signature_verification() {
+        let publisher = agent(1);
+        let issuer = agent(3);
+        let mut obs = observation(100);
+        obs.provenance.acquisition_protocol = id("other-protocol");
+        let entry = released_entry(&publisher, &issuer, obs);
+        assert!(validate_released_entry_semantics(
+            &publisher,
+            14_000,
+            &entry,
+            &release_policy(),
+            &authority_policy(&issuer),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn malformed_signature_length_fails_before_host_crypto() {
+        let publisher = agent(1);
+        let issuer = agent(3);
+        let mut entry = released_entry(&publisher, &issuer, observation(100));
+        entry.authority_signature = vec![1; 63];
+        assert!(validate_released_entry_semantics(
+            &publisher,
+            14_000,
+            &entry,
+            &release_policy(),
+            &authority_policy(&issuer),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn release_policy_substitution_still_fails_with_valid_authority_shape() {
+        let publisher = agent(1);
+        let issuer = agent(3);
+        let entry = released_entry(&publisher, &issuer, observation(100));
+        let other_release = configured_release_policy_from_properties(&ReleasePolicyProperties {
+            policy_revision: "other-release".to_string(),
             min_cohort_size: 50,
             min_window_s: 3_600,
             max_geographic_precision: GeographicPrecision::District,
         })
         .unwrap();
-        let b = configured_release_policy_from_properties(&ReleasePolicyProperties {
-            policy_revision: "policy-v1".to_string(),
-            min_cohort_size: 100,
-            min_window_s: 3_600,
-            max_geographic_precision: GeographicPrecision::District,
-        })
-        .unwrap();
-
-        assert_eq!(a.policy_revision, b.policy_revision);
-        assert_ne!(a.policy_id, b.policy_id);
-    }
-
-    #[test]
-    fn exact_policy_assessment_author_and_policy_identity_are_required() {
-        let configured = policy();
-        let publisher = agent(1);
-        let entry = released_entry(&configured, observation(100), publisher.clone());
-
-        assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_ok());
-        assert!(validate_released_entry_against_policy(&agent(2), &entry, &configured).is_err());
-    }
-
-    #[test]
-    fn undersized_aggregate_cannot_be_published_even_with_forged_pass_receipt() {
-        let configured = policy();
-        let good = observation(100);
-        let forged_assessment = configured.policy.assess(&good).unwrap();
-        let publisher = agent(1);
-        let entry = ReleasedSurveillanceObservation {
-            observation: observation(10),
-            release_assessment: forged_assessment,
-            policy_revision: configured.policy_revision.clone(),
-            policy_id: configured.policy_id,
-            publisher: publisher.clone(),
-        };
-
-        assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_err());
-    }
-
-    #[test]
-    fn policy_revision_substitution_is_rejected() {
-        let configured = policy();
-        let publisher = agent(1);
-        let mut entry = released_entry(&configured, observation(100), publisher.clone());
-        entry.policy_revision = CanonicalId::new("different-policy").unwrap();
-
-        assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_err());
-    }
-
-    #[test]
-    fn same_revision_different_policy_id_substitution_is_rejected() {
-        let configured = policy();
-        let other = configured_release_policy_from_properties(&ReleasePolicyProperties {
-            policy_revision: configured.policy_revision.as_str().to_string(),
-            min_cohort_size: 100,
-            min_window_s: 3_600,
-            max_geographic_precision: GeographicPrecision::District,
-        })
-        .unwrap();
-        let publisher = agent(1);
-        let mut entry = released_entry(&configured, observation(100), publisher.clone());
-        entry.policy_id = other.policy_id;
-
-        assert_ne!(configured.policy_id, other.policy_id);
-        assert!(validate_released_entry_against_policy(&publisher, &entry, &configured).is_err());
+        assert!(validate_released_entry_semantics(
+            &publisher,
+            14_000,
+            &entry,
+            &other_release,
+            &authority_policy(&issuer),
+        )
+        .is_err());
     }
 }

--- a/zomes/surveillance/integrity/src/lib.rs
+++ b/zomes/surveillance/integrity/src/lib.rs
@@ -92,7 +92,7 @@ pub struct ProducerAuthorityPolicyProperties {
 }
 
 #[dna_properties]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct SurveillanceDnaProperties {
     /// `None` intentionally disables aggregate publication.
     pub release_policy: Option<ReleasePolicyProperties>,


### PR DESCRIPTION
## Summary

Stack on #12 and make producer authorization a real DHT integrity requirement rather than a caller-supplied provenance claim.

This tranche verifies a detached Ed25519 proof over #12's exact canonical producer-authority transcript against an issuer/security-domain/schema trust policy frozen into Surveillance DNA properties. Verification remains deterministic and local to every peer; no validation callback depends on a live cross-DNA lookup.

## Exact dependency state

Current parent #12 head: `d5e77c7032af8837105ff5bb5afc7f417e832b2b`.

Current #13 head: `430d14dd75cfa1eca0eedf9e6229441c40b60742`.

#13 is a real descendant of the synchronized #12 tree through two-parent restack commit `430d14dd75cfa1eca0eedf9e6229441c40b60742`.

Comparing exact #12 → exact #13 yields only the six #13-owned verifier/DNA files. #10's focused source gate is green; #11/#12/#13 exact downstream gates remain queued. Keep draft and preserve bottom-up qualification.

## DNA-bound authority policy

`SurveillanceDnaProperties` requires independent publication policy surfaces for structural release and producer authority. Missing required policy means publication fails closed.

The producer-authority policy binds a non-zero maximum grant lifetime and one or more exact trusted issuer tuples `(security_domain, issuer_did, credential_schema_id)`. v1 issuer DIDs are `did:mycelix:<AgentPubKey>` and are parsed to the actual Holochain verification key during policy validation. Duplicate issuer tuples fail closed.

Changing these DNA properties changes the DNA/network rather than silently changing trust underneath already-published evidence.

## Released entry authority evidence

`ReleasedSurveillanceObservation` carries the complete `ProducerAuthorityGrant` plus a detached 64-byte Ed25519 signature over the canonical grant transcript.

Every validating peer requires publisher/action-author binding, exact release-policy identity, observation/release reassessment, grant validity, publisher-subject binding, exact DNA-trusted issuer/domain/schema membership, claimed producer/source/signal/feed/protocol/geography scope, and literal-byte issuer signature verification.

Semantic substitution checks occur before host crypto; a valid signature cannot rescue a grant for the wrong publisher, domain, schema, protocol, geography, policy, or observation.

## Time / revocation limitation

This PR does **not** establish trusted global wall-clock freshness or real-time credential revocation.

Holochain action timestamps are authenticated chain metadata but are not treated as proof of external/global wall-clock truth. Any grant-validity evaluation based on publication/action time therefore remains a bounded structural mechanism, not evidence equivalent to a fresh external credential-status check.

#14 adds the stronger normal-online profile: a separately signed, exact-observation positive status endorsement whose issuer-asserted check time is itself bound into the signed endorsement. Do not interpret #13 alone as fresh revocation evidence.

## Why Ed25519 first

Current Mycelix Identity VC issuance/presentation uses Holochain agent Ed25519 signing and verification, and Holochain exposes literal-byte signature verification inside zomes. v1 therefore supports one unambiguous algorithm instead of premature negotiation logic.

PQC/ML-DSA can be additive in a later proof-profile version without weakening the existing Holochain author/DID binding.

## Independence remains separate

A valid producer grant does not authenticate `IndependenceGroup` or prove statistical/causal independence. Producer authorization cannot become a shortcut for corroboration quality.

## Explicit non-goals

No patient-level records, diagnosis, treatment, outbreak declaration, public-health orders, emergency authority, general-purpose institutional trust score, pathogen engineering/design, or autonomous Symthaea response.

## Qualification

The focused Surveillance DNA workflow covers exact-head checkout, Rust 1.96.0, complete locked metadata, formatting, integrity/coordinator host tests, Clippy with warnings denied, and both integrity/coordinator WASM compatibility.

The current exact-head run remains queued. Merge sequencing remains `#10 → #11 → #12 → #13`; #14 cannot qualify #13 by implication.