### PR TITLE
feat(surveillance): define dimension-specific lineage attestations

### DIFF
--- a/.github/workflows/surveillance-lineage.yml
+++ b/.github/workflows/surveillance-lineage.yml
@@ -36,6 +36,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          EXPECTED="${{ github.event.pull_request.head.sha || github.sha }}"
+          ACTUAL="$(git rev-parse HEAD)"
+          test "$ACTUAL" = "$EXPECTED"
+          echo "QUALIFIED_SOURCE_HEAD=$ACTUAL"
 
       - name: Check out pinned parent workspace dependencies
         shell: bash

--- a/.github/workflows/surveillance-lineage.yml
+++ b/.github/workflows/surveillance-lineage.yml
@@ -7,6 +7,7 @@ on:
       - "crates/health-surveillance-lineage/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-lineage.yml"
   push:
     branches: [main]
@@ -15,25 +16,36 @@ on:
       - "crates/health-surveillance-lineage/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-lineage.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  PARENT_MYCELIX_REF: 7daefcbfa6c4427809e9d8dc24a039bb024da5e9
 
 jobs:
   surveillance-lineage:
     name: Dimension-specific lineage contract
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      # Cargo resolves the complete workspace graph even for a focused package.
-      # Mirror the sibling dependency layout used by repository CI.
-      - name: Check out parent workspace dependencies
+      - name: Check out pinned parent workspace dependencies
+        shell: bash
         run: |
-          git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
+          git init /tmp/mycelix-parent
+          git -C /tmp/mycelix-parent remote add origin https://github.com/Luminous-Dynamics/mycelix.git
+          git -C /tmp/mycelix-parent fetch --depth 1 origin "$PARENT_MYCELIX_REF"
+          git -C /tmp/mycelix-parent checkout --detach FETCH_HEAD
+          test "$(git -C /tmp/mycelix-parent rev-parse HEAD)" = "$PARENT_MYCELIX_REF"
+
           mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
           cp -r /tmp/mycelix-parent/crates/. ../crates/
           cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
@@ -41,7 +53,7 @@ jobs:
           rm -rf /tmp/mycelix-parent
 
       - name: Install pinned Rust
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e
         with:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
@@ -51,17 +63,32 @@ jobs:
         shell: bash
         run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
 
+      - name: Record qualification environment
+        shell: bash
+        run: |
+          echo "HEAD=$(git rev-parse HEAD)"
+          echo "PARENT_MYCELIX_REF=$PARENT_MYCELIX_REF"
+          rustc -vV
+          cargo -Vv
+          sha256sum Cargo.toml Cargo.lock \
+            crates/health-surveillance-core/Cargo.toml \
+            crates/health-surveillance-lineage/Cargo.toml
+          if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
+
+      - name: Verify committed lock graph
+        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+
       - name: Check formatting
         run: cargo fmt -p health-surveillance-lineage -- --check
 
       - name: Run host tests
-        run: cargo test -p health-surveillance-lineage --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p health-surveillance-lineage --target "${{ steps.host.outputs.triple }}"
 
       - name: Run Clippy
-        run: cargo clippy -p health-surveillance-lineage --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+        run: cargo clippy --locked -p health-surveillance-lineage --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
 
       - name: Run documentation tests
-        run: cargo test -p health-surveillance-lineage --doc --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p health-surveillance-lineage --doc --target "${{ steps.host.outputs.triple }}"
 
       - name: Check WASM compatibility
-        run: cargo check -p health-surveillance-lineage --target wasm32-unknown-unknown
+        run: cargo check --locked -p health-surveillance-lineage --target wasm32-unknown-unknown

--- a/.github/workflows/surveillance-lineage.yml
+++ b/.github/workflows/surveillance-lineage.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5 / node24
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
@@ -86,8 +86,8 @@ jobs:
             crates/health-surveillance-lineage/Cargo.toml
           if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
 
-      - name: Verify committed lock graph
-        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+      - name: Verify complete committed lock graph
+        run: cargo metadata --locked --format-version 1 > /dev/null
 
       - name: Check formatting
         run: cargo fmt -p health-surveillance-lineage -- --check

--- a/.github/workflows/surveillance-lineage.yml
+++ b/.github/workflows/surveillance-lineage.yml
@@ -1,0 +1,67 @@
+name: Public Health Surveillance Lineage
+
+on:
+  pull_request:
+    paths:
+      - "crates/health-surveillance-core/**"
+      - "crates/health-surveillance-lineage/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/surveillance-lineage.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/health-surveillance-core/**"
+      - "crates/health-surveillance-lineage/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/surveillance-lineage.yml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  surveillance-lineage:
+    name: Dimension-specific lineage contract
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Cargo resolves the complete workspace graph even for a focused package.
+      # Mirror the sibling dependency layout used by repository CI.
+      - name: Check out parent workspace dependencies
+        run: |
+          git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
+          mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
+          cp -r /tmp/mycelix-parent/crates/. ../crates/
+          cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
+          cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-workspace/mycelix-core/
+          rm -rf /tmp/mycelix-parent
+
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Resolve host target
+        id: host
+        shell: bash
+        run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Check formatting
+        run: cargo fmt -p health-surveillance-lineage -- --check
+
+      - name: Run host tests
+        run: cargo test -p health-surveillance-lineage --target "${{ steps.host.outputs.triple }}"
+
+      - name: Run Clippy
+        run: cargo clippy -p health-surveillance-lineage --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+
+      - name: Run documentation tests
+        run: cargo test -p health-surveillance-lineage --doc --target "${{ steps.host.outputs.triple }}"
+
+      - name: Check WASM compatibility
+        run: cargo check -p health-surveillance-lineage --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "crates/health-surveillance-core",
     "crates/health-surveillance-authority",
     "crates/health-surveillance-endorsement",
