### PR TITLE
feat(surveillance): add aggregate-only source adapters

### DIFF
--- a/.github/workflows/surveillance-source-adapters.yml
+++ b/.github/workflows/surveillance-source-adapters.yml
@@ -36,6 +36,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact source checkout
+        shell: bash
+        run: |
+          EXPECTED="${{ github.event.pull_request.head.sha || github.sha }}"
+          ACTUAL="$(git rev-parse HEAD)"
+          test "$ACTUAL" = "$EXPECTED"
+          echo "QUALIFIED_SOURCE_HEAD=$ACTUAL"
 
       - name: Check out pinned parent workspace dependencies
         shell: bash

--- a/.github/workflows/surveillance-source-adapters.yml
+++ b/.github/workflows/surveillance-source-adapters.yml
@@ -1,0 +1,66 @@
+name: Public Health Surveillance Source Adapters
+
+on:
+  pull_request:
+    paths:
+      - "crates/health-surveillance-core/**"
+      - "crates/health-surveillance-source-adapters/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/surveillance-source-adapters.yml"
+  push:
+    branches: [main]
+    paths:
+      - "crates/health-surveillance-core/**"
+      - "crates/health-surveillance-source-adapters/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/surveillance-source-adapters.yml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  source-adapters:
+    name: Aggregate-only source adapter qualification
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Cargo resolves the complete workspace graph even for this focused crate.
+      - name: Check out parent workspace dependencies
+        run: |
+          git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
+          mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
+          cp -r /tmp/mycelix-parent/crates/. ../crates/
+          cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
+          cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-workspace/mycelix-core/
+          rm -rf /tmp/mycelix-parent
+
+      - name: Install pinned Rust
+        uses: dtolnay/rust-toolchain@1.96.0
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Resolve host target
+        id: host
+        shell: bash
+        run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
+
+      - name: Check formatting
+        run: cargo fmt -p health-surveillance-source-adapters -- --check
+
+      - name: Run host tests
+        run: cargo test -p health-surveillance-source-adapters --target "${{ steps.host.outputs.triple }}"
+
+      - name: Run Clippy
+        run: cargo clippy -p health-surveillance-source-adapters --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+
+      - name: Run documentation tests
+        run: cargo test -p health-surveillance-source-adapters --doc --target "${{ steps.host.outputs.triple }}"
+
+      - name: Check WASM compatibility
+        run: cargo check -p health-surveillance-source-adapters --target wasm32-unknown-unknown

--- a/.github/workflows/surveillance-source-adapters.yml
+++ b/.github/workflows/surveillance-source-adapters.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5 / node24
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
@@ -86,8 +86,8 @@ jobs:
             crates/health-surveillance-source-adapters/Cargo.toml
           if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
 
-      - name: Verify committed lock graph
-        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+      - name: Verify complete committed lock graph
+        run: cargo metadata --locked --format-version 1 > /dev/null
 
       - name: Check formatting
         run: cargo fmt -p health-surveillance-source-adapters -- --check

--- a/.github/workflows/surveillance-source-adapters.yml
+++ b/.github/workflows/surveillance-source-adapters.yml
@@ -7,6 +7,7 @@ on:
       - "crates/health-surveillance-source-adapters/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-source-adapters.yml"
   push:
     branches: [main]
@@ -15,24 +16,36 @@ on:
       - "crates/health-surveillance-source-adapters/**"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "rust-toolchain.toml"
       - ".github/workflows/surveillance-source-adapters.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  PARENT_MYCELIX_REF: 7daefcbfa6c4427809e9d8dc24a039bb024da5e9
 
 jobs:
   source-adapters:
     name: Aggregate-only source adapter qualification
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      # Cargo resolves the complete workspace graph even for this focused crate.
-      - name: Check out parent workspace dependencies
+      - name: Check out pinned parent workspace dependencies
+        shell: bash
         run: |
