### PR TITLE
feat(surveillance): verify separately trusted lineage evidence

### DIFF
--- a/.github/workflows/surveillance-lineage.yml
+++ b/.github/workflows/surveillance-lineage.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5 / node24
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
@@ -92,8 +92,8 @@ jobs:
             zomes/surveillance_lineage/coordinator/Cargo.toml
           if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
 
-      - name: Verify committed lock graph
-        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+      - name: Verify complete committed lock graph
+        run: cargo metadata --locked --format-version 1 > /dev/null
 
       - name: Check formatting
         run: cargo fmt -p health-surveillance-lineage -p surveillance_lineage_integrity -p surveillance_lineage -- --check

--- a/.github/workflows/surveillance-lineage.yml
+++ b/.github/workflows/surveillance-lineage.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "crates/health-surveillance-core/**"
       - "crates/health-surveillance-lineage/**"
+      - "zomes/surveillance_lineage/**"
+      - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/surveillance-lineage.yml"
@@ -13,6 +15,8 @@ on:
     paths:
       - "crates/health-surveillance-core/**"
       - "crates/health-surveillance-lineage/**"
+      - "zomes/surveillance_lineage/**"
+      - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/surveillance-lineage.yml"
@@ -24,13 +28,12 @@ env:
 
 jobs:
   surveillance-lineage:
-    name: Dimension-specific lineage contract
+    name: Lineage contract + separate trust boundary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      # Cargo resolves the complete workspace graph even for a focused package.
-      # Mirror the sibling dependency layout used by repository CI.
+      # Cargo resolves the complete workspace graph even for focused packages.
       - name: Check out parent workspace dependencies
         run: |
           git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
@@ -52,16 +55,28 @@ jobs:
         run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
 
       - name: Check formatting
-        run: cargo fmt -p health-surveillance-lineage -- --check
+        run: cargo fmt -p health-surveillance-lineage -p surveillance_lineage_integrity -p surveillance_lineage -- --check
 
-      - name: Run host tests
+      - name: Run lineage contract host tests
         run: cargo test -p health-surveillance-lineage --target "${{ steps.host.outputs.triple }}"
 
+      - name: Run lineage integrity host tests
+        run: cargo test -p surveillance_lineage_integrity --target "${{ steps.host.outputs.triple }}"
+
+      - name: Run lineage coordinator host tests
+        run: cargo test -p surveillance_lineage --target "${{ steps.host.outputs.triple }}"
+
       - name: Run Clippy
-        run: cargo clippy -p health-surveillance-lineage --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+        run: cargo clippy -p health-surveillance-lineage -p surveillance_lineage_integrity -p surveillance_lineage --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
 
       - name: Run documentation tests
         run: cargo test -p health-surveillance-lineage --doc --target "${{ steps.host.outputs.triple }}"
 
-      - name: Check WASM compatibility
+      - name: Check lineage contract WASM compatibility
         run: cargo check -p health-surveillance-lineage --target wasm32-unknown-unknown
+
+      - name: Check lineage integrity WASM compatibility
+        run: cargo check -p surveillance_lineage_integrity --target wasm32-unknown-unknown
+
+      - name: Check lineage coordinator WASM compatibility
+        run: cargo check -p surveillance_lineage --target wasm32-unknown-unknown

--- a/.github/workflows/surveillance-lineage.yml
+++ b/.github/workflows/surveillance-lineage.yml
@@ -40,6 +40,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          EXPECTED="${{ github.event.pull_request.head.sha || github.sha }}"
+          ACTUAL="$(git rev-parse HEAD)"
+          test "$ACTUAL" = "$EXPECTED"
+          echo "QUALIFIED_SOURCE_HEAD=$ACTUAL"
 
       - name: Check out pinned parent workspace dependencies
         shell: bash

--- a/.github/workflows/surveillance-lineage.yml
+++ b/.github/workflows/surveillance-lineage.yml
@@ -9,6 +9,7 @@ on:
       - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-lineage.yml"
   push:
     branches: [main]
@@ -19,24 +20,36 @@ on:
       - "dna/surveillance/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-lineage.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  PARENT_MYCELIX_REF: 7daefcbfa6c4427809e9d8dc24a039bb024da5e9
 
 jobs:
   surveillance-lineage:
     name: Lineage contract + separate trust boundary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      # Cargo resolves the complete workspace graph even for focused packages.
-      - name: Check out parent workspace dependencies
+      - name: Check out pinned parent workspace dependencies
+        shell: bash
         run: |
-          git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
+          git init /tmp/mycelix-parent
+          git -C /tmp/mycelix-parent remote add origin https://github.com/Luminous-Dynamics/mycelix.git
+          git -C /tmp/mycelix-parent fetch --depth 1 origin "$PARENT_MYCELIX_REF"
+          git -C /tmp/mycelix-parent checkout --detach FETCH_HEAD
+          test "$(git -C /tmp/mycelix-parent rev-parse HEAD)" = "$PARENT_MYCELIX_REF"
+
           mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
           cp -r /tmp/mycelix-parent/crates/. ../crates/
           cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
@@ -44,7 +57,7 @@ jobs:
           rm -rf /tmp/mycelix-parent
 
       - name: Install pinned Rust
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e
         with:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