+    "crates/health-surveillance-lineage",
 
     # ── Public Health Surveillance (separate aggregate-only DNA) ──
     "zomes/surveillance/integrity",

--- a/crates/health-surveillance-lineage/Cargo.toml
+++ b/crates/health-surveillance-lineage/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "health-surveillance-lineage"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Canonical dimension-specific lineage attestations for aggregate public-health surveillance"
+
+[lib]
+name = "health_surveillance_lineage"
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+thiserror.workspace = true
+sha2 = "0.10"
+health-surveillance-core = { path = "../health-surveillance-core" }

--- a/crates/health-surveillance-lineage/README.md
+++ b/crates/health-surveillance-lineage/README.md
@@ -1,0 +1,81 @@
+# Health Surveillance Lineage
+
+Canonical, crypto-free lineage attestations for aggregate public-health surveillance evidence.
+
+## Why this is not an `is_independent` boolean
+
+Two feeds can differ in one way and still share a hidden upstream dependency:
+
+- different dashboards backed by the same dataset;
+- different laboratories sampling the same population frame;
+- different sensors operated by one control domain;
+- different reports produced by the same transformation pipeline.
+
+A global signed boolean such as `independent: true` would be easy to overinterpret and hard to audit.
+
+This crate instead represents **dimension-specific known lineage facts**.
+
+## Lineage dimensions
+
+`LineageDescriptor` carries explicit knowledge for:
+
+- upstream roots/datasets/feeds;
+- sampling frames/populations;
+- collection/sensor/site systems;
+- measurement/instrument/laboratory systems;
+- processing/software/transformation pipelines;
+- operator/control domains.
+
+Each dimension is either:
+
+- `Known(non-empty canonical ID set)`; or
+- `Unknown`.
+
+Unknown is never represented by an empty set and is never treated as evidence of separation.
+
+## Exact observation binding
+
+`EvidenceLineageAttestation` binds:
+
+- security domain;
+- attestation profile;
+- attestor DID;
+- exact `ObservationId`;
+- the dimension-specific descriptor;
+- attestor-asserted assessment time;
+- opaque evidence commitment;
+- non-zero issuance nonce.
+
+Changing any observation field that participates in `ObservationId`—including the producer's own `IndependenceGroup` claim—breaks the attestation binding.
+
+## Comparison semantics
+
+Pairwise comparison returns one relation per dimension:
+
+- `SharedKnown` — both attestations know identifiers and share at least one;
+- `NoKnownOverlap` — both know non-empty identifier sets and those sets are disjoint;
+- `Unknown` — at least one side lacks knowledge.
+
+`NoKnownOverlap` is intentionally **not** named `Independent`. It says only what the attested identifier sets establish on that dimension.
+
+The comparison also reports whether both attestations use the same security domain and assessment profile. A downstream policy may require compatible profiles before using even `NoKnownOverlap` as corroboration evidence.
+
+## Trust boundary
+
+This crate performs no cryptographic verification and grants no authority. A later surveillance lineage-integrity tranche should define a DNA-bound allowlist for lineage attestors separately from producer-authority issuers.
+
+That separation matters: being authorized to publish a laboratory feed does not automatically make the laboratory, its credential issuer, or its operator authoritative about causal/statistical independence.
+
+## Intended downstream use
+
+Symthaea should consume lineage attestations as **evidence about source diversity**, not as ground truth. A conservative reasoning policy can then:
+
+1. down-weight or merge evidence with known shared upstream dimensions;
+2. abstain from independence-sensitive conclusions when dimensions are unknown;
+3. distinguish no-known-overlap from actual demonstrated independence;
+4. show which dimensions support or weaken corroboration;
+5. preserve the original signed attestations in the reasoning receipt.
+
+## Non-goals
+
+No patient data, pathogen data, epidemiological diagnosis, treatment advice, outbreak declaration, emergency authority, or autonomous action.