-          git clone --depth 1 https://github.com/Luminous-Dynamics/mycelix.git /tmp/mycelix-parent
+          git init /tmp/mycelix-parent
+          git -C /tmp/mycelix-parent remote add origin https://github.com/Luminous-Dynamics/mycelix.git
+          git -C /tmp/mycelix-parent fetch --depth 1 origin "$PARENT_MYCELIX_REF"
+          git -C /tmp/mycelix-parent checkout --detach FETCH_HEAD
+          test "$(git -C /tmp/mycelix-parent rev-parse HEAD)" = "$PARENT_MYCELIX_REF"
+
           mkdir -p ../crates ../mycelix-core ../mycelix-workspace/mycelix-core
           cp -r /tmp/mycelix-parent/crates/. ../crates/
           cp -r /tmp/mycelix-parent/mycelix-core/. ../mycelix-core/
@@ -40,7 +53,7 @@ jobs:
           rm -rf /tmp/mycelix-parent
 
       - name: Install pinned Rust
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: dtolnay/rust-toolchain@01ba1edad32c6f80dbcce879d3e0fa5a00b2a84e
         with:
           components: rustfmt, clippy
           targets: wasm32-unknown-unknown
@@ -50,17 +63,32 @@ jobs:
         shell: bash
         run: echo "triple=$(rustc -vV | awk '/^host:/{print $2}')" >> "$GITHUB_OUTPUT"
 
+      - name: Record qualification environment
+        shell: bash
+        run: |
+          echo "HEAD=$(git rev-parse HEAD)"
+          echo "PARENT_MYCELIX_REF=$PARENT_MYCELIX_REF"
+          rustc -vV
+          cargo -Vv
+          sha256sum Cargo.toml Cargo.lock \
+            crates/health-surveillance-core/Cargo.toml \
+            crates/health-surveillance-source-adapters/Cargo.toml
+          if [[ -f rust-toolchain.toml ]]; then sha256sum rust-toolchain.toml; fi
+
+      - name: Verify committed lock graph
+        run: cargo metadata --locked --format-version 1 --no-deps > /dev/null
+
       - name: Check formatting
         run: cargo fmt -p health-surveillance-source-adapters -- --check
 
       - name: Run host tests
-        run: cargo test -p health-surveillance-source-adapters --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p health-surveillance-source-adapters --target "${{ steps.host.outputs.triple }}"
 
       - name: Run Clippy
-        run: cargo clippy -p health-surveillance-source-adapters --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
+        run: cargo clippy --locked -p health-surveillance-source-adapters --all-targets --target "${{ steps.host.outputs.triple }}" -- -D warnings
 
       - name: Run documentation tests
-        run: cargo test -p health-surveillance-source-adapters --doc --target "${{ steps.host.outputs.triple }}"
+        run: cargo test --locked -p health-surveillance-source-adapters --doc --target "${{ steps.host.outputs.triple }}"
 
       - name: Check WASM compatibility
-        run: cargo check -p health-surveillance-source-adapters --target wasm32-unknown-unknown
+        run: cargo check --locked -p health-surveillance-source-adapters --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "crates/health-surveillance-authority",
     "crates/health-surveillance-endorsement",
     "crates/health-surveillance-lineage",
+    "crates/health-surveillance-source-adapters",
 
     # ── Public Health Surveillance (separate aggregate-only DNA) ──
     "zomes/surveillance/integrity",

--- a/crates/health-surveillance-source-adapters/Cargo.toml
+++ b/crates/health-surveillance-source-adapters/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "health-surveillance-source-adapters"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Pure aggregate-only source adapters for public-health surveillance evidence"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+health-surveillance-core = { path = "../health-surveillance-core" }
+serde.workspace = true
+thiserror.workspace = true

