### PR TITLE
feat(health): add typed medication-order semantics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "crates/clinical-evidence",
     "crates/clinical-promotion",
     "crates/fhir-conformance",
+    "crates/medication-semantics",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/medication-semantics/Cargo.toml
+++ b/crates/medication-semantics/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mycelix-medication-semantics"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Typed medication-order and dosage semantics for Mycelix-Health"
+
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-semantics = { path = "../clinical-semantics" }

--- a/crates/medication-semantics/src/lib.rs
+++ b/crates/medication-semantics/src/lib.rs
@@ -1,0 +1,582 @@
+#![deny(unsafe_code)]
+//! Typed medication-order semantics for Mycelix-Health.
+//!
+//! This crate separates a structured medication request from free-text SIG
+//! instructions and, critically, separates FHIR request *intent* from clinical
+//! authority. An `order` intent can be an order-like request, but this crate does
+//! not verify practitioner credentials or authorize dispensing/administration.
+
+use mycelix_clinical_semantics::{
+    ClinicalSemanticsError, ClinicalValue, CodeableConcept, Quantity, Range, Ratio, SubjectRef,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MedicationRequestStatus {
+    Active,
+    OnHold,
+    Cancelled,
+    Completed,
+    EnteredInError,
+    Stopped,
+    Draft,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MedicationRequestIntent {
+    Proposal,
+    Plan,
+    Order,
+    OriginalOrder,
+    ReflexOrder,
+    FillerOrder,
+    InstanceOrder,
+    Option,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum MedicationWorkflowClass {
+    /// Suggestion/request that does not itself represent an active order.
+    NonAuthorizingProposal,
+    /// Planned future action, not an active medication order.
+    NonAuthorizingPlan,
+    /// Optional order set choice, not an active medication order by itself.
+    NonAuthorizingOption,
+    /// Active order-like request. External practitioner authority still must be verified.
+    ActiveOrderIntent,
+    /// Order-like request currently on hold.
+    OnHoldOrderIntent,
+    /// Historical/inactive order-like request.
+    InactiveOrderIntent,
+    /// Draft has not crossed the order workflow boundary.
+    Draft,
+    /// Source explicitly says this request should never have existed.
+    EnteredInError,
+    /// Source cannot establish current status.
+    Unknown,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum DoseAmount {
+    Quantity(Quantity),
+    Range(Range),
+}
+
+impl DoseAmount {
+    fn validate(&self) -> Result<(), MedicationSemanticsError> {
+        match self {
+            Self::Quantity(quantity) => quantity.validate_machine_actionable()?,
+            Self::Range(range) => ClinicalValue::Range(range.clone()).validate_machine_actionable()?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum RateAmount {
+    Quantity(Quantity),
+    Range(Range),
+    Ratio(Ratio),
+}
+
+impl RateAmount {
+    fn validate(&self) -> Result<(), MedicationSemanticsError> {
+        match self {
+            Self::Quantity(quantity) => quantity.validate_machine_actionable()?,
+            Self::Range(range) => ClinicalValue::Range(range.clone()).validate_machine_actionable()?,
+            Self::Ratio(ratio) => ClinicalValue::Ratio(ratio.clone()).validate_machine_actionable()?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum AdministrationTiming {
+    /// Give exactly once.
+    OneTime,
+    /// Give `frequency` times per UCUM-coded period (e.g. 2 times / 1 day).
+    Scheduled {
+        frequency: u32,
+        period: Quantity,
+    },
+    /// Give only when the coded clinical indication applies.
+    AsNeeded {
+        indication: CodeableConcept,
+        min_interval: Option<Quantity>,
+    },
+}
+
+impl AdministrationTiming {
+    fn validate(&self) -> Result<(), MedicationSemanticsError> {
+        match self {
+            Self::OneTime => Ok(()),
+            Self::Scheduled { frequency, period } => {
+                if *frequency == 0 {
+                    return Err(MedicationSemanticsError::ZeroFrequency);
+                }
+                validate_time_quantity(period)
+            }
+            Self::AsNeeded {
+                indication,
+                min_interval,
+            } => {
+                indication.validate_machine_actionable()?;
+                if let Some(interval) = min_interval {
+                    validate_time_quantity(interval)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct DosageInstruction {
+    pub sequence: Option<i32>,
+    /// Human-readable SIG retained for display/audit. It is never a substitute
+    /// for the typed fields below at the strict machine-actionable boundary.
+    pub narrative_sig: Option<String>,
+    pub patient_instruction: Option<String>,
+    pub timing: AdministrationTiming,
+    pub route: CodeableConcept,
+    pub method: Option<CodeableConcept>,
+    pub site: Option<CodeableConcept>,
+    pub dose: DoseAmount,
+    pub rate: Option<RateAmount>,
+    pub max_dose_per_period: Option<Ratio>,
+    pub max_dose_per_administration: Option<Quantity>,
+    pub max_dose_per_lifetime: Option<Quantity>,
+}
+
+impl DosageInstruction {
+    pub fn validate_machine_actionable(&self) -> Result<(), MedicationSemanticsError> {
+        if matches!(self.sequence, Some(sequence) if sequence < 0) {
+            return Err(MedicationSemanticsError::InvalidSequence);
+        }
+        self.route.validate_machine_actionable()?;
+        if let Some(method) = &self.method {
+            method.validate_machine_actionable()?;
+        }
+        if let Some(site) = &self.site {
+            site.validate_machine_actionable()?;
+        }
+        self.dose.validate()?;
+        self.timing.validate()?;
+        if let Some(rate) = &self.rate {
+            rate.validate()?;
+        }
+        if let Some(maximum) = &self.max_dose_per_period {
+            ClinicalValue::Ratio(maximum.clone()).validate_machine_actionable()?;
+            validate_time_quantity(&maximum.denominator)?;
+        }
+        if let Some(maximum) = &self.max_dose_per_administration {
+            maximum.validate_machine_actionable()?;
+        }
+        if let Some(maximum) = &self.max_dose_per_lifetime {
+            maximum.validate_machine_actionable()?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RequesterAuthorityRef {
+    /// Practitioner/PractitionerRole/Organization reference supplied by the source.
+    pub requester_reference: String,
+    /// Optional Mycelix credential/attestation reference. Presence does not itself
+    /// prove validity; the authority layer must verify it before action.
+    pub credential_reference: Option<String>,
+}
+
+impl RequesterAuthorityRef {
+    fn validate(&self) -> Result<(), MedicationSemanticsError> {
+        if self.requester_reference.trim().is_empty() {
+            return Err(MedicationSemanticsError::MissingRequester);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MedicationOrderProvenance {
+    pub source_system: String,
+    pub source_resource_id: String,
+    pub source_version: Option<String>,
+    pub recorded_at_micros: i64,
+}
+
+impl MedicationOrderProvenance {
+    fn validate(&self) -> Result<(), MedicationSemanticsError> {
+        if self.source_system.trim().is_empty() || self.source_resource_id.trim().is_empty() {
+            return Err(MedicationSemanticsError::IncompleteProvenance);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct MedicationOrder {
+    pub order_id: String,
+    pub subject: SubjectRef,
+    pub medication: CodeableConcept,
+    /// Optional typed product strength such as 500 mg / 1 tablet.
+    pub product_strength: Option<Ratio>,
+    pub status: MedicationRequestStatus,
+    pub intent: MedicationRequestIntent,
+    pub dosage: Vec<DosageInstruction>,
+    pub dispense_quantity: Option<Quantity>,
+    pub refills_authorized: Option<u32>,
+    pub requester: Option<RequesterAuthorityRef>,
+    pub authored_at_micros: Option<i64>,
+    pub provenance: MedicationOrderProvenance,
+}
+
+impl MedicationOrder {
+    /// Validate that medication semantics are explicit enough for deterministic
+    /// interpretation. This does not prove clinical correctness or requester authority.
+    pub fn validate_machine_actionable(&self) -> Result<(), MedicationSemanticsError> {
+        if self.order_id.trim().is_empty() {
+            return Err(MedicationSemanticsError::MissingOrderId);
+        }
+        if self.subject.resource_type.trim().is_empty() || self.subject.id.trim().is_empty() {
+            return Err(MedicationSemanticsError::InvalidSubject);
+        }
+        self.medication.validate_machine_actionable()?;
+        self.provenance.validate()?;
+
+        if let Some(strength) = &self.product_strength {
+            ClinicalValue::Ratio(strength.clone()).validate_machine_actionable()?;
+        }
+        if let Some(quantity) = &self.dispense_quantity {
+            quantity.validate_machine_actionable()?;
+        }
+
+        // An active/on-hold order-like request with no typed dosage is unsafe to
+        // interpret even when a free-text SIG exists elsewhere.
+        if matches!(
+            self.workflow_class(),
+            MedicationWorkflowClass::ActiveOrderIntent | MedicationWorkflowClass::OnHoldOrderIntent
+        ) && self.dosage.is_empty()
+        {
+            return Err(MedicationSemanticsError::MissingTypedDosage);
+        }
+
+        for dosage in &self.dosage {
+            dosage.validate_machine_actionable()?;
+        }
+
+        if matches!(
+            self.workflow_class(),
+            MedicationWorkflowClass::ActiveOrderIntent | MedicationWorkflowClass::OnHoldOrderIntent
+        ) {
+            self.requester
+                .as_ref()
+                .ok_or(MedicationSemanticsError::MissingRequester)?
+                .validate()?;
+        }
+
+        Ok(())
+    }
+
+    /// Classify workflow meaning without pretending that a source `intent=order`
+    /// is itself cryptographic/legal proof of prescriber authority.
+    pub fn workflow_class(&self) -> MedicationWorkflowClass {
+        if self.status == MedicationRequestStatus::EnteredInError {
+            return MedicationWorkflowClass::EnteredInError;
+        }
+        if self.status == MedicationRequestStatus::Unknown {
+            return MedicationWorkflowClass::Unknown;
+        }
+        if self.status == MedicationRequestStatus::Draft {
+            return MedicationWorkflowClass::Draft;
+        }
+
+        match self.intent {
+            MedicationRequestIntent::Proposal => MedicationWorkflowClass::NonAuthorizingProposal,
+            MedicationRequestIntent::Plan => MedicationWorkflowClass::NonAuthorizingPlan,
+            MedicationRequestIntent::Option => MedicationWorkflowClass::NonAuthorizingOption,
+            MedicationRequestIntent::Order
+            | MedicationRequestIntent::OriginalOrder
+            | MedicationRequestIntent::ReflexOrder
+            | MedicationRequestIntent::FillerOrder
+            | MedicationRequestIntent::InstanceOrder => match self.status {
+                MedicationRequestStatus::Active => MedicationWorkflowClass::ActiveOrderIntent,
+                MedicationRequestStatus::OnHold => MedicationWorkflowClass::OnHoldOrderIntent,
+                MedicationRequestStatus::Cancelled
+                | MedicationRequestStatus::Completed
+                | MedicationRequestStatus::Stopped => MedicationWorkflowClass::InactiveOrderIntent,
+                MedicationRequestStatus::EnteredInError => MedicationWorkflowClass::EnteredInError,
+                MedicationRequestStatus::Draft => MedicationWorkflowClass::Draft,
+                MedicationRequestStatus::Unknown => MedicationWorkflowClass::Unknown,
+            },
+        }
+    }
+
+    /// Strict precondition for entering a later prescription-authority workflow.
+    /// The caller must still verify practitioner credentials, scope, signatures,
+    /// jurisdiction, and any controlled-substance requirements.
+    pub fn validate_active_order_candidate(&self) -> Result<(), MedicationSemanticsError> {
+        self.validate_machine_actionable()?;
+        if self.workflow_class() != MedicationWorkflowClass::ActiveOrderIntent {
+            return Err(MedicationSemanticsError::NotActiveOrderIntent);
+        }
+        Ok(())
+    }
+}
+
+fn validate_time_quantity(quantity: &Quantity) -> Result<(), MedicationSemanticsError> {
+    quantity.validate_machine_actionable()?;
+    if !matches!(quantity.code.as_str(), "s" | "min" | "h" | "d" | "wk" | "mo" | "a") {
+        return Err(MedicationSemanticsError::NonTimePeriodUnit(
+            quantity.code.clone(),
+        ));
+    }
+    if quantity.value <= 0.0 {
+        return Err(MedicationSemanticsError::NonPositiveTimePeriod);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum MedicationSemanticsError {
+    #[error("medication order id is required")]
+    MissingOrderId,
+    #[error("medication subject must have resource type and id")]
+    InvalidSubject,
+    #[error("active/on-hold order-like requests require typed dosage semantics")]
+    MissingTypedDosage,
+    #[error("active/on-hold order-like requests require a requester reference")]
+    MissingRequester,
+    #[error("medication order provenance is incomplete")]
+    IncompleteProvenance,
+    #[error("dosage sequence cannot be negative")]
+    InvalidSequence,
+    #[error("scheduled dosage frequency must be greater than zero")]
+    ZeroFrequency,
+    #[error("timing period must use a UCUM time unit, got {0}")]
+    NonTimePeriodUnit(String),
+    #[error("timing period must be positive")]
+    NonPositiveTimePeriod,
+    #[error("medication request is not an active order intent")]
+    NotActiveOrderIntent,
+    #[error(transparent)]
+    ClinicalSemantics(#[from] ClinicalSemanticsError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_semantics::{Coding, UCUM_SYSTEM};
+
+    fn concept(system: &str, code: &str) -> CodeableConcept {
+        CodeableConcept {
+            coding: vec![Coding {
+                system: system.into(),
+                code: code.into(),
+                display: None,
+                version: None,
+            }],
+            text: None,
+        }
+    }
+
+    fn quantity(value: f64, code: &str) -> Quantity {
+        Quantity {
+            value,
+            display_unit: Some(code.into()),
+            system: UCUM_SYSTEM.into(),
+            code: code.into(),
+        }
+    }
+
+    fn valid_order() -> MedicationOrder {
+        MedicationOrder {
+            order_id: "medreq-1".into(),
+            subject: SubjectRef {
+                resource_type: "Patient".into(),
+                id: "patient-a".into(),
+            },
+            medication: concept("http://www.nlm.nih.gov/research/umls/rxnorm", "860975"),
+            product_strength: Some(Ratio {
+                numerator: quantity(500.0, "mg"),
+                denominator: quantity(1.0, "{tablet}"),
+            }),
+            status: MedicationRequestStatus::Active,
+            intent: MedicationRequestIntent::Order,
+            dosage: vec![DosageInstruction {
+                sequence: Some(1),
+                narrative_sig: Some("Take one tablet twice daily".into()),
+                patient_instruction: None,
+                timing: AdministrationTiming::Scheduled {
+                    frequency: 2,
+                    period: quantity(1.0, "d"),
+                },
+                route: concept("http://snomed.info/sct", "26643006"),
+                method: None,
+                site: None,
+                dose: DoseAmount::Quantity(quantity(1.0, "{tablet}")),
+                rate: None,
+                max_dose_per_period: Some(Ratio {
+                    numerator: quantity(2.0, "{tablet}"),
+                    denominator: quantity(1.0, "d"),
+                }),
+                max_dose_per_administration: Some(quantity(1.0, "{tablet}")),
+                max_dose_per_lifetime: None,
+            }],
+            dispense_quantity: Some(quantity(60.0, "{tablet}")),
+            refills_authorized: Some(1),
+            requester: Some(RequesterAuthorityRef {
+                requester_reference: "Practitioner/123".into(),
+                credential_reference: Some("mycelix:credential:abc".into()),
+            }),
+            authored_at_micros: Some(1_700_000_000_000_000),
+            provenance: MedicationOrderProvenance {
+                source_system: "https://ehr.example/fhir".into(),
+                source_resource_id: "medreq-1".into(),
+                source_version: Some("7".into()),
+                recorded_at_micros: 1_700_000_000_100_000,
+            },
+        }
+    }
+
+    #[test]
+    fn typed_active_order_is_machine_actionable_candidate() {
+        let order = valid_order();
+        assert_eq!(order.validate_machine_actionable(), Ok(()));
+        assert_eq!(order.workflow_class(), MedicationWorkflowClass::ActiveOrderIntent);
+        assert_eq!(order.validate_active_order_candidate(), Ok(()));
+    }
+
+    #[test]
+    fn proposal_never_becomes_active_order_intent() {
+        let mut order = valid_order();
+        order.intent = MedicationRequestIntent::Proposal;
+        assert_eq!(
+            order.workflow_class(),
+            MedicationWorkflowClass::NonAuthorizingProposal
+        );
+        assert_eq!(
+            order.validate_active_order_candidate(),
+            Err(MedicationSemanticsError::NotActiveOrderIntent)
+        );
+    }
+
+    #[test]
+    fn entered_in_error_never_becomes_active_order_intent() {
+        let mut order = valid_order();
+        order.status = MedicationRequestStatus::EnteredInError;
+        assert_eq!(order.workflow_class(), MedicationWorkflowClass::EnteredInError);
+        assert_eq!(
+            order.validate_active_order_candidate(),
+            Err(MedicationSemanticsError::NotActiveOrderIntent)
+        );
+    }
+
+    #[test]
+    fn narrative_sig_cannot_replace_typed_dose_and_timing() {
+        let mut order = valid_order();
+        order.dosage.clear();
+        assert_eq!(
+            order.validate_machine_actionable(),
+            Err(MedicationSemanticsError::MissingTypedDosage)
+        );
+    }
+
+    #[test]
+    fn non_ucum_dose_is_rejected() {
+        let mut order = valid_order();
+        let DoseAmount::Quantity(dose) = &mut order.dosage[0].dose else {
+            panic!("expected quantity dose")
+        };
+        dose.system = "http://example.invalid/units".into();
+        assert!(matches!(
+            order.validate_machine_actionable(),
+            Err(MedicationSemanticsError::ClinicalSemantics(
+                ClinicalSemanticsError::NonUcumQuantity { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn zero_frequency_is_rejected() {
+        let mut order = valid_order();
+        order.dosage[0].timing = AdministrationTiming::Scheduled {
+            frequency: 0,
+            period: quantity(1.0, "d"),
+        };
+        assert_eq!(
+            order.validate_machine_actionable(),
+            Err(MedicationSemanticsError::ZeroFrequency)
+        );
+    }
+
+    #[test]
+    fn dose_unit_cannot_masquerade_as_timing_period() {
+        let mut order = valid_order();
+        order.dosage[0].timing = AdministrationTiming::Scheduled {
+            frequency: 2,
+            period: quantity(1.0, "mg"),
+        };
+        assert_eq!(
+            order.validate_machine_actionable(),
+            Err(MedicationSemanticsError::NonTimePeriodUnit("mg".into()))
+        );
+    }
+
+    #[test]
+    fn as_needed_timing_requires_coded_indication() {
+        let mut order = valid_order();
+        order.dosage[0].timing = AdministrationTiming::AsNeeded {
+            indication: CodeableConcept {
+                coding: vec![],
+                text: Some("when needed".into()),
+            },
+            min_interval: None,
+        };
+        assert!(matches!(
+            order.validate_machine_actionable(),
+            Err(MedicationSemanticsError::ClinicalSemantics(
+                ClinicalSemanticsError::UncodedConcept
+            ))
+        ));
+    }
+
+    #[test]
+    fn max_dose_period_denominator_must_be_time() {
+        let mut order = valid_order();
+        order.dosage[0].max_dose_per_period = Some(Ratio {
+            numerator: quantity(2.0, "{tablet}"),
+            denominator: quantity(1.0, "mg"),
+        });
+        assert_eq!(
+            order.validate_machine_actionable(),
+            Err(MedicationSemanticsError::NonTimePeriodUnit("mg".into()))
+        );
+    }
+
+    #[test]
+    fn on_hold_order_is_not_active_candidate() {
+        let mut order = valid_order();
+        order.status = MedicationRequestStatus::OnHold;
+        assert_eq!(
+            order.workflow_class(),
+            MedicationWorkflowClass::OnHoldOrderIntent
+        );
+        assert_eq!(
+            order.validate_active_order_candidate(),
+            Err(MedicationSemanticsError::NotActiveOrderIntent)
+        );
+    }
+
+    #[test]
+    fn active_order_requires_requester_reference() {
+        let mut order = valid_order();
+        order.requester = None;
+        assert_eq!(
+            order.validate_machine_actionable(),
+            Err(MedicationSemanticsError::MissingRequester)
+        );
+    }
+}

--- a/docs/MEDICATION_SEMANTICS_V1.md
+++ b/docs/MEDICATION_SEMANTICS_V1.md
@@ -1,0 +1,122 @@
+# Medication Semantics v1
+
+## Purpose
+
+`mycelix-medication-semantics` defines the minimum typed semantics required before a medication request may be treated as a machine-interpretable order candidate.
+
+It does **not** authorize prescribing, dispensing, administration, substitution, or autonomous treatment.
+
+## Why this exists
+
+The existing Mycelix prescription and FHIR mapping layers preserve useful medication information, but several safety-significant concepts can still be represented as free text: strength, SIG, timing, maximum dose, and quantity units. Free text is valuable for display and patient instructions, but it is not a safe computational identity.
+
+Medication semantics therefore follow the same rule established by the Clinical Semantics Kernel:
+
+> preserve narrative, but never silently promote narrative into machine-actionable meaning.
+
+## Core model
+
+A `MedicationOrder` binds:
+
+- patient/subject identity;
+- coded medication identity;
+- optional typed product strength;
+- FHIR MedicationRequest status;
+- FHIR MedicationRequest intent;
+- one or more typed dosage instructions for active/on-hold order-like requests;
+- optional typed dispense quantity;
+- refill count;
+- requester reference;
+- authored time when available;
+- source/version provenance.
+
+A `DosageInstruction` binds:
+
+- optional sequence;
+- narrative SIG for human display/audit;
+- patient instructions;
+- typed administration timing;
+- coded route;
+- optional coded method and site;
+- typed dose quantity/range;
+- optional typed administration rate;
+- optional maximum dose per period, administration, and lifetime.
+
+## Intent is not authority
+
+FHIR MedicationRequest intent is preserved rather than collapsed:
+
+- `proposal` -> non-authorizing proposal
+- `plan` -> non-authorizing plan
+- `option` -> non-authorizing option
+- order-like intents -> order workflow classification depending on status
+
+An active `intent=order` is only an **active order candidate**. It does not prove that the requester:
+
+- is a licensed practitioner;
+- holds the correct current credential;
+- is acting within scope of practice;
+- is authorized in the relevant jurisdiction;
+- has produced a valid required signature;
+- may prescribe the requested controlled substance;
+- has satisfied organizational policy.
+
+Those checks belong to a separate authority verifier. No downstream medication action should infer them from `MedicationRequest.intent` alone.
+
+## Typed timing
+
+v1 supports:
+
+- one-time administration;
+- scheduled administration as `frequency / UCUM-coded time period`;
+- as-needed administration with a coded indication and optional minimum interval.
+
+Scheduled frequency must be greater than zero. Time periods must be positive and use an explicit UCUM time code supported by v1.
+
+## Typed dose and rate
+
+Dose is represented as a `Quantity` or `Range` from the Clinical Semantics Kernel. Rate may be a `Quantity`, `Range`, or `Ratio`. Maximum dose per period uses a typed ratio whose denominator must itself be a valid time quantity.
+
+Display-only units are insufficient for machine actionability.
+
+## Workflow states
+
+`workflow_class()` deliberately distinguishes:
+
+- `NonAuthorizingProposal`
+- `NonAuthorizingPlan`
+- `NonAuthorizingOption`
+- `ActiveOrderIntent`
+- `OnHoldOrderIntent`
+- `InactiveOrderIntent`
+- `Draft`
+- `EnteredInError`
+- `Unknown`
+
+Only `ActiveOrderIntent` may pass `validate_active_order_candidate()`, and even then external authority verification is still required.
+
+## Safety invariants
+
+1. Active/on-hold order-like requests require typed dosage semantics.
+2. Active/on-hold order-like requests require an explicit requester reference.
+3. Narrative SIG does not substitute for typed dosage.
+4. Medication, route, method, site, and PRN indication are coded when used computationally.
+5. Quantities used computationally retain UCUM system + code.
+6. Scheduled time periods are positive and time-coded.
+7. Maximum-dose periods have a typed time denominator.
+8. `entered-in-error` cannot classify as an active order.
+9. `on-hold` cannot classify as active.
+10. FHIR request intent never substitutes for verified prescriber authority.
+
+## Next integration
+
+1. Add a strict FHIR R4 MedicationRequest -> `MedicationOrder` adapter.
+2. Resolve MedicationRequest subject/requester references using the same no-guessing policy as Observation ingestion.
+3. Add a practitioner authority verifier that produces an opaque prescribing-authority permit.
+4. Require both an `ActiveOrderIntent` and verified authority permit before order presentation/activation workflows.
+5. Adapt the existing prescription zome so new writes require typed medication semantics while preserving legacy entries for migration/audit.
+6. Add dosage normalization and comparison only after unit-conversion semantics are independently qualified.
+
+## Non-claims
+
+This crate does not establish clinical appropriateness, dose correctness, interaction safety, pharmacogenomic suitability, regulatory compliance, or authorization to prescribe/dispense/administer. It establishes a typed semantic boundary on which those later checks can safely depend.


### PR DESCRIPTION
## Stack

Depends on #35 -> #33 -> #32 -> #31 -> #30. Base is `feat/fhir-bundle-conformance-v1` so this PR isolates medication-order semantics.

## Why

Mycelix already preserves rich medication and FHIR mapping data, but several safety-significant fields can still be represented as strings: strength, SIG/timing, maximum dose, and quantity units. That is not strong enough for deterministic clinical interpretation.

## What this adds

- `crates/medication-semantics`
- typed medication identity via `CodeableConcept`
- typed product strength using a ratio
- exact FHIR MedicationRequest status + intent enums
- explicit workflow classification separating proposal, plan, option, active order intent, on-hold order intent, inactive order, draft, entered-in-error, and unknown
- typed dosage instructions with:
  - coded route/method/site
  - quantity/range dose
  - quantity/range/ratio rate
  - one-time, scheduled, or PRN timing
  - coded PRN indication
  - typed max dose per period/administration/lifetime
- UCUM-bound dose and timing quantities
- requester reference + optional credential reference
- source/version provenance
- `validate_active_order_candidate()` as a strict precondition for later authority verification
- tests for free-text-only dosage, bad units, zero frequency, malformed timing/max-dose periods, PRN coding, on-hold/entered-in-error behavior, and missing requester
- `docs/MEDICATION_SEMANTICS_V1.md`

## Central invariant

Narrative SIG is preserved for people and audit, but it cannot substitute for typed dosage semantics at a machine-actionable medication boundary.

## Authority boundary

FHIR `intent=order` is **not** treated as prescribing authority. An active order candidate must still pass a separate verifier for practitioner credential, scope, jurisdiction, signatures, organizational policy, and any controlled-substance requirements before an actionable prescribing/dispensing workflow may proceed.

## Migration policy

Legacy free-text prescription records remain readable for migration and audit. New machine-actionable paths should converge on the typed model rather than silently coercing legacy strings.

## Next

1. add strict FHIR R4 MedicationRequest -> `MedicationOrder` projection;
2. add verifier-owned prescribing-authority permit;
3. require both active-order semantics and verified authority at prescription activation/presentation boundaries;
4. adapt the existing prescription zome without rewriting historical entries;
5. add qualified unit normalization/conversion only after exact conversion semantics are separately tested.

## Non-claims

This PR does not establish dose appropriateness, drug-interaction safety, prescribing authority, regulatory compliance, or authorization to dispense/administer. It establishes typed medication-order semantics that later safety checks can depend on.