--- a/crates/health-surveillance-lineage/src/lib.rs
+++ b/crates/health-surveillance-lineage/src/lib.rs
@@ -1,0 +1,709 @@
+#![deny(unsafe_code)]
+//! Canonical dimension-specific evidence-lineage attestations.
+//!
+//! This crate deliberately does **not** define a global `is_independent` boolean.
+//! Independence is contextual and can be overclaimed easily. Instead, a trusted
+//! lineage adapter may attest known lineage identifiers on separate dimensions
+//! such as upstream data, sampling frame, measurement system, processing
+//! pipeline, and operator/control domain. Missing knowledge is represented
+//! explicitly as `Unknown` rather than as an empty set.
+//!
+//! The crate is crypto-free and I/O-free. It defines stable content identities,
+//! signing transcripts, exact observation binding, and conservative pairwise
+//! comparison semantics. Cryptographic trust policy belongs in a later adapter/
+//! integrity tranche.
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use health_surveillance_core::{CanonicalId, ObservationId, SurveillanceObservation};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+pub const LINEAGE_ATTESTATION_SCHEMA_V1: u16 = 1;
+pub const MAX_LINEAGE_IDS_PER_DIMENSION: usize = 64;
+pub const LINEAGE_ATTESTATION_ID_DOMAIN_V1: &[u8] =
+    b"mycelix-health-surveillance-lineage-attestation-id-v1\0";
+pub const LINEAGE_ATTESTATION_SIGNING_DOMAIN_V1: &[u8] =
+    b"mycelix-health-surveillance-lineage-attestation-signing-v1\0";
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum LineageError {
+    #[error("lineage attestation schema version {0} is unsupported")]
+    UnsupportedSchema(u16),
+    #[error("lineage attestor must use a DID identifier")]
+    InvalidDid,
+    #[error("known lineage dimension must contain at least one identifier")]
+    EmptyKnownDimension,
+    #[error("lineage dimension exceeds the maximum direct identifier count")]
+    DimensionTooLarge,
+    #[error("lineage descriptor must contain at least one known dimension")]
+    NoKnownLineageFacts,
+    #[error("lineage evidence commitment must not be all zeroes")]
+    ZeroEvidenceCommitment,
+    #[error("lineage attestation nonce must not be all zeroes")]
+    ZeroNonce,
+    #[error("invalid surveillance observation: {0}")]
+    InvalidObservation(String),
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct LineageAttestationId([u8; 32]);
+
+impl LineageAttestationId {
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    pub fn to_hex(&self) -> String {
+        let mut out = String::with_capacity(64);
+        for byte in self.0 {
+            use fmt::Write as _;
+            write!(&mut out, "{byte:02x}").expect("writing to String cannot fail");
+        }
+        out
+    }
+}
+
+impl fmt::Display for LineageAttestationId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+/// Explicit knowledge state for one lineage dimension.
+///
+/// `Unknown` is not equivalent to `Known(empty)`. Known sets are non-empty and
+/// bounded. BTreeSet makes semantic ordering canonical and prevents duplicate
+/// aliases.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LineageKnowledge {
+    Unknown,
+    Known(BTreeSet<CanonicalId>),
+}
+
+impl LineageKnowledge {
+    pub fn unknown() -> Self {
+        Self::Unknown
+    }
+
+    pub fn known(values: impl IntoIterator<Item = CanonicalId>) -> Result<Self, LineageError> {
+        let values: BTreeSet<CanonicalId> = values.into_iter().collect();
+        let knowledge = Self::Known(values);
+        knowledge.validate()?;
+        Ok(knowledge)
+    }
+
+    pub fn validate(&self) -> Result<(), LineageError> {
+        match self {
+            Self::Unknown => Ok(()),
+            Self::Known(values) => {
+                if values.is_empty() {
+                    return Err(LineageError::EmptyKnownDimension);
+                }
+                if values.len() > MAX_LINEAGE_IDS_PER_DIMENSION {
+                    return Err(LineageError::DimensionTooLarge);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    pub fn is_known(&self) -> bool {
+        matches!(self, Self::Known(_))
+    }
+
+    pub fn values(&self) -> Option<&BTreeSet<CanonicalId>> {
+        match self {
+            Self::Unknown => None,
+            Self::Known(values) => Some(values),
+        }
+    }
+}
+
+/// Dimension-specific lineage facts for one exact observation.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LineageDescriptor {
+    /// Root datasets/feeds from which this evidence ultimately derives.
+    pub upstream_roots: LineageKnowledge,
+    /// Sampling populations/frames; shared frames can create correlated evidence.
+    pub sampling_frames: LineageKnowledge,
+    /// Collection/sensor/site systems that produced primary observations.
+    pub collection_systems: LineageKnowledge,
+    /// Measurement/instrument/laboratory systems.
+    pub measurement_systems: LineageKnowledge,
+    /// Transformation/software/analysis pipelines applied before publication.
+    pub processing_pipelines: LineageKnowledge,
+    /// Organization/control domains capable of coordinating or biasing sources.
+    pub operator_control_domains: LineageKnowledge,
+}
+
+impl LineageDescriptor {
+    pub fn new(
+        upstream_roots: LineageKnowledge,
+        sampling_frames: LineageKnowledge,
+        collection_systems: LineageKnowledge,
+        measurement_systems: LineageKnowledge,
+        processing_pipelines: LineageKnowledge,
+        operator_control_domains: LineageKnowledge,
+    ) -> Result<Self, LineageError> {
+        let descriptor = Self {
+            upstream_roots,
+            sampling_frames,
+            collection_systems,
+            measurement_systems,
+            processing_pipelines,
+            operator_control_domains,
+        };
+        descriptor.validate()?;
+        Ok(descriptor)
+    }
+
+    pub fn validate(&self) -> Result<(), LineageError> {
+        for knowledge in [
+            &self.upstream_roots,
+            &self.sampling_frames,
+            &self.collection_systems,
+            &self.measurement_systems,
+            &self.processing_pipelines,
+            &self.operator_control_domains,
+        ] {
+            knowledge.validate()?;
+        }
+        if ![
+            &self.upstream_roots,
+            &self.sampling_frames,
+            &self.collection_systems,
+            &self.measurement_systems,
+            &self.processing_pipelines,
+            &self.operator_control_domains,
+        ]
+        .iter()
+        .any(|knowledge| knowledge.is_known())
+        {
+            return Err(LineageError::NoKnownLineageFacts);
+        }
+        Ok(())
+    }
+}
+
+/// Signed semantic payload for an exact observation's known lineage facts.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct EvidenceLineageAttestation {
+    schema_version: u16,
+    security_domain: CanonicalId,
+    attestation_profile_id: CanonicalId,
+    attestor_did: CanonicalId,
+    observation_id: ObservationId,
+    descriptor: LineageDescriptor,
+    assessed_at_unix_s: i64,
+    evidence_commitment: [u8; 32],
+    issuance_nonce: [u8; 32],
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EvidenceLineageAttestationWire {
+    schema_version: u16,
+    security_domain: CanonicalId,
+    attestation_profile_id: CanonicalId,
+    attestor_did: CanonicalId,
+    observation_id: ObservationId,
+    descriptor: LineageDescriptor,
+    assessed_at_unix_s: i64,
+    evidence_commitment: [u8; 32],
+    issuance_nonce: [u8; 32],
+}
+
+impl<'de> Deserialize<'de> for EvidenceLineageAttestation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = EvidenceLineageAttestationWire::deserialize(deserializer)?;
+        if wire.schema_version != LINEAGE_ATTESTATION_SCHEMA_V1 {
+            return Err(serde::de::Error::custom(LineageError::UnsupportedSchema(
+                wire.schema_version,
+            )));
+        }
+        Self::new(
+            wire.security_domain,
+            wire.attestation_profile_id,
+            wire.attestor_did,
+            wire.observation_id,
+            wire.descriptor,
+            wire.assessed_at_unix_s,
+            wire.evidence_commitment,
+            wire.issuance_nonce,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+impl EvidenceLineageAttestation {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        security_domain: CanonicalId,
+        attestation_profile_id: CanonicalId,
+        attestor_did: CanonicalId,
+        observation_id: ObservationId,
+        descriptor: LineageDescriptor,
+        assessed_at_unix_s: i64,
+        evidence_commitment: [u8; 32],
+        issuance_nonce: [u8; 32],
+    ) -> Result<Self, LineageError> {
+        if !attestor_did.as_str().starts_with("did:") {
+            return Err(LineageError::InvalidDid);
+        }
+        if evidence_commitment == [0; 32] {
+            return Err(LineageError::ZeroEvidenceCommitment);
+        }
+        if issuance_nonce == [0; 32] {
+            return Err(LineageError::ZeroNonce);
+        }
+        descriptor.validate()?;
+        Ok(Self {
+            schema_version: LINEAGE_ATTESTATION_SCHEMA_V1,
+            security_domain,
+            attestation_profile_id,
+            attestor_did,
+            observation_id,
+            descriptor,
+            assessed_at_unix_s,
+            evidence_commitment,
+            issuance_nonce,
+        })
+    }
+
+    pub fn security_domain(&self) -> &CanonicalId {
+        &self.security_domain
+    }
+
+    pub fn attestation_profile_id(&self) -> &CanonicalId {
+        &self.attestation_profile_id
+    }
+
+    pub fn attestor_did(&self) -> &CanonicalId {
+        &self.attestor_did
+    }
+
+    pub fn observation_id(&self) -> ObservationId {
+        self.observation_id
+    }
+
+    pub fn descriptor(&self) -> &LineageDescriptor {
+        &self.descriptor
+    }
+
+    pub fn assessed_at_unix_s(&self) -> i64 {
+        self.assessed_at_unix_s
+    }
+
+    pub fn evidence_commitment(&self) -> &[u8; 32] {
+        &self.evidence_commitment
+    }
+
+    pub fn validate(&self) -> Result<(), LineageError> {
+        if self.schema_version != LINEAGE_ATTESTATION_SCHEMA_V1 {
+            return Err(LineageError::UnsupportedSchema(self.schema_version));
+        }
+        if !self.attestor_did.as_str().starts_with("did:") {
+            return Err(LineageError::InvalidDid);
+        }
+        if self.evidence_commitment == [0; 32] {
+            return Err(LineageError::ZeroEvidenceCommitment);
+        }
+        if self.issuance_nonce == [0; 32] {
+            return Err(LineageError::ZeroNonce);
+        }
+        self.descriptor.validate()
+    }
+
+    pub fn binds_observation(
+        &self,
+        observation: &SurveillanceObservation,
+    ) -> Result<bool, LineageError> {
+        self.validate()?;
+        let observation_id = observation
+            .id()
+            .map_err(|e| LineageError::InvalidObservation(e.to_string()))?;
+        Ok(self.observation_id == observation_id)
+    }
+
+    pub fn id(&self) -> Result<LineageAttestationId, LineageError> {
+        self.validate()?;
+        let payload = self.canonical_payload();
+        let mut h = Sha256::new();
+        h.update(LINEAGE_ATTESTATION_ID_DOMAIN_V1);
+        h.update(payload);
+        Ok(LineageAttestationId(h.finalize().into()))
+    }
+
+    pub fn signing_transcript(&self) -> Result<Vec<u8>, LineageError> {
+        self.validate()?;
+        let payload = self.canonical_payload();
+        let mut out = Vec::with_capacity(LINEAGE_ATTESTATION_SIGNING_DOMAIN_V1.len() + payload.len());
+        out.extend_from_slice(LINEAGE_ATTESTATION_SIGNING_DOMAIN_V1);
+        out.extend_from_slice(&payload);
+        Ok(out)
+    }
+
+    /// Conservative comparison of dimension-specific lineage facts.
+    ///
+    /// `NoKnownOverlap` means only that the two attested known identifier sets
+    /// are disjoint on that dimension. It is deliberately **not** named or
+    /// exposed as proof of statistical/causal independence.
+    pub fn compare(&self, other: &Self) -> Result<LineageComparison, LineageError> {
+        self.validate()?;
+        other.validate()?;
+        Ok(LineageComparison {
+            left_attestation_id: self.id()?,
+            right_attestation_id: other.id()?,
+            same_security_domain: self.security_domain == other.security_domain,
+            same_attestation_profile: self.attestation_profile_id == other.attestation_profile_id,
+            dimensions: vec![
+                dimension_comparison(
+                    LineageDimension::UpstreamRoots,
+                    &self.descriptor.upstream_roots,
+                    &other.descriptor.upstream_roots,
+                ),
+                dimension_comparison(
+                    LineageDimension::SamplingFrames,
+                    &self.descriptor.sampling_frames,
+                    &other.descriptor.sampling_frames,
+                ),
+                dimension_comparison(
+                    LineageDimension::CollectionSystems,
+                    &self.descriptor.collection_systems,
+                    &other.descriptor.collection_systems,
+                ),
+                dimension_comparison(
+                    LineageDimension::MeasurementSystems,
+                    &self.descriptor.measurement_systems,
+                    &other.descriptor.measurement_systems,
+                ),
+                dimension_comparison(
+                    LineageDimension::ProcessingPipelines,
+                    &self.descriptor.processing_pipelines,
+                    &other.descriptor.processing_pipelines,
+                ),
+                dimension_comparison(
+                    LineageDimension::OperatorControlDomains,
+                    &self.descriptor.operator_control_domains,
+                    &other.descriptor.operator_control_domains,
+                ),
+            ],
+        })
+    }
+
+    fn canonical_payload(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        put_u16(&mut out, self.schema_version);
+        put_id(&mut out, &self.security_domain);
+        put_id(&mut out, &self.attestation_profile_id);
+        put_id(&mut out, &self.attestor_did);
+        out.extend_from_slice(self.observation_id.as_bytes());
+        put_descriptor(&mut out, &self.descriptor);
+        put_i64(&mut out, self.assessed_at_unix_s);
+        out.extend_from_slice(&self.evidence_commitment);
+        out.extend_from_slice(&self.issuance_nonce);
+        out
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum LineageDimension {
+    UpstreamRoots,
+    SamplingFrames,
+    CollectionSystems,
+    MeasurementSystems,
+    ProcessingPipelines,
+    OperatorControlDomains,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DimensionRelation {
+    /// Both attestations know identifiers on this dimension and share at least one.
+    SharedKnown,
+    /// Both know non-empty identifier sets and those sets are disjoint.
+    NoKnownOverlap,
+    /// At least one attestation explicitly lacks knowledge on this dimension.
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DimensionComparison {
+    pub dimension: LineageDimension,
+    pub relation: DimensionRelation,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LineageComparison {
+    pub left_attestation_id: LineageAttestationId,
+    pub right_attestation_id: LineageAttestationId,
+    pub same_security_domain: bool,
+    pub same_attestation_profile: bool,
+    pub dimensions: Vec<DimensionComparison>,
+}
+
+impl LineageComparison {
+    pub fn relation(&self, dimension: LineageDimension) -> Option<DimensionRelation> {
+        self.dimensions
+            .iter()
+            .find(|comparison| comparison.dimension == dimension)
+            .map(|comparison| comparison.relation)
+    }
+
+    pub fn has_known_shared_dimension(&self) -> bool {
+        self.dimensions
+            .iter()
+            .any(|comparison| comparison.relation == DimensionRelation::SharedKnown)
+    }
+
+    pub fn has_unknown_dimension(&self) -> bool {
+        self.dimensions
+            .iter()
+            .any(|comparison| comparison.relation == DimensionRelation::Unknown)
+    }
+}
+
+fn dimension_comparison(
+    dimension: LineageDimension,
+    left: &LineageKnowledge,
+    right: &LineageKnowledge,
+) -> DimensionComparison {
+    let relation = match (left.values(), right.values()) {
+        (Some(left), Some(right)) => {
+            if left.is_disjoint(right) {
+                DimensionRelation::NoKnownOverlap
+            } else {
+                DimensionRelation::SharedKnown
+            }
+        }
+        _ => DimensionRelation::Unknown,
+    };
+    DimensionComparison { dimension, relation }
+}
+
+fn put_descriptor(out: &mut Vec<u8>, descriptor: &LineageDescriptor) {
+    for knowledge in [
+        &descriptor.upstream_roots,
+        &descriptor.sampling_frames,
+        &descriptor.collection_systems,
+        &descriptor.measurement_systems,
+        &descriptor.processing_pipelines,
+        &descriptor.operator_control_domains,
+    ] {
+        put_knowledge(out, knowledge);
+    }
+}
+
+fn put_knowledge(out: &mut Vec<u8>, knowledge: &LineageKnowledge) {
+    match knowledge {
+        LineageKnowledge::Unknown => out.push(0),
+        LineageKnowledge::Known(values) => {
+            out.push(1);
+            out.extend_from_slice(&(values.len() as u32).to_be_bytes());
+            for value in values {
+                put_id(out, value);
+            }
+        }
+    }
+}
+
+fn put_u16(out: &mut Vec<u8>, value: u16) {
+    out.extend_from_slice(&value.to_be_bytes());
+}
+
+fn put_i64(out: &mut Vec<u8>, value: i64) {
+    out.extend_from_slice(&value.to_be_bytes());
+}
+
+fn put_id(out: &mut Vec<u8>, value: &CanonicalId) {
+    let bytes = value.as_str().as_bytes();
+    out.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use health_surveillance_core::{
+        BoundedUncertainty, EvidenceProvenance, GeographicPrecision, GeographicScope,
+        IndependenceGroup, MetricKind, ObservationWindow, ObservedMetric, SignalFamily, SourceKind,
+        SourceRecordDigest,
+    };
+
+    fn id(value: &str) -> CanonicalId {
+        CanonicalId::new(value).unwrap()
+    }
+
+    fn known(values: &[&str]) -> LineageKnowledge {
+        LineageKnowledge::known(values.iter().map(|value| id(value))).unwrap()
+    }
+
+    fn observation(independence: &str) -> SurveillanceObservation {
+        SurveillanceObservation::new(
+            SignalFamily::Respiratory,
+            SourceKind::LaboratoryAggregate,
+            "lab-feed-a",
+            IndependenceGroup::new(independence).unwrap(),
+            GeographicScope::new("health-district", "district-17", GeographicPrecision::District)
+                .unwrap(),
+            ObservationWindow::new(10_000, 13_600).unwrap(),
+            13_700,
+            100,
+            ObservedMetric::new(
+                MetricKind::FractionPositive,
+                0.20,
+                BoundedUncertainty::new(0.15, 0.25).unwrap(),
+                "fraction",
+            )
+            .unwrap(),
+            EvidenceProvenance::new(
+                "lab-a",
+                "aggregate-protocol-v1",
+                "rev-1",
+                Some("upstream-lab-a"),
+                SourceRecordDigest::sha256([7; 32]).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn descriptor(root: &str, sampling: LineageKnowledge) -> LineageDescriptor {
+        LineageDescriptor::new(
+            known(&[root]),
+            sampling,
+            known(&["collection:district-17"]),
+            known(&["instrument:lab-analyzer-a"]),
+            known(&["pipeline:aggregate-v1"]),
+            known(&["control:org-a"]),
+        )
+        .unwrap()
+    }
+
+    fn attestation(
+        obs: &SurveillanceObservation,
+        root: &str,
+        sampling: LineageKnowledge,
+    ) -> EvidenceLineageAttestation {
+        EvidenceLineageAttestation::new(
+            id("lineage-domain:public-health-v1"),
+            id("lineage-profile:multi-dimension-v1"),
+            id("did:mycelix:lineage-auditor-a"),
+            obs.id().unwrap(),
+            descriptor(root, sampling),
+            13_800,
+            [4; 32],
+            [5; 32],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn all_unknown_descriptor_is_rejected() {
+        assert_eq!(
+            LineageDescriptor::new(
+                LineageKnowledge::Unknown,
+                LineageKnowledge::Unknown,
+                LineageKnowledge::Unknown,
+                LineageKnowledge::Unknown,
+                LineageKnowledge::Unknown,
+                LineageKnowledge::Unknown,
+            ),
+            Err(LineageError::NoKnownLineageFacts)
+        );
+    }
+
+    #[test]
+    fn known_set_order_does_not_change_attestation_identity() {
+        let obs = observation("lineage-a");
+        let mut a = descriptor("root-a", known(&["sample-b", "sample-a"]));
+        let b = descriptor("root-a", known(&["sample-a", "sample-b"]));
+        assert_eq!(a, b);
+        a.sampling_frames = known(&["sample-a", "sample-b"]);
+        let left = EvidenceLineageAttestation::new(
+            id("lineage-domain:public-health-v1"),
+            id("lineage-profile:multi-dimension-v1"),
+            id("did:mycelix:lineage-auditor-a"),
+            obs.id().unwrap(),
+            a,
+            13_800,
+            [4; 32],
+            [5; 32],
+        )
+        .unwrap();
+        let right = EvidenceLineageAttestation::new(
+            id("lineage-domain:public-health-v1"),
+            id("lineage-profile:multi-dimension-v1"),
+            id("did:mycelix:lineage-auditor-a"),
+            obs.id().unwrap(),
+            b,
+            13_800,
+            [4; 32],
+            [5; 32],
+        )
+        .unwrap();
+        assert_eq!(left.id().unwrap(), right.id().unwrap());
+    }
+
+    #[test]
+    fn shared_upstream_root_is_detected_even_when_sampling_is_distinct() {
+        let obs_a = observation("lineage-a");
+        let mut obs_b = observation("lineage-b");
+        obs_b.provenance.source_revision = id("rev-2");
+        let a = attestation(&obs_a, "root-shared", known(&["sample-a"]));
+        let b = attestation(&obs_b, "root-shared", known(&["sample-b"]));
+        let comparison = a.compare(&b).unwrap();
+        assert_eq!(
+            comparison.relation(LineageDimension::UpstreamRoots),
+            Some(DimensionRelation::SharedKnown)
+        );
+        assert_eq!(
+            comparison.relation(LineageDimension::SamplingFrames),
+            Some(DimensionRelation::NoKnownOverlap)
+        );
+        assert!(comparison.has_known_shared_dimension());
+    }
+
+    #[test]
+    fn unknown_is_not_promoted_to_no_known_overlap() {
+        let obs_a = observation("lineage-a");
+        let mut obs_b = observation("lineage-b");
+        obs_b.provenance.source_revision = id("rev-2");
+        let a = attestation(&obs_a, "root-a", LineageKnowledge::Unknown);
+        let b = attestation(&obs_b, "root-b", known(&["sample-b"]));
+        let comparison = a.compare(&b).unwrap();
+        assert_eq!(
+            comparison.relation(LineageDimension::SamplingFrames),
+            Some(DimensionRelation::Unknown)
+        );
+        assert!(comparison.has_unknown_dimension());
+    }
+
+    #[test]
+    fn attestation_binds_exact_observation_identity() {
+        let obs = observation("lineage-a");
+        let changed = observation("lineage-b");
+        let attestation = attestation(&obs, "root-a", known(&["sample-a"]));
+        assert!(attestation.binds_observation(&obs).unwrap());
+        assert!(!attestation.binds_observation(&changed).unwrap());
+    }
+
+    #[test]
+    fn independence_group_change_cannot_reuse_lineage_attestation() {
+        let original = observation("claimed-independent-a");
+        let changed = observation("claimed-independent-b");
+        let attestation = attestation(&original, "root-a", known(&["sample-a"]));
+        assert_ne!(original.id().unwrap(), changed.id().unwrap());
+        assert!(!attestation.binds_observation(&changed).unwrap());
+    }
+}

--- a/crates/health-surveillance-lineage/tests/identity_vectors.rs
+++ b/crates/health-surveillance-lineage/tests/identity_vectors.rs
@@ -1,0 +1,93 @@
+use health_surveillance_core::{
+    BoundedUncertainty, CanonicalId, EvidenceProvenance, GeographicPrecision, GeographicScope,
+    IndependenceGroup, MetricKind, ObservationWindow, ObservedMetric, SignalFamily, SourceKind,
+    SourceRecordDigest, SurveillanceObservation,
+};
+use health_surveillance_lineage::{
+    EvidenceLineageAttestation, LineageDescriptor, LineageKnowledge,
+};
+use sha2::{Digest, Sha256};
+
+fn id(value: &str) -> CanonicalId {
+    CanonicalId::new(value).unwrap()
+}
+
+fn known(values: &[&str]) -> LineageKnowledge {
+    LineageKnowledge::known(values.iter().map(|value| id(value))).unwrap()
+}
+
+fn observation() -> SurveillanceObservation {
+    SurveillanceObservation::new(
+        SignalFamily::Respiratory,
+        SourceKind::LaboratoryAggregate,
+        "lab-feed-a",
+        IndependenceGroup::new("lineage-a").unwrap(),
+        GeographicScope::new(
+            "health-district",
+            "district-17",
+            GeographicPrecision::District,
+        )
+        .unwrap(),
+        ObservationWindow::new(10_000, 13_600).unwrap(),
+        13_700,
+        100,
+        ObservedMetric::new(
+            MetricKind::FractionPositive,
+            0.20,
+            BoundedUncertainty::new(0.15, 0.25).unwrap(),
+            "fraction",
+        )
+        .unwrap(),
+        EvidenceProvenance::new(
+            "lab-a",
+            "aggregate-protocol-v1",
+            "rev-1",
+            Some("upstream-lab-a"),
+            SourceRecordDigest::sha256([7; 32]).unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+fn attestation() -> EvidenceLineageAttestation {
+    let descriptor = LineageDescriptor::new(
+        known(&["root-a"]),
+        known(&["sample-a"]),
+        known(&["collection:district-17"]),
+        known(&["instrument:lab-analyzer-a"]),
+        known(&["pipeline:aggregate-v1"]),
+        known(&["control:org-a"]),
+    )
+    .unwrap();
+
+    EvidenceLineageAttestation::new(
+        id("lineage-domain:public-health-v1"),
+        id("lineage-profile:multi-dimension-v1"),
+        id("did:mycelix:lineage-auditor-a"),
+        observation().id().unwrap(),
+        descriptor,
+        13_800,
+        [4; 32],
+        [5; 32],
+    )
+    .unwrap()
+}
+
+#[test]
+fn lineage_attestation_id_v1_golden_vector() {
+    assert_eq!(
+        attestation().id().unwrap().to_hex(),
+        "42aaef49957c5067bb838085f4c8ada81db9528ad0e9ba8d214c0bfed12c155b"
+    );
+}
+
+#[test]
+fn lineage_attestation_signing_transcript_v1_golden_vector() {
+    let transcript = attestation().signing_transcript().unwrap();
+    assert_eq!(transcript.len(), 420);
+    assert_eq!(
+        format!("{:x}", Sha256::digest(&transcript)),
+        "8ac9405273c20bf508b168371242755276e04e695b2d97f86e5d2cc5e90dca64"
+    );
+}


### PR DESCRIPTION
## Summary

Stack on #14 and define a conservative, crypto-free lineage/corroboration evidence contract for aggregate surveillance.

This tranche deliberately does **not** add a signed `is_independent: true` boolean and does not make lineage proof a publication prerequisite. It represents known dependency facts by dimension, preserves explicit unknowns, binds every attestation to one exact `ObservationId`, and provides pairwise comparison semantics that stop short of causal/statistical independence claims.

## Dependency

Base: `feat/public-health-observation-endorsement-v1` / #14 exact head `cedc72a6bdd881c27fb13ee242a849eb090fbd31`.

Do not merge ahead of #10-#14. Keep draft until exact-head qualification succeeds.

## Commit stack

1. `feat(surveillance): define dimension-specific lineage attestations`
2. `ci(surveillance): qualify lineage attestation contract`

## New crate

Adds `crates/health-surveillance-lineage`, intentionally crypto-free and I/O-free.

## No global independence boolean

A feed may be separate on one dimension while sharing dependency on another. Examples include different dashboards over one dataset, different labs over one sampling frame, or different outputs from one transformation pipeline.

The contract therefore contains no `independent`, `is_independent`, probability-of-independence, or generic trust-score field.

## Explicit lineage dimensions

`LineageDescriptor` carries knowledge for:

- upstream roots / source datasets;
- sampling frames / populations;
- collection systems / sites / sensors;
- measurement systems / instruments / laboratories;
- processing pipelines / transformations;
- operator or control domains.

Each dimension is either:

- `Known(non-empty bounded canonical ID set)`; or
- `Unknown`.

An all-Unknown descriptor is rejected because it carries no information. A known-empty set is also rejected so absence of knowledge cannot masquerade as evidence of separation.

Known sets use canonical `BTreeSet` ordering, are bounded to 64 IDs per dimension, and cannot create semantic aliases through ordering or duplicate values.

## Exact observation binding

`EvidenceLineageAttestation` commits to:

- security domain;
- attestation profile;
- attestor DID;
- exact `ObservationId`;
- dimension-specific descriptor;
- attestor-asserted assessment time;
- opaque lineage-evidence commitment;
- non-zero nonce.

It has separate domain-separated semantic identity and signing transcript domains.

Changing any observation field covered by `ObservationId`, including the producer's own `IndependenceGroup` claim, makes the attestation no longer bind.

## Conservative comparison semantics

Pairwise comparison returns one relation per dimension:

- `SharedKnown` — both attestations know IDs and share at least one;
- `NoKnownOverlap` — both know non-empty ID sets and those sets are disjoint;
- `Unknown` — at least one side lacks knowledge.

`NoKnownOverlap` is intentionally **not** named `Independent`. It only reports what the attested identifier sets establish for that one dimension.

The comparison also reports whether both attestations use the same security domain and attestation profile. Downstream policy can require compatible profiles before using even `NoKnownOverlap` as corroboration evidence.

## Publication remains independent of lineage audit

This PR does not modify `ReleasedSurveillanceObservation` or the surveillance integrity zome.

An urgent aggregate observation can be valid and authenticated before a lineage auditor has completed its work. Missing lineage evidence should therefore remain explicit `Unknown` downstream rather than blocking ingestion.

The next enforcement tranche should add append-only signed lineage-attestation records referencing exact observations, with a **separate DNA-bound lineage-attestor trust policy**. Producer-authority issuers must not automatically inherit lineage-auditor authority.

## Conflicts must remain evidence

Future storage/verification should never overwrite one lineage attestation with another. If trusted attestors disagree, both immutable attestations should survive and downstream reasoning should surface the conflict rather than manufacture one canonical truth.

## Symthaea use

A conservative future Symthaea consumer can:

- down-weight or merge evidence with known shared lineage dimensions;
- abstain from independence-sensitive conclusions when relevant dimensions are Unknown;
- distinguish `NoKnownOverlap` from demonstrated independence;
- expose exactly which dimensions strengthen or weaken corroboration;
- retain the signed lineage evidence in its reasoning receipt.

## Explicit non-goals

No patient data, pathogen data, diagnosis, treatment advice, outbreak declaration, emergency authority, public-health orders, or autonomous Symthaea action.

## Qualification

Adds a focused `Public Health Surveillance Lineage` workflow for:

- formatting;
- host tests;
- Clippy with warnings denied;
- documentation tests;
- WASM compatibility.

The PR trigger permits stacked bases. No merge-ready claim until the exact head is green.

## Next tranche

Add append-only signed lineage-attestation records and a dedicated `lineage_attestor_policy`, without making lineage availability a prerequisite for base observation publication.