--- a/crates/health-surveillance-source-adapters/README.md
+++ b/crates/health-surveillance-source-adapters/README.md
@@ -1,0 +1,107 @@
+# Health Surveillance Source Adapters
+
+Pure Rust adapters that convert **already-aggregated** source measurements into the common `health-surveillance-core::SurveillanceObservation` contract.
+
+This crate is intentionally upstream of Holochain publication and downstream of source-specific privacy/aggregation. It has no network I/O and no authority semantics.
+
+## Boundary
+
+Accepted inputs contain only aggregate facts such as:
+
+- positive and tested counts;
+- event count and aggregate denominator;
+- wastewater/environmental concentration index plus sample count;
+- health-system capacity counts;
+- aggregate geography/time window;
+- source/protocol/provenance identifiers;
+- source-supplied uncertainty bounds.
+
+The input API contains no fields for patient IDs, names, DOB, MRN, encounter identifiers, street addresses, coordinates, raw FHIR resources, laboratory line lists, genomes, sequences, or free-form clinical records.
+
+If a deployment begins with patient-level/FHIR data, that data must remain inside its clinical/privacy boundary and be aggregated before calling this crate.
+
+## Adapters
+
+### Laboratory fraction
+
+`adapt_laboratory_fraction` computes `positive_count / tested_count` and emits:
+
+- `SourceKind::LaboratoryAggregate`;
+- `MetricKind::FractionPositive`;
+- unit `fraction`;
+- `cohort_size = tested_count`.
+
+Zero denominators and `positive_count > tested_count` fail closed.
+
+### Syndromic rate
+
+`adapt_syndromic_rate_per_100k` computes an aggregate event rate from an already-aggregated event count and denominator and emits:
+
+- `SourceKind::ClinicalSyndromicAggregate`;
+- `MetricKind::RatePer100k`;
+- unit `per_100k`.
+
+The adapter does not decide which patient encounters satisfy a syndrome definition.
+
+### Wastewater/environmental concentration
+
+`adapt_concentration` preserves whether the aggregate source is wastewater or another environmental monitoring path and emits `MetricKind::ConcentrationIndex` with a caller-supplied canonical aggregate unit.
+
+Raw assay/genomic payloads are outside this contract.
+
+### Health-system capacity
+
+`adapt_capacity_fraction` emits `SourceKind::HealthSystemCapacityAggregate` and requires explicit `Available` or `Occupied` semantics. The resulting unit is respectively `fraction_available` or `fraction_occupied`, preventing those meanings from being silently conflated.
+
+## Uncertainty
+
+The adapters do **not** invent confidence intervals or probabilities.
+
+Every source supplies its own `BoundedUncertainty`, and the common evidence core verifies that the computed/declared estimate is finite, in range, and inside the supplied interval.
+
+Statistical methods for producing uncertainty belong to separately reviewed source/protocol implementations. This prevents an adapter convenience function from becoming an undocumented epidemiological model.
+
+## Provenance and lineage
+
+`ObservationContext` carries the common source instance, claimed `IndependenceGroup`, aggregate geography/window, reporting time, and `EvidenceProvenance`.
+
+These adapters preserve those claims; they do not authenticate them. Producer authority/status and signed lineage evidence remain separate surveillance layers.
+
+## Non-goals
+
+This crate does not:
+
+- read patient records or FHIR resources;
+- de-identify raw clinical datasets;
+- publish to Holochain;
+- issue producer credentials;
+- prove source independence;
+- diagnose disease;
+- declare outbreaks;
+- recommend treatment;
+- authorize emergency/public-health actions;
+- identify, design, or optimize pathogens.
+
+## Intended flow
+
+```text
+private clinical / laboratory / environmental source
+                    |
+          source-specific aggregation
+          privacy + legal review
+                    |
+                    v
+ health-surveillance-source-adapters
+                    |
+        SurveillanceObservation
+                    |
+                    v
+     aggregate release policy
+     producer/status verification
+                    |
+                    v
+       Health Surveillance DNA
+                    |
+                    v
+      lineage evidence + Symthaea
+```