@@ -54,29 +67,46 @@ jobs:
         shell: bash
         run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
 
+      - name: Record qualification environment
+        shell: bash
+        run: |
+          echo "HEAD=$(git rev-parse HEAD)"
+          echo "PARENT_MYCELIX_REF=$PARENT_MYCELIX_REF"
+          rustc -vV
+          cargo -Vv
+          sha256sum Cargo.toml Cargo.lock \
+            crates/health-surveillance-core/Cargo.toml \
+            crates/health-surveillance-lineage/Cargo.toml \
+            zomes/surveillance_lineage/integrity/Cargo.toml \
+            zomes/surveillance_lineage/coordinator/Cargo.toml
+          if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
+
+      - name: Verify committed lock graph
+        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+
       - name: Check formatting
         run: cargo fmt -p health-surveillance-lineage -p surveillance_lineage_integrity -p surveillance_lineage -- --check
 
       - name: Run lineage contract host tests
-        run: cargo test -p health-surveillance-lineage --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p health-surveillance-lineage --target "${{ steps.host.outputs.triple }}"
 
       - name: Run lineage integrity host tests
-        run: cargo test -p surveillance_lineage_integrity --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p surveillance_lineage_integrity --target "${{ steps.host.outputs.triple }}"
 
       - name: Run lineage coordinator host tests
-        run: cargo test -p surveillance_lineage --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p surveillance_lineage --target "${{ steps.host.outputs.triple }}"
 
       - name: Run Clippy
-        run: cargo clippy -p health-surveillance-lineage -p surveillance_lineage_integrity -p surveillance_lineage --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+        run: cargo clippy --locked -p health-surveillance-lineage -p surveillance_lineage_integrity -p surveillance_lineage --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
 
       - name: Run documentation tests
-        run: cargo test -p health-surveillance-lineage --doc --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p health-surveillance-lineage --doc --target "${{ steps.host.outputs.triple }}"
 
       - name: Check lineage contract WASM compatibility
-        run: cargo check -p health-surveillance-lineage --target wasm32-unknown-unknown
+        run: cargo check --locked -p health-surveillance-lineage --target wasm32-unknown-unknown
 
       - name: Check lineage integrity WASM compatibility
-        run: cargo check -p surveillance_lineage_integrity --target wasm32-unknown-unknown
+        run: cargo check --locked -p surveillance_lineage_integrity --target wasm32-unknown-unknown
 
       - name: Check lineage coordinator WASM compatibility
