### PR TITLE
feat(health): establish Clinical Semantics Kernel v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "crates/hdc-core",
     "crates/hdc-experiments",
     "crates/health-validation",
+    "crates/clinical-semantics",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",
@@ -119,4 +120,3 @@ todo = "deny"
 unimplemented = "deny"
 eq_op = "deny"
 cast_ptr_alignment = "deny"
-

--- a/crates/clinical-semantics/Cargo.toml
+++ b/crates/clinical-semantics/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mycelix-clinical-semantics"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Typed clinical semantics and safety invariants for Mycelix-Health"
+
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/clinical-semantics/src/lib.rs
+++ b/crates/clinical-semantics/src/lib.rs
@@ -1,0 +1,613 @@
+#![deny(unsafe_code)]
+//! Typed clinical semantics and safety invariants for Mycelix-Health.
+//!
+//! This crate deliberately has no Holochain or transport dependency. Adapters may
+//! be permissive while parsing external data, but a clinical fact must satisfy
+//! [`ClinicalFact::validate_machine_actionable`] before downstream code may treat
+//! it as machine-actionable clinical data.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Canonical UCUM system URI used by FHIR quantities.
+pub const UCUM_SYSTEM: &str = "http://unitsofmeasure.org";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Coding {
+    pub system: String,
+    pub code: String,
+    pub display: Option<String>,
+    pub version: Option<String>,
+}
+
+impl Coding {
+    fn validate(&self) -> Result<(), ClinicalSemanticsError> {
+        if self.system.trim().is_empty() {
+            return Err(ClinicalSemanticsError::MissingCodingSystem);
+        }
+        if self.code.trim().is_empty() {
+            return Err(ClinicalSemanticsError::MissingCodingCode);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodeableConcept {
+    pub coding: Vec<Coding>,
+    pub text: Option<String>,
+}
+
+impl CodeableConcept {
+    pub fn validate_machine_actionable(&self) -> Result<(), ClinicalSemanticsError> {
+        if self.coding.is_empty() {
+            return Err(ClinicalSemanticsError::UncodedConcept);
+        }
+        for coding in &self.coding {
+            coding.validate()?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SubjectRef {
+    pub resource_type: String,
+    pub id: String,
+}
+
+impl SubjectRef {
+    fn validate(&self) -> Result<(), ClinicalSemanticsError> {
+        if self.resource_type.trim().is_empty() || self.id.trim().is_empty() {
+            return Err(ClinicalSemanticsError::InvalidSubject);
+        }
+        Ok(())
+    }
+}
+
+/// Quantitative clinical data with both display text and a computable unit code.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Quantity {
+    pub value: f64,
+    pub display_unit: Option<String>,
+    pub system: String,
+    pub code: String,
+}
+
+impl Quantity {
+    /// Construct an explicitly UCUM-bound quantity.
+    pub fn ucum(value: f64, code: impl Into<String>) -> Self {
+        let code = code.into();
+        Self {
+            value,
+            display_unit: Some(code.clone()),
+            system: UCUM_SYSTEM.to_string(),
+            code,
+        }
+    }
+
+    /// Enforce the strict quantity contract used for computation.
+    pub fn validate_machine_actionable(&self) -> Result<(), ClinicalSemanticsError> {
+        if !self.value.is_finite() {
+            return Err(ClinicalSemanticsError::NonFiniteNumber);
+        }
+        if self.system != UCUM_SYSTEM {
+            return Err(ClinicalSemanticsError::NonUcumQuantity {
+                system: self.system.clone(),
+            });
+        }
+        if self.code.trim().is_empty() {
+            return Err(ClinicalSemanticsError::MissingUnitCode);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Range {
+    pub low: Option<Quantity>,
+    pub high: Option<Quantity>,
+}
+
+impl Range {
+    fn validate_machine_actionable(&self) -> Result<(), ClinicalSemanticsError> {
+        if self.low.is_none() && self.high.is_none() {
+            return Err(ClinicalSemanticsError::EmptyRange);
+        }
+        if let Some(low) = &self.low {
+            low.validate_machine_actionable()?;
+        }
+        if let Some(high) = &self.high {
+            high.validate_machine_actionable()?;
+        }
+        if let (Some(low), Some(high)) = (&self.low, &self.high) {
+            if low.system != high.system || low.code != high.code {
+                return Err(ClinicalSemanticsError::IncompatibleRangeUnits);
+            }
+            if low.value > high.value {
+                return Err(ClinicalSemanticsError::InvertedRange);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Ratio {
+    pub numerator: Quantity,
+    pub denominator: Quantity,
+}
+
+impl Ratio {
+    fn validate_machine_actionable(&self) -> Result<(), ClinicalSemanticsError> {
+        self.numerator.validate_machine_actionable()?;
+        self.denominator.validate_machine_actionable()?;
+        if self.denominator.value == 0.0 {
+            return Err(ClinicalSemanticsError::ZeroRatioDenominator);
+        }
+        Ok(())
+    }
+}
+
+/// Clinical value algebra. Narrative data is preserved explicitly rather than
+/// coerced into a typed value.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum ClinicalValue {
+    Quantity(Quantity),
+    CodeableConcept(CodeableConcept),
+    Range(Range),
+    Ratio(Ratio),
+    Boolean(bool),
+    Integer(i64),
+    Decimal(f64),
+    DateTimeMicros(i64),
+    Reference(SubjectRef),
+    Narrative {
+        text: String,
+        reason_not_typed: String,
+    },
+}
+
+impl ClinicalValue {
+    pub fn validate_machine_actionable(&self) -> Result<(), ClinicalSemanticsError> {
+        match self {
+            Self::Quantity(value) => value.validate_machine_actionable(),
+            Self::CodeableConcept(value) => value.validate_machine_actionable(),
+            Self::Range(value) => value.validate_machine_actionable(),
+            Self::Ratio(value) => value.validate_machine_actionable(),
+            Self::Boolean(_) | Self::Integer(_) | Self::DateTimeMicros(_) => Ok(()),
+            Self::Decimal(value) if value.is_finite() => Ok(()),
+            Self::Decimal(_) => Err(ClinicalSemanticsError::NonFiniteNumber),
+            Self::Reference(value) => value.validate(),
+            Self::Narrative { .. } => Err(ClinicalSemanticsError::NarrativeOnly),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TransformationProvenance {
+    pub software: String,
+    pub version: String,
+    pub operation: String,
+    pub input_fact_ids: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FactProvenance {
+    pub source_system: String,
+    pub source_resource_type: String,
+    pub source_resource_id: String,
+    pub source_version: Option<String>,
+    pub recorded_at_micros: i64,
+    pub asserted_by: Option<String>,
+    pub transformation: Option<TransformationProvenance>,
+}
+
+impl FactProvenance {
+    fn validate(&self) -> Result<(), ClinicalSemanticsError> {
+        if self.source_system.trim().is_empty()
+            || self.source_resource_type.trim().is_empty()
+            || self.source_resource_id.trim().is_empty()
+        {
+            return Err(ClinicalSemanticsError::IncompleteProvenance);
+        }
+        if let Some(transformation) = &self.transformation {
+            if transformation.software.trim().is_empty()
+                || transformation.version.trim().is_empty()
+                || transformation.operation.trim().is_empty()
+            {
+                return Err(ClinicalSemanticsError::IncompleteTransformationProvenance);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Uncertainty {
+    /// Optional calibrated probability/confidence. None means no calibrated
+    /// numerical confidence is claimed.
+    pub confidence: Option<f64>,
+    pub interpretation: Option<String>,
+}
+
+impl Uncertainty {
+    fn validate(&self) -> Result<(), ClinicalSemanticsError> {
+        if let Some(confidence) = self.confidence {
+            if !confidence.is_finite() || !(0.0..=1.0).contains(&confidence) {
+                return Err(ClinicalSemanticsError::InvalidConfidence);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Minimum semantic unit permitted at a strict clinical trust boundary.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ClinicalFact {
+    pub fact_id: String,
+    pub subject: SubjectRef,
+    pub concept: CodeableConcept,
+    pub value: ClinicalValue,
+    /// Time the underlying clinical event/measurement occurred, distinct from
+    /// provenance.recorded_at_micros.
+    pub effective_at_micros: i64,
+    pub provenance: FactProvenance,
+    pub uncertainty: Option<Uncertainty>,
+}
+
+impl ClinicalFact {
+    pub fn validate_machine_actionable(&self) -> Result<(), ClinicalSemanticsError> {
+        if self.fact_id.trim().is_empty() {
+            return Err(ClinicalSemanticsError::MissingFactId);
+        }
+        self.subject.validate()?;
+        self.concept.validate_machine_actionable()?;
+        self.value.validate_machine_actionable()?;
+        self.provenance.validate()?;
+        if let Some(uncertainty) = &self.uncertainty {
+            uncertainty.validate()?;
+        }
+        Ok(())
+    }
+}
+
+/// Four-state evaluation prevents missing information from becoming false
+/// evidence for or against a clinical criterion.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum EvaluationState {
+    Satisfied,
+    NotSatisfied,
+    Indeterminate,
+    NotApplicable,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EvaluationResult {
+    pub state: EvaluationState,
+    pub reasons: Vec<String>,
+    pub evidence_fact_ids: Vec<String>,
+    pub missing_requirements: Vec<String>,
+}
+
+impl EvaluationResult {
+    pub fn indeterminate(requirement: impl Into<String>) -> Self {
+        Self {
+            state: EvaluationState::Indeterminate,
+            reasons: Vec::new(),
+            evidence_fact_ids: Vec::new(),
+            missing_requirements: vec![requirement.into()],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SubjectBinding {
+    Match,
+    Mismatch { expected: String, found: String },
+    Unresolved {
+        reference: Option<String>,
+        reason: UnresolvedReferenceReason,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum UnresolvedReferenceReason {
+    MissingReference,
+    UnsupportedReferenceForm,
+    WrongResourceType,
+}
+
+/// Resolve common FHIR R4 patient reference forms without guessing.
+///
+/// Relative (`Patient/123`) and absolute (`https://ehr/fhir/Patient/123`) forms
+/// are compared directly. URN and contained references require Bundle context,
+/// so they remain explicitly unresolved for a caller to resolve or quarantine.
+pub fn bind_fhir_patient_reference(
+    reference: Option<&str>,
+    expected_patient_id: &str,
+) -> SubjectBinding {
+    let Some(reference) = reference.map(str::trim).filter(|value| !value.is_empty()) else {
+        return SubjectBinding::Unresolved {
+            reference: None,
+            reason: UnresolvedReferenceReason::MissingReference,
+        };
+    };
+
+    if reference.starts_with("urn:") || reference.starts_with('#') {
+        return SubjectBinding::Unresolved {
+            reference: Some(reference.to_string()),
+            reason: UnresolvedReferenceReason::UnsupportedReferenceForm,
+        };
+    }
+
+    let without_query = reference.split('?').next().unwrap_or(reference);
+    let without_fragment = without_query.split('#').next().unwrap_or(without_query);
+    let segments: Vec<&str> = without_fragment
+        .trim_end_matches('/')
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+
+    if segments.len() == 2 && segments[0] != "Patient" {
+        return SubjectBinding::Unresolved {
+            reference: Some(reference.to_string()),
+            reason: UnresolvedReferenceReason::WrongResourceType,
+        };
+    }
+
+    let patient_id = segments
+        .windows(2)
+        .find(|pair| pair[0] == "Patient")
+        .map(|pair| pair[1]);
+
+    match patient_id {
+        Some(id) if id == expected_patient_id => SubjectBinding::Match,
+        Some(id) => SubjectBinding::Mismatch {
+            expected: expected_patient_id.to_string(),
+            found: id.to_string(),
+        },
+        None => SubjectBinding::Unresolved {
+            reference: Some(reference.to_string()),
+            reason: UnresolvedReferenceReason::UnsupportedReferenceForm,
+        },
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ClinicalSemanticsError {
+    #[error("clinical fact id is required")]
+    MissingFactId,
+    #[error("clinical subject must have resource type and id")]
+    InvalidSubject,
+    #[error("machine-actionable concept requires at least one coding")]
+    UncodedConcept,
+    #[error("coding system is required")]
+    MissingCodingSystem,
+    #[error("coding code is required")]
+    MissingCodingCode,
+    #[error("numeric clinical value must be finite")]
+    NonFiniteNumber,
+    #[error("machine-actionable quantity requires UCUM; got {system}")]
+    NonUcumQuantity { system: String },
+    #[error("machine-actionable quantity requires a UCUM code")]
+    MissingUnitCode,
+    #[error("range requires at least one bound")]
+    EmptyRange,
+    #[error("range bounds must use the same unit encoding")]
+    IncompatibleRangeUnits,
+    #[error("range low bound exceeds high bound")]
+    InvertedRange,
+    #[error("ratio denominator cannot be zero")]
+    ZeroRatioDenominator,
+    #[error("narrative value is not machine-actionable")]
+    NarrativeOnly,
+    #[error("source provenance is incomplete")]
+    IncompleteProvenance,
+    #[error("transformation provenance is incomplete")]
+    IncompleteTransformationProvenance,
+    #[error("confidence must be finite and between 0 and 1")]
+    InvalidConfidence,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn glucose_concept() -> CodeableConcept {
+        CodeableConcept {
+            coding: vec![Coding {
+                system: "http://loinc.org".into(),
+                code: "14771-0".into(),
+                display: Some("Glucose [Moles/volume] in Serum or Plasma".into()),
+                version: None,
+            }],
+            text: Some("Glucose".into()),
+        }
+    }
+
+    fn valid_fact() -> ClinicalFact {
+        ClinicalFact {
+            fact_id: "fact-1".into(),
+            subject: SubjectRef {
+                resource_type: "Patient".into(),
+                id: "patient-a".into(),
+            },
+            concept: glucose_concept(),
+            value: ClinicalValue::Quantity(Quantity::ucum(5.5, "mmol/L")),
+            effective_at_micros: 1_700_000_000_000_000,
+            provenance: FactProvenance {
+                source_system: "https://ehr.example/fhir".into(),
+                source_resource_type: "Observation".into(),
+                source_resource_id: "obs-1".into(),
+                source_version: Some("7".into()),
+                recorded_at_micros: 1_700_000_000_100_000,
+                asserted_by: Some("Practitioner/123".into()),
+                transformation: Some(TransformationProvenance {
+                    software: "mycelix-fhir-bridge".into(),
+                    version: "1".into(),
+                    operation: "FHIR R4 Observation -> ClinicalFact".into(),
+                    input_fact_ids: vec![],
+                }),
+            },
+            uncertainty: None,
+        }
+    }
+
+    #[test]
+    fn valid_ucum_fact_is_machine_actionable() {
+        assert_eq!(valid_fact().validate_machine_actionable(), Ok(()));
+    }
+
+    #[test]
+    fn display_only_unit_is_rejected() {
+        let mut fact = valid_fact();
+        fact.value = ClinicalValue::Quantity(Quantity {
+            value: 5.5,
+            display_unit: Some("mmol/L".into()),
+            system: String::new(),
+            code: String::new(),
+        });
+        assert!(matches!(
+            fact.validate_machine_actionable(),
+            Err(ClinicalSemanticsError::NonUcumQuantity { .. })
+        ));
+    }
+
+    #[test]
+    fn non_finite_number_is_rejected() {
+        let mut fact = valid_fact();
+        fact.value = ClinicalValue::Quantity(Quantity::ucum(f64::NAN, "mmol/L"));
+        assert_eq!(
+            fact.validate_machine_actionable(),
+            Err(ClinicalSemanticsError::NonFiniteNumber)
+        );
+    }
+
+    #[test]
+    fn narrative_is_preserved_but_not_promoted() {
+        let mut fact = valid_fact();
+        fact.value = ClinicalValue::Narrative {
+            text: "five point five".into(),
+            reason_not_typed: "source supplied only free text".into(),
+        };
+        assert_eq!(
+            fact.validate_machine_actionable(),
+            Err(ClinicalSemanticsError::NarrativeOnly)
+        );
+    }
+
+    #[test]
+    fn uncoded_concept_is_rejected() {
+        let mut fact = valid_fact();
+        fact.concept = CodeableConcept {
+            coding: vec![],
+            text: Some("Glucose".into()),
+        };
+        assert_eq!(
+            fact.validate_machine_actionable(),
+            Err(ClinicalSemanticsError::UncodedConcept)
+        );
+    }
+
+    #[test]
+    fn range_units_must_match() {
+        let range = Range {
+            low: Some(Quantity::ucum(3.0, "mmol/L")),
+            high: Some(Quantity::ucum(180.0, "mg/dL")),
+        };
+        assert_eq!(
+            range.validate_machine_actionable(),
+            Err(ClinicalSemanticsError::IncompatibleRangeUnits)
+        );
+    }
+
+    #[test]
+    fn relative_cross_patient_reference_is_mismatch() {
+        assert_eq!(
+            bind_fhir_patient_reference(Some("Patient/patient-b"), "patient-a"),
+            SubjectBinding::Mismatch {
+                expected: "patient-a".into(),
+                found: "patient-b".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn absolute_patient_reference_is_comparable() {
+        assert_eq!(
+            bind_fhir_patient_reference(
+                Some("https://ehr.example/fhir/Patient/patient-a"),
+                "patient-a"
+            ),
+            SubjectBinding::Match
+        );
+    }
+
+    #[test]
+    fn historical_absolute_cross_patient_reference_is_mismatch() {
+        assert_eq!(
+            bind_fhir_patient_reference(
+                Some("https://ehr.example/fhir/Patient/patient-b/_history/7"),
+                "patient-a"
+            ),
+            SubjectBinding::Mismatch {
+                expected: "patient-a".into(),
+                found: "patient-b".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn urn_reference_is_explicitly_unresolved() {
+        assert_eq!(
+            bind_fhir_patient_reference(Some("urn:uuid:abc"), "patient-a"),
+            SubjectBinding::Unresolved {
+                reference: Some("urn:uuid:abc".into()),
+                reason: UnresolvedReferenceReason::UnsupportedReferenceForm,
+            }
+        );
+    }
+
+    #[test]
+    fn missing_reference_is_explicitly_unresolved() {
+        assert_eq!(
+            bind_fhir_patient_reference(None, "patient-a"),
+            SubjectBinding::Unresolved {
+                reference: None,
+                reason: UnresolvedReferenceReason::MissingReference,
+            }
+        );
+    }
+
+    #[test]
+    fn wrong_resource_type_is_not_treated_as_patient() {
+        assert_eq!(
+            bind_fhir_patient_reference(Some("Group/cohort-a"), "patient-a"),
+            SubjectBinding::Unresolved {
+                reference: Some("Group/cohort-a".into()),
+                reason: UnresolvedReferenceReason::WrongResourceType,
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_confidence_is_rejected() {
+        let mut fact = valid_fact();
+        fact.uncertainty = Some(Uncertainty {
+            confidence: Some(1.2),
+            interpretation: None,
+        });
+        assert_eq!(
+            fact.validate_machine_actionable(),
+            Err(ClinicalSemanticsError::InvalidConfidence)
+        );
+    }
+
+    #[test]
+    fn indeterminate_preserves_missing_requirement() {
+        let result = EvaluationResult::indeterminate("HbA1c within 90 days");
+        assert_eq!(result.state, EvaluationState::Indeterminate);
+        assert_eq!(result.missing_requirements, vec!["HbA1c within 90 days"]);
+    }
+}

--- a/docs/CLINICAL_SEMANTICS_KERNEL_V1.md
+++ b/docs/CLINICAL_SEMANTICS_KERNEL_V1.md
@@ -1,0 +1,166 @@
+# Clinical Semantics Kernel v1
+
+Status: proposed executable contract
+
+## Purpose
+
+This document defines the minimum semantic contract that every clinical value crossing a Mycelix-Health trust boundary must satisfy before it can be treated as machine-actionable clinical data.
+
+The goal is to prevent syntactically valid but clinically ambiguous data from silently entering records, decision support, trials, or research pipelines.
+
+## Core invariant
+
+A machine-actionable clinical assertion MUST bind:
+
+1. a subject,
+2. a typed value,
+3. a clinical concept,
+4. an effective time,
+5. provenance,
+6. units when the value is quantitative,
+7. an explicit uncertainty / interpretation state when applicable.
+
+If the system cannot establish those bindings, the value MUST remain narrative-only or be rejected at a stricter boundary. It MUST NOT be silently promoted into a typed clinical fact.
+
+## ClinicalValue algebra
+
+The shared representation should converge on the following semantic forms:
+
+- `Quantity { value, unit, system, code }`
+- `CodeableConcept { codings, text }`
+- `Range { low, high }`
+- `Ratio { numerator, denominator }`
+- `Boolean`
+- `Integer`
+- `Decimal`
+- `DateTime`
+- `Reference { resource_type, id }`
+- `Narrative { text, reason_not_typed }`
+
+`Narrative` is intentionally a fallback. It is never equivalent to a typed value.
+
+## Quantity rules
+
+A quantitative value intended for computation MUST NOT be represented as a bare number or a number plus display-only unit text.
+
+The preferred representation is UCUM-bound:
+
+```text
+value: 5.5
+unit: "mmol/L"
+system: "http://unitsofmeasure.org"
+code: "mmol/L"
+```
+
+At ingestion boundaries:
+
+- missing unit on a unit-bearing concept is `Indeterminate` or invalid according to the profile,
+- unknown unit systems are not normalized by guessing,
+- conversion must preserve the original value/unit as provenance,
+- conversion must record the conversion function/version,
+- incompatible dimensions are rejected.
+
+## Subject binding
+
+Every imported clinical resource MUST be bound to the expected patient/subject before persistence.
+
+A resource with an unambiguous subject reference that conflicts with the target patient MUST be rejected.
+
+A resource whose subject cannot be resolved MUST NOT be silently attached to the target patient. It may be quarantined as `UnresolvedReference` for explicit reconciliation.
+
+This deliberately strengthens the current permissive behavior for references that cannot be compared reliably.
+
+## Coded concepts
+
+Clinical concepts should use established coding systems where available, including:
+
+- LOINC for observations/labs,
+- SNOMED CT for clinical concepts where licensing/deployment permits,
+- RxNorm for US medication concepts,
+- ICD only where classification/billing semantics are actually intended,
+- UCUM for units.
+
+Display strings are not stable identifiers.
+
+## Provenance
+
+Every machine-actionable clinical fact MUST carry or resolve to provenance sufficient to answer:
+
+- where did this value originate?
+- who or what asserted it?
+- when was it observed vs recorded?
+- which source resource/version produced it?
+- which transformation produced the current representation?
+- what software/schema/profile version performed that transformation?
+
+Derived facts MUST additionally bind their input fact identifiers.
+
+## Four-state evaluation
+
+Clinical logic MUST prefer four-state outcomes over unsafe booleans:
+
+- `Satisfied`
+- `NotSatisfied`
+- `Indeterminate`
+- `NotApplicable`
+
+Missing data is not evidence of absence.
+
+This applies especially to trial eligibility, contraindications, quality measures, and decision support.
+
+## FHIR R4 ingestion contract
+
+For FHIR R4 imports:
+
+1. validate resource type and profile expectations,
+2. resolve the expected subject,
+3. preserve resource id and source system,
+4. prefer native typed `value[x]` forms over string coercion,
+5. preserve `valueQuantity.value`, `unit`, `system`, and `code`,
+6. preserve coding system + code + display for coded concepts,
+7. preserve effective time separately from ingestion time,
+8. record parsing/normalization provenance,
+9. reject unambiguous cross-patient references,
+10. quarantine unresolved subject references at strict clinical boundaries.
+
+## Trial semantics
+
+Free-text inclusion/exclusion criteria remain useful for human-readable protocol text, but MUST NOT be the authoritative executable eligibility representation.
+
+A future computable criterion should bind:
+
+- criterion id,
+- human-readable text,
+- computable expression reference (CQL where appropriate),
+- required facts/concepts,
+- temporal window,
+- unit expectations,
+- missing-data behavior,
+- protocol version.
+
+Eligibility results should use the four-state model above and include reasons/evidence.
+
+## Evidence capsule boundary
+
+Any decision-support output that could materially influence care SHOULD bind an evidence capsule containing:
+
+- intended use,
+- patient/context inputs,
+- missing inputs,
+- knowledge artifact and version,
+- algorithm/model and version,
+- output and uncertainty,
+- contraindications / exclusions checked,
+- known limitations,
+- execution timestamp,
+- approval/escalation requirement.
+
+## Non-goals
+
+This contract does not claim regulatory compliance, clinical validity, or autonomous diagnostic authority.
+
+It is a semantic safety floor on which those higher assurance claims can later be built and independently validated.
+
+## Promotion gate
+
+No new clinical feature should be promoted to a higher assurance tier merely because it compiles or passes schema validation. Promotion requires evidence that semantic invariants are enforced under malformed, missing, contradictory, cross-subject, and unit-sensitive inputs.

--- a/tests/clinical-semantics/fhir-observation-cross-patient.json
+++ b/tests/clinical-semantics/fhir-observation-cross-patient.json
@@ -1,0 +1,35 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "patient-a"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Observation",
+        "id": "obs-cross-patient",
+        "status": "final",
+        "subject": { "reference": "Patient/patient-b" },
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "2345-7",
+              "display": "Glucose [Mass/volume] in Serum or Plasma"
+            }
+          ]
+        },
+        "valueQuantity": {
+          "value": 5.5,
+          "unit": "mmol/L",
+          "system": "http://unitsofmeasure.org",
+          "code": "mmol/L"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Why

Mycelix-Health already has broad clinical functionality, but several boundaries still permit syntactically valid data to remain semantically ambiguous. Recent FHIR bridge hardening exposed exactly this risk class: patient-reference binding and quantitative-unit preservation can be safety-significant even when JSON/schema handling succeeds.

This PR establishes a small, transport-independent semantic kernel before adding more clinical surface area.

## What this adds

- `crates/clinical-semantics` as a workspace member
- typed clinical value algebra for quantities, coded concepts, ranges, ratios, booleans, integers, decimals, dates, references, and narrative fallback
- strict machine-actionability validation
- UCUM-bound quantitative semantics (`http://unitsofmeasure.org` + code), rejecting display-only units
- finite-number checks, range/unit consistency, nonzero ratio denominators
- required coded concepts for machine-actionable facts
- subject + source provenance + transformation provenance bindings
- bounded uncertainty/confidence semantics
- four-state evaluation: `Satisfied`, `NotSatisfied`, `Indeterminate`, `NotApplicable`
- FHIR patient-reference binding that distinguishes `Match`, `Mismatch`, and `Unresolved` rather than treating unresolved identity as success
- tests for cross-patient references, absolute/history references, URNs, missing references, unit ambiguity, narrative fallback, coding, uncertainty, and indeterminate criteria
- `docs/CLINICAL_SEMANTICS_KERNEL_V1.md` describing the intended safety contract
- adversarial cross-patient FHIR fixture for the next bridge-conformance tranche

## Central invariant

A machine-actionable clinical fact must bind a subject, coded concept, typed value, effective time, and provenance. Quantities used computationally must be UCUM-coded. Missing/unresolved information is represented explicitly rather than guessed or collapsed into a boolean.

## Deliberate non-goals

- no claim of regulatory compliance or clinical validity
- no autonomous diagnostic authority
- no FHIR bridge behavior change in this PR yet
- no resurrection of the archived trial-matching zome

The archived matcher already had a useful `Indeterminate` state, but its lab values and criterion targets remained stringly typed. This PR extracts the good epistemic state model without restoring that ambiguity.

## Next stack

1. qualify this pure kernel on exact-head CI
2. adapt FHIR Observation ingestion to produce/validate kernel facts
3. quarantine unresolved subject references at strict ingest boundaries
4. add golden/negative FHIR conformance fixtures for quantity and subject semantics
5. migrate executable trial criteria onto typed facts + four-state evaluation

## Review focus

Please treat semantic correctness as the primary review axis: missing data must not become absence, display strings must not become unit identity, and unresolved subject identity must not become implicit authorization to attach data.