--- a/crates/health-surveillance-source-adapters/src/lib.rs
+++ b/crates/health-surveillance-source-adapters/src/lib.rs
@@ -1,0 +1,483 @@
+#![deny(unsafe_code)]
+//! Pure, aggregate-only adapters into `health-surveillance-core`.
+//!
+//! These adapters deliberately start *after* source-specific aggregation. They do
+//! not parse patient records, FHIR resources, laboratory line lists, exact
+//! locations, genomes, or other individual/raw clinical material. Their only
+//! output is a validated [`SurveillanceObservation`] carrying aggregate evidence.
+//!
+//! The adapters also do not manufacture epistemic confidence. Callers must supply
+//! explicit uncertainty bounds produced by the source pipeline; the core contract
+//! verifies that the computed/declared estimate lies inside those bounds.
+
+use health_surveillance_core::{
+    BoundedUncertainty, CanonicalId, EvidenceProvenance, GeographicScope, IndependenceGroup,
+    MetricKind, ObservationWindow, ObservedMetric, SignalFamily, SourceKind,
+    SurveillanceError, SurveillanceObservation,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum AdapterError {
+    #[error(transparent)]
+    Surveillance(#[from] SurveillanceError),
+    #[error("aggregate denominator must be greater than zero")]
+    ZeroDenominator,
+    #[error("fraction numerator cannot exceed denominator")]
+    NumeratorExceedsDenominator,
+    #[error("aggregate sample count must be greater than zero")]
+    EmptySampleSet,
+    #[error("capacity measured_units cannot exceed total_units")]
+    CapacityExceedsTotal,
+}
+
+/// Source/provenance fields shared by all adapter inputs.
+///
+/// There are intentionally no patient identifiers, addresses, coordinates, raw
+/// records, or free-form clinical payload fields in this type.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ObservationContext {
+    pub source_instance: CanonicalId,
+    pub independence_group: IndependenceGroup,
+    pub geography: GeographicScope,
+    pub window: ObservationWindow,
+    pub reported_at_unix_s: i64,
+    pub provenance: EvidenceProvenance,
+}
+
+impl ObservationContext {
+    pub fn new(
+        source_instance: CanonicalId,
+        independence_group: IndependenceGroup,
+        geography: GeographicScope,
+        window: ObservationWindow,
+        reported_at_unix_s: i64,
+        provenance: EvidenceProvenance,
+    ) -> Result<Self, AdapterError> {
+        window.validate()?;
+        provenance.validate()?;
+        if reported_at_unix_s < window.end_unix_s {
+            return Err(AdapterError::Surveillance(
+                SurveillanceError::ReportedBeforeWindowEnd,
+            ));
+        }
+        Ok(Self {
+            source_instance,
+            independence_group,
+            geography,
+            window,
+            reported_at_unix_s,
+            provenance,
+        })
+    }
+
+    fn build(
+        self,
+        signal: SignalFamily,
+        source_kind: SourceKind,
+        cohort_size: u64,
+        metric: ObservedMetric,
+    ) -> Result<SurveillanceObservation, AdapterError> {
+        SurveillanceObservation::new(
+            signal,
+            source_kind,
+            self.source_instance.as_str().to_string(),
+            self.independence_group,
+            self.geography,
+            self.window,
+            self.reported_at_unix_s,
+            cohort_size,
+            metric,
+            self.provenance,
+        )
+        .map_err(AdapterError::from)
+    }
+}
+
+/// Already-aggregated laboratory positives over an aggregate denominator.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct LaboratoryFractionInput {
+    pub context: ObservationContext,
+    pub signal: SignalFamily,
+    pub positive_count: u64,
+    pub tested_count: u64,
+    /// Source-supplied uncertainty for the resulting fraction in `[0, 1]`.
+    pub uncertainty: BoundedUncertainty,
+}
+
+pub fn adapt_laboratory_fraction(
+    input: LaboratoryFractionInput,
+) -> Result<SurveillanceObservation, AdapterError> {
+    if input.tested_count == 0 {
+        return Err(AdapterError::ZeroDenominator);
+    }
+    if input.positive_count > input.tested_count {
+        return Err(AdapterError::NumeratorExceedsDenominator);
+    }
+
+    let estimate = input.positive_count as f64 / input.tested_count as f64;
+    let metric = ObservedMetric::new(
+        MetricKind::FractionPositive,
+        estimate,
+        input.uncertainty,
+        "fraction",
+    )?;
+
+    input.context.build(
+        input.signal,
+        SourceKind::LaboratoryAggregate,
+        input.tested_count,
+        metric,
+    )
+}
+
+/// Already-aggregated syndromic event count over an aggregate population/visit
+/// denominator. The adapter computes a rate per 100,000 but does not infer the
+/// syndrome from patient-level records.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct SyndromicRateInput {
+    pub context: ObservationContext,
+    pub signal: SignalFamily,
+    pub event_count: u64,
+    pub denominator: u64,
+    /// Source-supplied uncertainty in rate-per-100k units.
+    pub uncertainty: BoundedUncertainty,
+}
+
+pub fn adapt_syndromic_rate_per_100k(
+    input: SyndromicRateInput,
+) -> Result<SurveillanceObservation, AdapterError> {
+    if input.denominator == 0 {
+        return Err(AdapterError::ZeroDenominator);
+    }
+
+    let estimate = (input.event_count as f64 / input.denominator as f64) * 100_000.0;
+    let metric = ObservedMetric::new(
+        MetricKind::RatePer100k,
+        estimate,
+        input.uncertainty,
+        "per_100k",
+    )?;
+
+    input.context.build(
+        input.signal,
+        SourceKind::ClinicalSyndromicAggregate,
+        input.denominator,
+        metric,
+    )
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConcentrationSource {
+    Wastewater,
+    Environmental,
+}
+
+/// Already-aggregated concentration/index result from wastewater or another
+/// environmental monitoring pipeline.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct ConcentrationAggregateInput {
+    pub context: ObservationContext,
+    pub signal: SignalFamily,
+    pub source: ConcentrationSource,
+    /// Number of aggregate samples/units contributing to this released value.
+    pub sample_count: u64,
+    pub estimate: f64,
+    pub uncertainty: BoundedUncertainty,
+    /// Source-defined canonical aggregate unit. Raw assay payloads do not belong here.
+    pub unit: CanonicalId,
+}
+
+pub fn adapt_concentration(
+    input: ConcentrationAggregateInput,
+) -> Result<SurveillanceObservation, AdapterError> {
+    if input.sample_count == 0 {
+        return Err(AdapterError::EmptySampleSet);
+    }
+
+    let source_kind = match input.source {
+        ConcentrationSource::Wastewater => SourceKind::WastewaterAggregate,
+        ConcentrationSource::Environmental => SourceKind::EnvironmentalAggregate,
+    };
+    let metric = ObservedMetric::new(
+        MetricKind::ConcentrationIndex,
+        input.estimate,
+        input.uncertainty,
+        input.unit.as_str().to_string(),
+    )?;
+
+    input
+        .context
+        .build(input.signal, source_kind, input.sample_count, metric)
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CapacitySemantics {
+    Available,
+    Occupied,
+}
+
+impl CapacitySemantics {
+    fn unit(self) -> &'static str {
+        match self {
+            Self::Available => "fraction_available",
+            Self::Occupied => "fraction_occupied",
+        }
+    }
+}
+
+/// Already-aggregated health-system capacity count. `signal` identifies the
+/// service/syndrome family to which the capacity snapshot applies; deployments
+/// may use `SignalFamily::Other(...)` for all-cause or service-specific capacity.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct CapacityFractionInput {
+    pub context: ObservationContext,
+    pub signal: SignalFamily,
+    pub measured_units: u64,
+    pub total_units: u64,
+    pub semantics: CapacitySemantics,
+    /// Source-supplied uncertainty for the resulting capacity fraction.
+    pub uncertainty: BoundedUncertainty,
+}
+
+pub fn adapt_capacity_fraction(
+    input: CapacityFractionInput,
+) -> Result<SurveillanceObservation, AdapterError> {
+    if input.total_units == 0 {
+        return Err(AdapterError::ZeroDenominator);
+    }
+    if input.measured_units > input.total_units {
+        return Err(AdapterError::CapacityExceedsTotal);
+    }
+
+    let estimate = input.measured_units as f64 / input.total_units as f64;
+    let metric = ObservedMetric::new(
+        MetricKind::CapacityFraction,
+        estimate,
+        input.uncertainty,
+        input.semantics.unit(),
+    )?;
+
+    input.context.build(
+        input.signal,
+        SourceKind::HealthSystemCapacityAggregate,
+        input.total_units,
+        metric,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use health_surveillance_core::{
+        Digest32Algorithm, GeographicPrecision, SourceRecordDigest,
+    };
+
+    fn context(source: &str) -> ObservationContext {
+        ObservationContext::new(
+            CanonicalId::new(source).unwrap(),
+            IndependenceGroup::new(format!("{source}-lineage")).unwrap(),
+            GeographicScope::new(
+                "health-district",
+                "district-17",
+                GeographicPrecision::District,
+            )
+            .unwrap(),
+            ObservationWindow::new(10_000, 13_600).unwrap(),
+            13_700,
+            EvidenceProvenance::new(
+                "producer-a",
+                "aggregate-protocol-v1",
+                "rev-1",
+                Some("upstream-a"),
+                SourceRecordDigest::new(Digest32Algorithm::Sha256, [7; 32]).unwrap(),
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn laboratory_fraction_is_computed_from_aggregate_counts() {
+        let observation = adapt_laboratory_fraction(LaboratoryFractionInput {
+            context: context("lab-feed-a"),
+            signal: SignalFamily::Respiratory,
+            positive_count: 20,
+            tested_count: 100,
+            uncertainty: BoundedUncertainty::new(0.15, 0.25).unwrap(),
+        })
+        .unwrap();
+
+        assert_eq!(observation.source_kind, SourceKind::LaboratoryAggregate);
+        assert_eq!(observation.cohort_size, 100);
+        assert_eq!(observation.metric.kind, MetricKind::FractionPositive);
+        assert!((observation.metric.estimate - 0.20).abs() < f64::EPSILON);
+        assert_eq!(observation.metric.unit.as_str(), "fraction");
+    }
+
+    #[test]
+    fn laboratory_fraction_rejects_impossible_aggregate_counts() {
+        let result = adapt_laboratory_fraction(LaboratoryFractionInput {
+            context: context("lab-feed-a"),
+            signal: SignalFamily::Respiratory,
+            positive_count: 101,
+            tested_count: 100,
+            uncertainty: BoundedUncertainty::new(0.0, 1.0).unwrap(),
+        });
+        assert_eq!(result, Err(AdapterError::NumeratorExceedsDenominator));
+    }
+
+    #[test]
+    fn source_uncertainty_must_cover_the_computed_fraction() {
+        let result = adapt_laboratory_fraction(LaboratoryFractionInput {
+            context: context("lab-feed-a"),
+            signal: SignalFamily::Respiratory,
+            positive_count: 20,
+            tested_count: 100,
+            uncertainty: BoundedUncertainty::new(0.30, 0.40).unwrap(),
+        });
+        assert_eq!(
+            result,
+            Err(AdapterError::Surveillance(
+                SurveillanceError::EstimateOutsideUncertainty
+            ))
+        );
+    }
+
+    #[test]
+    fn syndromic_rate_uses_only_preaggregated_event_and_denominator_counts() {
+        let observation = adapt_syndromic_rate_per_100k(SyndromicRateInput {
+            context: context("syndromic-feed-a"),
+            signal: SignalFamily::Respiratory,
+            event_count: 50,
+            denominator: 1_000,
+            uncertainty: BoundedUncertainty::new(4_500.0, 5_500.0).unwrap(),
+        })
+        .unwrap();
+
+        assert_eq!(
+            observation.source_kind,
+            SourceKind::ClinicalSyndromicAggregate
+        );
+        assert_eq!(observation.metric.kind, MetricKind::RatePer100k);
+        assert!((observation.metric.estimate - 5_000.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn wastewater_and_environmental_sources_remain_distinct() {
+        let wastewater = adapt_concentration(ConcentrationAggregateInput {
+            context: context("wastewater-feed-a"),
+            signal: SignalFamily::Respiratory,
+            source: ConcentrationSource::Wastewater,
+            sample_count: 12,
+            estimate: 3.4,
+            uncertainty: BoundedUncertainty::new(3.0, 3.8).unwrap(),
+            unit: CanonicalId::new("normalized_concentration_index").unwrap(),
+        })
+        .unwrap();
+        let environmental = adapt_concentration(ConcentrationAggregateInput {
+            context: context("environment-feed-a"),
+            signal: SignalFamily::Respiratory,
+            source: ConcentrationSource::Environmental,
+            sample_count: 12,
+            estimate: 3.4,
+            uncertainty: BoundedUncertainty::new(3.0, 3.8).unwrap(),
+            unit: CanonicalId::new("normalized_concentration_index").unwrap(),
+        })
+        .unwrap();
+
+        assert_eq!(wastewater.source_kind, SourceKind::WastewaterAggregate);
+        assert_eq!(environmental.source_kind, SourceKind::EnvironmentalAggregate);
+    }
+
+    #[test]
+    fn capacity_semantics_are_explicit_in_the_metric_unit() {
+        let available = adapt_capacity_fraction(CapacityFractionInput {
+            context: context("capacity-feed-a"),
+            signal: SignalFamily::Other(CanonicalId::new("all-cause").unwrap()),
+            measured_units: 25,
+            total_units: 100,
+            semantics: CapacitySemantics::Available,
+            uncertainty: BoundedUncertainty::new(0.20, 0.30).unwrap(),
+        })
+        .unwrap();
+        let occupied = adapt_capacity_fraction(CapacityFractionInput {
+            context: context("capacity-feed-b"),
+            signal: SignalFamily::Other(CanonicalId::new("all-cause").unwrap()),
+            measured_units: 75,
+            total_units: 100,
+            semantics: CapacitySemantics::Occupied,
+            uncertainty: BoundedUncertainty::new(0.70, 0.80).unwrap(),
+        })
+        .unwrap();
+
+        assert_eq!(available.metric.unit.as_str(), "fraction_available");
+        assert_eq!(occupied.metric.unit.as_str(), "fraction_occupied");
+        assert_eq!(
+            available.source_kind,
+            SourceKind::HealthSystemCapacityAggregate
+        );
+    }
+
+    #[test]
+    fn zero_denominators_and_empty_sample_sets_fail_closed() {
+        let lab = adapt_laboratory_fraction(LaboratoryFractionInput {
+            context: context("lab-feed-a"),
+            signal: SignalFamily::Respiratory,
+            positive_count: 0,
+            tested_count: 0,
+            uncertainty: BoundedUncertainty::new(0.0, 0.0).unwrap(),
+        });
+        assert_eq!(lab, Err(AdapterError::ZeroDenominator));
+
+        let wastewater = adapt_concentration(ConcentrationAggregateInput {
+            context: context("wastewater-feed-a"),
+            signal: SignalFamily::Respiratory,
+            source: ConcentrationSource::Wastewater,
+            sample_count: 0,
+            estimate: 1.0,
+            uncertainty: BoundedUncertainty::new(0.5, 1.5).unwrap(),
+            unit: CanonicalId::new("index").unwrap(),
+        });
+        assert_eq!(wastewater, Err(AdapterError::EmptySampleSet));
+    }
+
+    #[test]
+    fn context_rejects_reporting_before_window_end() {
+        let result = ObservationContext::new(
+            CanonicalId::new("feed-a").unwrap(),
+            IndependenceGroup::new("lineage-a").unwrap(),
+            GeographicScope::new(
+                "health-district",
+                "district-17",
+                GeographicPrecision::District,
+            )
+            .unwrap(),
+            ObservationWindow::new(10_000, 13_600).unwrap(),
+            13_599,
+            EvidenceProvenance::new(
+                "producer-a",
+                "aggregate-protocol-v1",
+                "rev-1",
+                None::<String>,
+                SourceRecordDigest::sha256([8; 32]).unwrap(),
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(
+            result,
+            Err(AdapterError::Surveillance(
+                SurveillanceError::ReportedBeforeWindowEnd
+            ))
+        );
+    }
+}

--- a/crates/health-surveillance-source-adapters/tests/provenance_binding.rs
+++ b/crates/health-surveillance-source-adapters/tests/provenance_binding.rs
@@ -1,0 +1,55 @@
+use health_surveillance_core::{
+    BoundedUncertainty, CanonicalId, EvidenceProvenance, GeographicPrecision, GeographicScope,
+    IndependenceGroup, ObservationWindow, SignalFamily, SourceRecordDigest,
+};
+use health_surveillance_source_adapters::{
+    LaboratoryFractionInput, ObservationContext, adapt_laboratory_fraction,
+};
+
+fn context(digest_byte: u8) -> ObservationContext {
+    ObservationContext::new(
+        CanonicalId::new("lab-feed-a").unwrap(),
+        IndependenceGroup::new("lab-feed-a-lineage").unwrap(),
+        GeographicScope::new(
+            "health-district",
+            "district-17",
+            GeographicPrecision::District,
+        )
+        .unwrap(),
+        ObservationWindow::new(10_000, 13_600).unwrap(),
+        13_700,
+        EvidenceProvenance::new(
+            "producer-a",
+            "aggregate-protocol-v1",
+            "rev-1",
+            Some("upstream-a"),
+            SourceRecordDigest::sha256([digest_byte; 32]).unwrap(),
+        )
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+fn adapt(digest_byte: u8) -> health_surveillance_core::SurveillanceObservation {
+    adapt_laboratory_fraction(LaboratoryFractionInput {
+        context: context(digest_byte),
+        signal: SignalFamily::Respiratory,
+        positive_count: 20,
+        tested_count: 100,
+        uncertainty: BoundedUncertainty::new(0.15, 0.25).unwrap(),
+    })
+    .unwrap()
+}
+
+#[test]
+fn identical_derived_metric_with_different_source_commitment_has_different_identity() {
+    let a = adapt(1);
+    let b = adapt(2);
+
+    // The adapter result is the same numerical aggregate, but the upstream
+    // evidence commitment is deliberately identity-significant. The adapter is
+    // not a lossless archive of all source-side aggregate inputs.
+    assert_eq!(a.metric, b.metric);
+    assert_eq!(a.cohort_size, b.cohort_size);
+    assert_ne!(a.id().unwrap(), b.id().unwrap());
+}


### PR DESCRIPTION
## Summary

Stack on #16 and add pure Rust adapters that convert already-aggregated laboratory, syndromic, wastewater/environmental, and health-system-capacity inputs into the common `SurveillanceObservation` contract.

The adapters intentionally start **after** source-specific aggregation/privacy processing. They do not parse patient records, FHIR resources, line lists, exact locations, genomes, or other raw clinical material, and they do not publish to Holochain.

## Dependency

Base: `feat/public-health-lineage-verification-v1` / #16 exact head `fad1d55f1e2d33448755e19afad5106a6b3c3711`.

Head is one normalized commit: `a2242a5e454dd8314966e21740d96b76f228ff8a`.

Do not merge ahead of #10-#16. Keep draft until exact-head qualification succeeds.

## New crate

Adds `crates/health-surveillance-source-adapters`.

### Common boundary

`ObservationContext` carries only aggregate-safe source metadata:

- source instance;
- claimed independence group;
- aggregate geography;
- observation window;
- report time;
- aggregate provenance/digest.

It contains no patient identifiers, addresses, coordinates, raw record payloads, or free-form clinical data.

## Adapter profiles

### Laboratory fraction

`adapt_laboratory_fraction` takes only aggregate positive/tested counts plus source-supplied uncertainty and emits `LaboratoryAggregate / FractionPositive`.

Zero denominators and impossible `positive_count > tested_count` inputs fail closed.

### Syndromic rate

`adapt_syndromic_rate_per_100k` computes a rate from an already-aggregated event count and denominator. It does not decide which patient encounters meet a syndrome definition.

### Wastewater/environmental concentration

`adapt_concentration` preserves the distinction between wastewater and other environmental aggregate sources and requires a canonical aggregate unit. Raw assay/genomic payloads remain outside the contract.

### Capacity fraction

`adapt_capacity_fraction` requires explicit `Available` versus `Occupied` semantics and encodes those meanings as `fraction_available` / `fraction_occupied` rather than silently conflating them.

## Uncertainty boundary

The adapter never manufactures confidence intervals/probabilities. Every input supplies a `BoundedUncertainty`, and `health-surveillance-core` verifies that the estimate is finite, admissible, and inside that interval.

Statistical uncertainty estimation remains part of separately reviewed source/protocol implementations.

## Authority/lineage boundary

Adapters preserve provenance and independence-group claims but do not authenticate them. Producer authority/status (#12-#14) and signed lineage evidence (#15-#16) remain separate layers.

## Tests

Covers:

- aggregate laboratory fraction construction;
- impossible fraction counts;
- uncertainty not covering a computed estimate;
- syndromic per-100k conversion;
- wastewater/environmental source separation;
- available/occupied capacity semantics;
- zero denominator/sample failure;
- invalid reporting time.

## Qualification

Adds a focused workflow for:

- formatting;
- host tests;
- Clippy with warnings denied;
- doc tests;
- `wasm32-unknown-unknown` compatibility.

The workflow permits stacked PR bases. No merge-ready claim until the exact head is green.

## Explicit non-goals

No raw FHIR/patient ingestion, de-identification of raw datasets, diagnosis, treatment, outbreak declaration, emergency authority, pathogen engineering/design, source-independence proof, or autonomous Symthaea action.

## Next

After executable qualification stabilizes the released-observation schema, extract the shared release-record wire contract. Then add reviewed source-specific frontends (for example a clinical/FHIR aggregate producer that performs aggregation inside the private clinical boundary) and begin the first conservative Symthaea evidence consumer.