-        run: cargo check -p surveillance_lineage --target wasm32-unknown-unknown
+        run: cargo check --locked -p surveillance_lineage --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ members = [
     # ── Public Health Surveillance (separate aggregate-only DNA) ──
     "zomes/surveillance/integrity",
     "zomes/surveillance/coordinator",
+    "zomes/surveillance_lineage/integrity",
+    "zomes/surveillance_lineage/coordinator",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/dna/surveillance/dna.yaml
+++ b/dna/surveillance/dna.yaml
@@ -4,20 +4,25 @@ name: health-surveillance
 integrity:
   network_seed: ~
   properties:
-    # Fail closed by default. A deployment must create a DNA with an explicit,
-    # governance-approved non-zero aggregate release policy before publication.
+    # Base observation publication is fail-closed by default.
     release_policy: ~
-    # Also fail closed until the deployment pins a finite grant-lifetime policy
-    # and exact trusted (security_domain, issuer_did, credential_schema_id) tuples.
-    # v1 producer proofs are detached Ed25519 signatures over the canonical
-    # health-surveillance-authority signing transcript.
+    # Pins broad producer authority + exact-observation positive status profiles.
     producer_authority_policy: ~
+    # Independently controls additive lineage evidence. Null disables only
+    # lineage-attestation publication; it does not disable base observations.
+    lineage_attestor_policy: ~
   zomes:
     - name: surveillance_integrity
       path: ../../target/wasm32-unknown-unknown/release/surveillance_integrity.wasm
+    - name: surveillance_lineage_integrity
+      path: ../../target/wasm32-unknown-unknown/release/surveillance_lineage_integrity.wasm
 coordinator:
   zomes:
     - name: surveillance
       path: ../../target/wasm32-unknown-unknown/release/surveillance.wasm
       dependencies:
         - name: surveillance_integrity
+    - name: surveillance_lineage
+      path: ../../target/wasm32-unknown-unknown/release/surveillance_lineage.wasm
+      dependencies:
+        - name: surveillance_lineage_integrity

--- a/zomes/surveillance_lineage/README.md
+++ b/zomes/surveillance_lineage/README.md
@@ -1,0 +1,66 @@
+# Surveillance Lineage Zomes
+
+These zomes publish signed, append-only lineage evidence about observations that have already crossed the main Health Surveillance DNA publication boundary.
+
+## Why a separate zome
+
+Lineage evidence has different availability and authority semantics from base surveillance evidence:
+
+- an observation may be urgently useful before lineage audit finishes;
+- absence of a lineage attestation means `Unknown`, not invalid observation;
+- producer credentials do not imply lineage-auditor authority;
+- multiple trusted auditors may disagree, and their statements must remain separately visible;
+- lineage evidence should never mutate the original released observation.
+
+For those reasons, lineage is additive rather than a required field on `ReleasedSurveillanceObservation`.
+
+## DNA policy
+
+`lineage_attestor_policy` is independent from `producer_authority_policy`.
+
+A lineage trust tuple is exactly:
+
+- `security_domain`;
+- `attestor_did`;
+- `attestation_profile_id`.
+
+v1 attestor DIDs must be `did:mycelix:<AgentPubKey>` and the attestor signs the canonical transcript from `health-surveillance-lineage` with Ed25519.
+
+If `lineage_attestor_policy` is absent, lineage-attestation publication fails closed. Base observation publication is unaffected.
+
+## Relay vs attestor
+
+`ReleasedLineageAttestation` carries both:
+
+- `submitted_by` — the Holochain agent that put the record on this DHT;
+- `attestor_did` inside the signed attestation — the authority that made the lineage claim.
+
+These identities may differ. A signed lineage statement can therefore be relayed without transferring attestor authority to the relay.
+
+## Exact target binding
+
+Each lineage record references the action hash of an existing released observation. Integrity resolves a valid record and requires the attestation's `ObservationId` to match the referenced observation exactly.
+
+Changing provenance, source revision, metric data, or even the producer's own `IndependenceGroup` claim changes `ObservationId` and prevents reuse of an existing lineage signature.
+
+## Cross-zome wire mirror
+
+The lineage integrity zome currently decodes the referenced observation through `ReleasedSurveillanceObservationMirror`, a read-only serialization mirror built entirely from the shared core/authority/endorsement types.
+
+This avoids linking the main integrity-zome implementation into the lineage WASM, but it creates an explicit schema-coupling obligation: breaking changes to `ReleasedSurveillanceObservation` must update this mirror and receive end-to-end DNA qualification in the same change.
+
+Once the released-observation schema is qualified and stable, the preferred cleanup is to move the shared wire payload into a dedicated shared release-record crate used by both integrity zomes.
+
+## No indexes in v1
+
+The lineage zome deliberately creates no DHT links yet. It supports submit/get-by-action-hash only.
+
+A later indexing tranche can add observation-to-attestation discovery after link validation, cardinality, conflict, and query semantics are reviewed. Until then, convenience indexing cannot become an unreviewed source of evidence authority.
+
+## Conflicting attestations
+
+There is no update/delete path. If two trusted attestors disagree, both records remain immutable evidence. Consumers should surface the conflict and apply explicit trust/profile policy rather than silently selecting one.
+
+## What this does not prove
+
+A valid lineage signature proves that a DNA-trusted attestor made the dimension-specific statement it signed. It does not automatically prove causal independence, statistical independence, measurement correctness, outbreak status, diagnosis, treatment need, or emergency authority.

--- a/zomes/surveillance_lineage/coordinator/Cargo.toml
+++ b/zomes/surveillance_lineage/coordinator/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "surveillance_lineage"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Coordinator zome for signed aggregate surveillance lineage attestations"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "surveillance_lineage"
+
+[dependencies]
+hdk.workspace = true
+serde.workspace = true
+holochain_serialized_bytes.workspace = true
+health-surveillance-core = { path = "../../../crates/health-surveillance-core" }
+surveillance_lineage_integrity = { path = "../integrity" }

--- a/zomes/surveillance_lineage/coordinator/src/lib.rs
+++ b/zomes/surveillance_lineage/coordinator/src/lib.rs
@@ -1,0 +1,129 @@
+#![deny(unsafe_code)]
+// Copyright (C) 2024-2026 Tristan Stoltz / Luminous Dynamics
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Commercial licensing: see COMMERCIAL_LICENSE.md at repository root
+//! Coordinator API for additive signed surveillance lineage evidence.
+//!
+//! The caller supplies an externally signed lineage attestation. The coordinator
+//! verifies it for fast feedback, but the lineage integrity zome independently
+//! repeats target-observation binding, attestor-policy, and signature checks.
+
+use hdk::prelude::*;
+use health_surveillance_core::{CanonicalId, ObservationId};
+use surveillance_lineage_integrity::*;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubmitLineageAttestationInput {
+    pub observation_action: ActionHash,
+    pub attestation: EvidenceLineageAttestation,
+    pub attestation_signature: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SubmitLineageAttestationOutput {
+    pub action_hash: ActionHash,
+    pub observation_action: ActionHash,
+    pub observation_id: ObservationId,
+    pub attestation_id: LineageAttestationId,
+    pub submitted_by: AgentPubKey,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TrustedLineageAttestorView {
+    pub security_domain: CanonicalId,
+    pub attestor_did: CanonicalId,
+    pub attestation_profile_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LineageAttestorPolicyView {
+    pub trusted_attestors: Vec<TrustedLineageAttestorView>,
+}
+
+#[hdk_extern]
+pub fn get_lineage_attestor_policy(_: ()) -> ExternResult<LineageAttestorPolicyView> {
+    let configured = configured_lineage_attestor_policy()?;
+    Ok(LineageAttestorPolicyView {
+        trusted_attestors: configured
+            .trusted_attestors
+            .into_iter()
+            .map(|attestor| TrustedLineageAttestorView {
+                security_domain: attestor.security_domain,
+                attestor_did: attestor.attestor_did,
+                attestation_profile_id: attestor.attestation_profile_id,
+            })
+            .collect(),
+    })
+}
+
+#[hdk_extern]
+pub fn submit_lineage_attestation(
+    input: SubmitLineageAttestationInput,
+) -> ExternResult<SubmitLineageAttestationOutput> {
+    let record = get(input.observation_action.clone(), GetOptions::default())?.ok_or_else(|| {
+        wasm_error!(WasmErrorInner::Guest(
+            "referenced released surveillance observation was not found".to_string()
+        ))
+    })?;
+    let released: ReleasedSurveillanceObservationMirror = record
+        .entry()
+        .to_app_option()
+        .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?
+        .ok_or_else(|| {
+            wasm_error!(WasmErrorInner::Guest(
+                "observation_action does not decode as a released surveillance observation"
+                    .to_string()
+            ))
+        })?;
+
+    let submitted_by = agent_info()?.agent_initial_pubkey;
+    let entry = ReleasedLineageAttestation {
+        observation_action: input.observation_action.clone(),
+        attestation: input.attestation,
+        attestation_signature: input.attestation_signature,
+        submitted_by: submitted_by.clone(),
+    };
+
+    let policy = configured_lineage_attestor_policy()?;
+    let plan = validate_lineage_attestation_semantics(&entry, &released.observation, &policy)
+        .map_err(|message| wasm_error!(WasmErrorInner::Guest(message)))?;
+    if !verify_lineage_signature(&plan, &entry.attestation_signature)? {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "lineage attestation signature verification failed".to_string()
+        )));
+    }
+
+    let observation_id = released.observation.id().map_err(|e| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "could not derive referenced observation identity: {e}"
+        )))
+    })?;
+    let attestation_id = plan.attestation_id;
+    let action_hash = create_entry(&EntryTypes::ReleasedLineageAttestation(entry))?;
+
+    Ok(SubmitLineageAttestationOutput {
+        action_hash,
+        observation_action: input.observation_action,
+        observation_id,
+        attestation_id,
+        submitted_by,
+    })
+}
+
+#[hdk_extern]
+pub fn get_lineage_attestation(
+    action_hash: ActionHash,
+) -> ExternResult<Option<ReleasedLineageAttestation>> {
+    let record = match get(action_hash, GetOptions::default())? {
+        Some(record) => record,
+        None => return Ok(None),
+    };
+    record
+        .entry()
+        .to_app_option::<ReleasedLineageAttestation>()
+        .map_err(|e| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "stored record is not a released lineage attestation: {e}"
+            )))
+        })
+}

--- a/zomes/surveillance_lineage/integrity/Cargo.toml
+++ b/zomes/surveillance_lineage/integrity/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "surveillance_lineage_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Integrity zome for signed dimension-specific surveillance lineage attestations"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+name = "surveillance_lineage_integrity"
+
+[dependencies]
+hdi.workspace = true
+serde.workspace = true
+holochain_serialized_bytes.workspace = true
+health-surveillance-core = { path = "../../../crates/health-surveillance-core" }
+health-surveillance-authority = { path = "../../../crates/health-surveillance-authority" }
+health-surveillance-endorsement = { path = "../../../crates/health-surveillance-endorsement" }
+health-surveillance-lineage = { path = "../../../crates/health-surveillance-lineage" }

--- a/zomes/surveillance_lineage/integrity/src/lib.rs
+++ b/zomes/surveillance_lineage/integrity/src/lib.rs
@@ -56,7 +56,7 @@ pub struct LineageAttestorPolicyProperties {
 /// This view intentionally contains only the lineage property. Extra DNA
 /// properties owned by the base surveillance zome are ignored by serde.
 #[dna_properties]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct LineageDnaProperties {
     pub lineage_attestor_policy: Option<LineageAttestorPolicyProperties>,
 }

--- a/zomes/surveillance_lineage/integrity/src/lib.rs
+++ b/zomes/surveillance_lineage/integrity/src/lib.rs
@@ -1,0 +1,489 @@
+#![deny(unsafe_code)]
+// Copyright (C) 2024-2026 Tristan Stoltz / Luminous Dynamics
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Commercial licensing: see COMMERCIAL_LICENSE.md at repository root
+//! Signed, append-only lineage evidence for released aggregate observations.
+//!
+//! Lineage trust is intentionally separate from producer authority. This zome
+//! accepts an attestation only when its exact security-domain / attestor-DID /
+//! profile tuple is frozen into this DNA's lineage-attestor policy and the
+//! detached Ed25519 signature verifies over the canonical lineage transcript.
+//!
+//! Lineage evidence is additive. It does not gate base observation publication,
+//! and conflicting valid attestations are not overwritten or collapsed here.
+
+use hdi::prelude::*;
+use health_surveillance_authority::ProducerAuthorityGrant;
+use health_surveillance_core::{CanonicalId, ReleaseAssessment, SurveillanceObservation};
+use health_surveillance_endorsement::AuthorizedObservationEndorsement;
+pub use health_surveillance_lineage::*;
+
+const MAX_TRUSTED_LINEAGE_ATTESTORS: usize = 64;
+const ED25519_SIGNATURE_BYTES: usize = 64;
+
+/// Read-only serialization mirror of `surveillance_integrity::ReleasedSurveillanceObservation`.
+///
+/// Keeping this mirror in shared semantic types avoids linking one integrity-zome
+/// implementation into another WASM. `policy_id` is represented by its transparent
+/// 32-byte wire value; lineage validation does not interpret release-policy authority.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ReleasedSurveillanceObservationMirror {
+    pub observation: SurveillanceObservation,
+    pub release_assessment: ReleaseAssessment,
+    pub policy_revision: CanonicalId,
+    pub policy_id: [u8; 32],
+    pub authority_grant: ProducerAuthorityGrant,
+    pub authority_signature: Vec<u8>,
+    pub status_endorsement: AuthorizedObservationEndorsement,
+    pub status_endorsement_signature: Vec<u8>,
+    pub publisher: AgentPubKey,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TrustedLineageAttestorProperties {
+    pub security_domain: String,
+    pub attestor_did: String,
+    pub attestation_profile_id: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct LineageAttestorPolicyProperties {
+    pub trusted_attestors: Vec<TrustedLineageAttestorProperties>,
+}
+
+/// This view intentionally contains only the lineage property. Extra DNA
+/// properties owned by the base surveillance zome are ignored by serde.
+#[dna_properties]
+#[derive(Clone, Debug, PartialEq)]
+pub struct LineageDnaProperties {
+    pub lineage_attestor_policy: Option<LineageAttestorPolicyProperties>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfiguredTrustedLineageAttestor {
+    pub security_domain: CanonicalId,
+    pub attestor_did: CanonicalId,
+    pub attestation_profile_id: CanonicalId,
+    pub attestor_pubkey: AgentPubKey,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfiguredLineageAttestorPolicy {
+    pub trusted_attestors: Vec<ConfiguredTrustedLineageAttestor>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LineageVerificationPlan {
+    pub attestor_pubkey: AgentPubKey,
+    pub signing_transcript: Vec<u8>,
+    pub attestation_id: LineageAttestationId,
+}
+
+pub fn configured_lineage_attestor_policy() -> ExternResult<ConfiguredLineageAttestorPolicy> {
+    let properties = LineageDnaProperties::try_from_dna_properties()?;
+    let configured = properties.lineage_attestor_policy.ok_or_else(|| {
+        wasm_error!(WasmErrorInner::Guest(
+            "Surveillance lineage publication is disabled: no DNA lineage_attestor_policy is configured"
+                .to_string()
+        ))
+    })?;
+    configured_lineage_attestor_policy_from_properties(&configured).map_err(|message| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Invalid surveillance lineage-attestor policy: {message}"
+        )))
+    })
+}
+
+pub fn configured_lineage_attestor_policy_from_properties(
+    properties: &LineageAttestorPolicyProperties,
+) -> Result<ConfiguredLineageAttestorPolicy, String> {
+    if properties.trusted_attestors.is_empty() {
+        return Err("trusted_attestors must contain at least one attestor".to_string());
+    }
+    if properties.trusted_attestors.len() > MAX_TRUSTED_LINEAGE_ATTESTORS {
+        return Err(format!(
+            "trusted_attestors exceeds maximum of {MAX_TRUSTED_LINEAGE_ATTESTORS}"
+        ));
+    }
+
+    let mut trusted_attestors = Vec::with_capacity(properties.trusted_attestors.len());
+    for attestor in &properties.trusted_attestors {
+        let security_domain = CanonicalId::new(attestor.security_domain.clone())
+            .map_err(|e| format!("invalid lineage security_domain: {e}"))?;
+        let attestor_did = CanonicalId::new(attestor.attestor_did.clone())
+            .map_err(|e| format!("invalid lineage attestor_did: {e}"))?;
+        let attestation_profile_id = CanonicalId::new(attestor.attestation_profile_id.clone())
+            .map_err(|e| format!("invalid lineage attestation_profile_id: {e}"))?;
+        let attestor_pubkey = parse_mycelix_did_agent(&attestor_did)?;
+        let configured = ConfiguredTrustedLineageAttestor {
+            security_domain,
+            attestor_did,
+            attestation_profile_id,
+            attestor_pubkey,
+        };
+        if trusted_attestors.iter().any(|existing| existing == &configured) {
+            return Err("trusted_attestors contains a duplicate trust tuple".to_string());
+        }
+        trusted_attestors.push(configured);
+    }
+
+    trusted_attestors.sort_by(|a, b| {
+        (
+            a.security_domain.as_str(),
+            a.attestor_did.as_str(),
+            a.attestation_profile_id.as_str(),
+        )
+            .cmp(&(
+                b.security_domain.as_str(),
+                b.attestor_did.as_str(),
+                b.attestation_profile_id.as_str(),
+            ))
+    });
+
+    Ok(ConfiguredLineageAttestorPolicy { trusted_attestors })
+}
+
+fn parse_mycelix_did_agent(did: &CanonicalId) -> Result<AgentPubKey, String> {
+    let encoded = did
+        .as_str()
+        .strip_prefix("did:mycelix:")
+        .ok_or_else(|| "trusted lineage attestor must use did:mycelix".to_string())?;
+    AgentPubKey::try_from(encoded.to_string())
+        .map_err(|_| "could not parse lineage attestor did:mycelix AgentPubKey".to_string())
+}
+
+/// One immutable signed lineage statement about one already released observation.
+///
+/// `submitted_by` authenticates the DHT relay/author. It is intentionally not
+/// required to equal the attestor: a valid signed attestation may be relayed by
+/// another agent without changing who made the lineage claim.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct ReleasedLineageAttestation {
+    pub observation_action: ActionHash,
+    pub attestation: EvidenceLineageAttestation,
+    pub attestation_signature: Vec<u8>,
+    pub submitted_by: AgentPubKey,
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    ReleasedLineageAttestation(ReleasedLineageAttestation),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    Reserved,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => match app_entry {
+                EntryTypes::ReleasedLineageAttestation(entry) => {
+                    validate_released_lineage_attestation(&action.author, &entry)
+                }
+            },
+            OpEntry::UpdateEntry { .. } => Ok(ValidateCallbackResult::Invalid(
+                "Released lineage attestations are append-only and cannot be updated".into(),
+            )),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterUpdate(_) => Ok(ValidateCallbackResult::Invalid(
+            "Released lineage attestations are append-only and cannot be updated".into(),
+        )),
+        FlatOp::RegisterDelete(_) => Ok(ValidateCallbackResult::Invalid(
+            "Released lineage attestations are evidence records and cannot be deleted".into(),
+        )),
+        FlatOp::RegisterCreateLink { .. } => Ok(ValidateCallbackResult::Invalid(
+            "Surveillance lineage v1 defines no publishable link operations".into(),
+        )),
+        FlatOp::RegisterDeleteLink { .. } => Ok(ValidateCallbackResult::Invalid(
+            "Surveillance lineage v1 defines no deletable link operations".into(),
+        )),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_released_lineage_attestation(
+    action_author: &AgentPubKey,
+    entry: &ReleasedLineageAttestation,
+) -> ExternResult<ValidateCallbackResult> {
+    if &entry.submitted_by != action_author {
+        return Ok(ValidateCallbackResult::Invalid(
+            "lineage submitted_by must equal the Holochain action author".to_string(),
+        ));
+    }
+
+    let record = must_get_valid_record(entry.observation_action.clone())?;
+    let released: ReleasedSurveillanceObservationMirror = record
+        .entry()
+        .to_app_option()
+        .map_err(|e| wasm_error!(WasmErrorInner::Guest(e.to_string())))?
+        .ok_or_else(|| {
+            wasm_error!(WasmErrorInner::Guest(
+                "lineage observation_action does not decode as a released surveillance observation"
+                    .to_string()
+            ))
+        })?;
+
+    let policy = configured_lineage_attestor_policy()?;
+    let plan = match validate_lineage_attestation_semantics(entry, &released.observation, &policy) {
+        Ok(plan) => plan,
+        Err(message) => return Ok(ValidateCallbackResult::Invalid(message)),
+    };
+
+    match verify_lineage_signature(&plan, &entry.attestation_signature)? {
+        true => Ok(ValidateCallbackResult::Valid),
+        false => Ok(ValidateCallbackResult::Invalid(
+            "lineage attestation signature verification failed".to_string(),
+        )),
+    }
+}
+
+/// Pure semantic validation once integrity has resolved the referenced released
+/// observation. This is the substitution-test boundary before host crypto.
+pub fn validate_lineage_attestation_semantics(
+    entry: &ReleasedLineageAttestation,
+    observation: &SurveillanceObservation,
+    policy: &ConfiguredLineageAttestorPolicy,
+) -> Result<LineageVerificationPlan, String> {
+    if entry.attestation_signature.len() != ED25519_SIGNATURE_BYTES {
+        return Err(format!(
+            "lineage Ed25519 signature must be {ED25519_SIGNATURE_BYTES} bytes"
+        ));
+    }
+    entry
+        .attestation
+        .validate()
+        .map_err(|e| format!("invalid lineage attestation: {e}"))?;
+
+    if !entry
+        .attestation
+        .binds_observation(observation)
+        .map_err(|e| format!("lineage observation binding failed: {e}"))?
+    {
+        return Err("lineage attestation does not bind the referenced observation".to_string());
+    }
+    if entry.attestation.assessed_at_unix_s() < observation.reported_at_unix_s {
+        return Err(
+            "lineage attestation assessment time cannot claim to precede observation report time"
+                .to_string(),
+        );
+    }
+
+    let trusted = policy
+        .trusted_attestors
+        .iter()
+        .find(|trusted| {
+            &trusted.security_domain == entry.attestation.security_domain()
+                && &trusted.attestor_did == entry.attestation.attestor_did()
+                && &trusted.attestation_profile_id == entry.attestation.attestation_profile_id()
+        })
+        .ok_or_else(|| {
+            "lineage security-domain/attestor/profile tuple is not trusted by this DNA".to_string()
+        })?;
+
+    let signing_transcript = entry
+        .attestation
+        .signing_transcript()
+        .map_err(|e| format!("could not construct lineage signing transcript: {e}"))?;
+    let attestation_id = entry
+        .attestation
+        .id()
+        .map_err(|e| format!("could not derive lineage attestation ID: {e}"))?;
+
+    Ok(LineageVerificationPlan {
+        attestor_pubkey: trusted.attestor_pubkey.clone(),
+        signing_transcript,
+        attestation_id,
+    })
+}
+
+pub fn verify_lineage_signature(
+    plan: &LineageVerificationPlan,
+    signature_bytes: &[u8],
+) -> ExternResult<bool> {
+    let raw: [u8; ED25519_SIGNATURE_BYTES] = match signature_bytes.try_into() {
+        Ok(raw) => raw,
+        Err(_) => return Ok(false),
+    };
+    verify_signature_raw(
+        plan.attestor_pubkey.clone(),
+        Signature::from(raw),
+        plan.signing_transcript.clone(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use health_surveillance_core::{
+        BoundedUncertainty, EvidenceProvenance, GeographicPrecision, GeographicScope,
+        IndependenceGroup, MetricKind, ObservationWindow, ObservedMetric, SignalFamily, SourceKind,
+        SourceRecordDigest,
+    };
+
+    fn id(value: &str) -> CanonicalId {
+        CanonicalId::new(value).unwrap()
+    }
+
+    fn agent(byte: u8) -> AgentPubKey {
+        AgentPubKey::from_raw_36(vec![byte; 36])
+    }
+
+    fn did(agent: &AgentPubKey) -> String {
+        format!("did:mycelix:{agent}")
+    }
+
+    fn observation(revision: &str) -> SurveillanceObservation {
+        SurveillanceObservation::new(
+            SignalFamily::Respiratory,
+            SourceKind::LaboratoryAggregate,
+            "lab-feed-a",
+            IndependenceGroup::new("producer-claim-lineage-a").unwrap(),
+            GeographicScope::new("health-district", "district-17", GeographicPrecision::District)
+                .unwrap(),
+            ObservationWindow::new(10_000, 13_600).unwrap(),
+            13_700,
+            100,
+            ObservedMetric::new(
+                MetricKind::FractionPositive,
+                0.20,
+                BoundedUncertainty::new(0.15, 0.25).unwrap(),
+                "fraction",
+            )
+            .unwrap(),
+            EvidenceProvenance::new(
+                "lab-a",
+                "aggregate-protocol-v1",
+                revision,
+                Some("upstream-lab-a"),
+                SourceRecordDigest::sha256([7; 32]).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn policy(attestor: &AgentPubKey) -> ConfiguredLineageAttestorPolicy {
+        configured_lineage_attestor_policy_from_properties(&LineageAttestorPolicyProperties {
+            trusted_attestors: vec![TrustedLineageAttestorProperties {
+                security_domain: "lineage-domain:public-health-v1".into(),
+                attestor_did: did(attestor),
+                attestation_profile_id: "lineage-profile:multi-dimension-v1".into(),
+            }],
+        })
+        .unwrap()
+    }
+
+    fn attestation(
+        observation: &SurveillanceObservation,
+        attestor: &AgentPubKey,
+    ) -> EvidenceLineageAttestation {
+        EvidenceLineageAttestation::new(
+            id("lineage-domain:public-health-v1"),
+            id("lineage-profile:multi-dimension-v1"),
+            id(&did(attestor)),
+            observation.id().unwrap(),
+            LineageDescriptor::new(
+                LineageKnowledge::known([id("root:dataset-a")]).unwrap(),
+                LineageKnowledge::known([id("sample:district-17")]).unwrap(),
+                LineageKnowledge::unknown(),
+                LineageKnowledge::known([id("instrument:lab-a")]).unwrap(),
+                LineageKnowledge::known([id("pipeline:aggregate-v1")]).unwrap(),
+                LineageKnowledge::known([id("control:audited-lab-a")]).unwrap(),
+            )
+            .unwrap(),
+            13_800,
+            [4; 32],
+            [5; 32],
+        )
+        .unwrap()
+    }
+
+    fn entry(observation: &SurveillanceObservation, attestor: &AgentPubKey) -> ReleasedLineageAttestation {
+        ReleasedLineageAttestation {
+            observation_action: ActionHash::from_raw_36(vec![7; 36]),
+            attestation: attestation(observation, attestor),
+            attestation_signature: vec![1; 64],
+            submitted_by: agent(9),
+        }
+    }
+
+    #[test]
+    fn empty_trust_policy_fails_closed() {
+        assert!(configured_lineage_attestor_policy_from_properties(
+            &LineageAttestorPolicyProperties {
+                trusted_attestors: vec![],
+            }
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn exact_lineage_semantics_produce_verification_plan() {
+        let attestor = agent(3);
+        let observation = observation("rev-1");
+        let entry = entry(&observation, &attestor);
+        let plan = validate_lineage_attestation_semantics(&entry, &observation, &policy(&attestor))
+            .unwrap();
+        assert_eq!(plan.attestor_pubkey, attestor);
+        assert_eq!(plan.attestation_id, entry.attestation.id().unwrap());
+    }
+
+    #[test]
+    fn observation_substitution_fails_before_crypto() {
+        let attestor = agent(3);
+        let original = observation("rev-1");
+        let changed = observation("rev-2");
+        let entry = entry(&original, &attestor);
+        assert!(validate_lineage_attestation_semantics(&entry, &changed, &policy(&attestor)).is_err());
+    }
+
+    #[test]
+    fn unrelated_attestor_does_not_inherit_trust() {
+        let trusted_attestor = agent(3);
+        let other_attestor = agent(2);
+        let observation = observation("rev-1");
+        let entry = entry(&observation, &other_attestor);
+        assert!(validate_lineage_attestation_semantics(
+            &entry,
+            &observation,
+            &policy(&trusted_attestor),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn relay_identity_is_not_lineage_authority() {
+        let attestor = agent(3);
+        let observation = observation("rev-1");
+        let mut entry = entry(&observation, &attestor);
+        entry.submitted_by = agent(42);
+        assert!(validate_lineage_attestation_semantics(
+            &entry,
+            &observation,
+            &policy(&attestor),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn malformed_signature_length_fails_before_host_crypto() {
+        let attestor = agent(3);
+        let observation = observation("rev-1");
+        let mut entry = entry(&observation, &attestor);
+        entry.attestation_signature = vec![1; 63];
+        assert!(validate_lineage_attestation_semantics(
+            &entry,
+            &observation,
+            &policy(&attestor),
+        )
+        .is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Stack on #15 and add append-only signed lineage-attestation storage/verification without making lineage availability a prerequisite for base observation publication.

This tranche preserves the architectural separation between **publisher authority** and **lineage-auditor authority**. It introduces dedicated lineage integrity/coordinator zomes, a separate DNA-bound lineage-attestor policy, relay-safe submission, immutable conflicting attestations, and exact binding to an already released aggregate observation.

## Dependency

Base: `feat/public-health-lineage-attestation-v1` / #15 exact head `c740946c4456a677d0ca88f22ef139439906631f`.

Head is a single normalized commit: `fad1d55f1e2d33448755e19afad5106a6b3c3711`.

Do not merge ahead of #10-#15. Keep draft until exact-head qualification succeeds.

## Separate lineage trust

Lineage publication is governed by `lineage_attestor_policy`, distinct from producer authority. A trusted tuple binds:

- security domain;
- attestor DID;
- attestation profile ID.

Producer-authority issuers do not inherit lineage-auditor authority.

## Optional/additive semantics

`lineage_attestor_policy: null` disables lineage-attestation publication only. It does **not** disable authenticated aggregate observation publication.

This is deliberate for degraded emergency operation: an observation may enter the network before lineage review is available; downstream reasoning must treat missing lineage as `Unknown`, not as independent evidence and not as an ingestion failure.

## Append-only conflict preservation

Lineage attestations are separate entries referencing an already released observation. They do not update the observation.

Multiple valid attestors may disagree. The integrity layer preserves all valid signed attestations rather than selecting or overwriting one canonical lineage claim.

## Relay semantics

`submitted_by` must equal the Holochain action author, but attestation authority comes only from the signed attestor DID and the DNA-bound attestor trust tuple. A relay can transport evidence without acquiring lineage authority.

## Exact observation binding

Before signature verification, the lineage integrity layer:

1. resolves the referenced released-observation action;
2. decodes the expected released-observation wire shape;
3. revalidates the underlying `SurveillanceObservation`;
4. recomputes `ObservationId`;
5. requires the signed lineage attestation to reference that exact ID;
6. requires the attestor security-domain/profile tuple to be DNA-trusted;
7. verifies the detached v1 Ed25519 signature over the canonical lineage signing transcript.

Changing any observation field that changes `ObservationId` invalidates the binding.

## Cross-zome wire boundary

The lineage integrity zome deliberately does **not** depend on the base `surveillance_integrity` implementation crate. It uses a read-only wire-compatible mirror assembled from shared core/authority/endorsement types, avoiding integrity-zome implementation coupling.

This mirror is explicitly treated as versioned technical debt. After the released-observation schema has executable qualification, the preferred follow-up is a tiny shared release-record wire crate consumed by both integrity zomes.

## No independence shortcut

This layer authenticates lineage facts, not `is_independent: true`.

The underlying #15 contract still represents each dimension as `SharedKnown`, `NoKnownOverlap`, or `Unknown`, with `NoKnownOverlap` explicitly weaker than demonstrated causal/statistical independence.

## Explicit non-goals

No patient data, diagnosis, treatment, outbreak declaration, pathogen engineering/design, emergency authority, public-health orders, generic trust scores, or autonomous Symthaea action.

## Qualification

The focused lineage workflow is expanded to cover:

- lineage contract formatting/tests/Clippy/docs/WASM;
- lineage integrity host tests and Clippy;
- lineage coordinator host tests and Clippy;
- both lineage zomes on `wasm32-unknown-unknown`.

No merge-ready claim until the exact head is green.

## Next

Once CI stabilizes the released-entry schema, extract the shared release-record wire contract. Then build source adapters (FHIR aggregate, wastewater, health-system capacity) before connecting the first conservative Symthaea health-resilience consumer.