### PR TITLE
feat(health): add privacy-preserving clinical quarantine lineage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ members = [
     "crates/clinical-promotion",
     "crates/fhir-conformance",
     "crates/medication-semantics",
+    "crates/clinical-quarantine",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-quarantine/Cargo.toml
+++ b/crates/clinical-quarantine/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mycelix-clinical-quarantine"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Privacy-preserving quarantine and reconciliation lineage for rejected Mycelix-Health clinical inputs"
+
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-evidence = { path = "../clinical-evidence" }
+mycelix-fhir-conformance = { path = "../fhir-conformance" }
+mycelix-fhir-semantics = { path = "../fhir-semantics" }

--- a/crates/clinical-quarantine/Cargo.toml
+++ b/crates/clinical-quarantine/Cargo.toml
@@ -8,6 +8,5 @@ description = "Privacy-preserving quarantine and reconciliation lineage for reje
 [dependencies]
 serde = { workspace = true }
 thiserror = { workspace = true }
-mycelix-clinical-evidence = { path = "../clinical-evidence" }
 mycelix-fhir-conformance = { path = "../fhir-conformance" }
 mycelix-fhir-semantics = { path = "../fhir-semantics" }

--- a/crates/clinical-quarantine/src/lib.rs
+++ b/crates/clinical-quarantine/src/lib.rs
@@ -1,0 +1,698 @@
+#![deny(unsafe_code)]
+//! Privacy-preserving quarantine and reconciliation lineage for Mycelix-Health.
+//!
+//! The distributed quarantine record intentionally contains no raw clinical
+//! payload, patient identifier, source resource identifier, source-system URL,
+//! or free-form error text. Sensitive payload/context remain in a separate
+//! encrypted/local store. The shared record carries only typed reason codes,
+//! keyed commitments, artifact digests, state transitions, and authority lineage.
+
+use mycelix_fhir_conformance::{ConformanceIssue, ConformanceIssueKind};
+use mycelix_fhir_semantics::ProjectionIssueKind;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use thiserror::Error;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum DigestAlgorithm {
+    Sha256,
+    Blake3,
+}
+
+/// Public integrity digest for non-sensitive artifacts such as a verifier binary,
+/// decision record, or prior public quarantine event.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct ArtifactDigest {
+    pub algorithm: DigestAlgorithm,
+    pub value: [u8; 32],
+}
+
+impl ArtifactDigest {
+    fn validate(&self) -> Result<(), QuarantineError> {
+        if self.value == [0u8; 32] {
+            return Err(QuarantineError::ZeroArtifactDigest);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum CommitmentScheme {
+    HmacSha256,
+    Blake3Keyed,
+}
+
+/// Keyed commitment for potentially identifying material. A raw SHA-256 digest of
+/// a clinical payload is deliberately not representable here because deterministic
+/// public hashes can enable confirmation/dictionary attacks when an attacker has a
+/// candidate payload.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct OpaqueCommitment {
+    pub scheme: CommitmentScheme,
+    pub value: [u8; 32],
+}
+
+impl OpaqueCommitment {
+    fn validate(&self) -> Result<(), QuarantineError> {
+        if self.value == [0u8; 32] {
+            return Err(QuarantineError::ZeroOpaqueCommitment);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum QuarantineScope {
+    Bundle,
+    Resource,
+    ClinicalFact,
+    MedicationOrder,
+    EvidenceAssertion,
+}
+
+/// Stable machine-readable reason taxonomy. No free-text extension exists in v1;
+/// adding a new reason requires an explicit code change/review so PHI cannot leak
+/// through an "error message" field on a distributed record.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum QuarantineReasonCode {
+    EmptySourceProvenance,
+    WrongResourceType,
+    MissingBundleType,
+    UnsupportedBundleType,
+    MissingBundleEntries,
+    InvalidPatientIdentity,
+    MissingPatient,
+    MultiplePatients,
+    DuplicateResourceIdentity,
+    DuplicateFullUrlVersion,
+    VersionSpecificFullUrl,
+    MissingObservationId,
+    MissingObservationStatus,
+    NonPromotableObservationStatus,
+    MissingEffectiveTime,
+    UnsupportedEffectiveForm,
+    SubjectMismatch,
+    SubjectUnresolved,
+    InvalidObservation,
+    SemanticValidationFailure,
+    DuplicateFactIdentity,
+    MedicationSemanticsFailure,
+    AuthorityUnverified,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum QuarantineState {
+    Pending,
+    UnderReview,
+    ResolvedPromoted,
+    ResolvedDiscarded,
+}
+
+impl QuarantineState {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::ResolvedPromoted | Self::ResolvedDiscarded)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ResolutionEvidence {
+    /// Public digest of the exact decision artifact / reconciliation record.
+    pub decision_artifact_digest: ArtifactDigest,
+    /// Required only when a quarantined item is promoted after reconciliation.
+    pub promoted_artifact_digest: Option<ArtifactDigest>,
+}
+
+impl ResolutionEvidence {
+    fn validate_for_state(&self, state: QuarantineState) -> Result<(), QuarantineError> {
+        self.decision_artifact_digest.validate()?;
+        match state {
+            QuarantineState::ResolvedPromoted => {
+                self.promoted_artifact_digest
+                    .as_ref()
+                    .ok_or(QuarantineError::MissingPromotedArtifact)?
+                    .validate()?;
+            }
+            QuarantineState::ResolvedDiscarded => {
+                if self.promoted_artifact_digest.is_some() {
+                    return Err(QuarantineError::DiscardCannotPromoteArtifact);
+                }
+            }
+            QuarantineState::Pending | QuarantineState::UnderReview => {
+                return Err(QuarantineError::ResolutionOnNonTerminalState);
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Public/shared quarantine event.
+///
+/// `case_nonce` is random opaque case identity. `payload_commitment` must be
+/// computed with a secret-keyed scheme outside this crate. The secret key and raw
+/// payload never appear in this structure.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QuarantineEvent {
+    pub case_nonce: [u8; 16],
+    pub sequence: u32,
+    pub payload_commitment: OpaqueCommitment,
+    pub scope: QuarantineScope,
+    pub reasons: Vec<QuarantineReasonCode>,
+    pub state: QuarantineState,
+    pub recorded_at_micros: i64,
+    /// Public digest of the software/artifact that emitted this transition.
+    pub producer_artifact_digest: ArtifactDigest,
+    /// Digest of the immediately preceding public event. Required after sequence 0.
+    pub previous_event_digest: Option<ArtifactDigest>,
+    /// Opaque commitment to reviewer/authority identity. This permits later proof
+    /// without exposing a practitioner DID, NPI, agent key, or patient-visible name.
+    pub reviewer_authority_commitment: Option<OpaqueCommitment>,
+    pub resolution: Option<ResolutionEvidence>,
+}
+
+impl QuarantineEvent {
+    pub fn new_pending(
+        case_nonce: [u8; 16],
+        payload_commitment: OpaqueCommitment,
+        scope: QuarantineScope,
+        reasons: Vec<QuarantineReasonCode>,
+        producer_artifact_digest: ArtifactDigest,
+        recorded_at_micros: i64,
+    ) -> Result<Self, QuarantineError> {
+        let event = Self {
+            case_nonce,
+            sequence: 0,
+            payload_commitment,
+            scope,
+            reasons,
+            state: QuarantineState::Pending,
+            recorded_at_micros,
+            producer_artifact_digest,
+            previous_event_digest: None,
+            reviewer_authority_commitment: None,
+            resolution: None,
+        };
+        event.validate()?;
+        Ok(event)
+    }
+
+    pub fn begin_review(
+        previous: &Self,
+        previous_event_digest: ArtifactDigest,
+        producer_artifact_digest: ArtifactDigest,
+        reviewer_authority_commitment: OpaqueCommitment,
+        recorded_at_micros: i64,
+    ) -> Result<Self, QuarantineError> {
+        let next = Self {
+            case_nonce: previous.case_nonce,
+            sequence: previous
+                .sequence
+                .checked_add(1)
+                .ok_or(QuarantineError::SequenceOverflow)?,
+            payload_commitment: previous.payload_commitment,
+            scope: previous.scope,
+            reasons: previous.reasons.clone(),
+            state: QuarantineState::UnderReview,
+            recorded_at_micros,
+            producer_artifact_digest,
+            previous_event_digest: Some(previous_event_digest),
+            reviewer_authority_commitment: Some(reviewer_authority_commitment),
+            resolution: None,
+        };
+        validate_transition(previous, previous_event_digest, &next)?;
+        Ok(next)
+    }
+
+    pub fn resolve(
+        previous: &Self,
+        previous_event_digest: ArtifactDigest,
+        producer_artifact_digest: ArtifactDigest,
+        reviewer_authority_commitment: OpaqueCommitment,
+        disposition: ResolutionDisposition,
+        decision_artifact_digest: ArtifactDigest,
+        promoted_artifact_digest: Option<ArtifactDigest>,
+        recorded_at_micros: i64,
+    ) -> Result<Self, QuarantineError> {
+        let state = match disposition {
+            ResolutionDisposition::Promote => QuarantineState::ResolvedPromoted,
+            ResolutionDisposition::Discard => QuarantineState::ResolvedDiscarded,
+        };
+        let next = Self {
+            case_nonce: previous.case_nonce,
+            sequence: previous
+                .sequence
+                .checked_add(1)
+                .ok_or(QuarantineError::SequenceOverflow)?,
+            payload_commitment: previous.payload_commitment,
+            scope: previous.scope,
+            reasons: previous.reasons.clone(),
+            state,
+            recorded_at_micros,
+            producer_artifact_digest,
+            previous_event_digest: Some(previous_event_digest),
+            reviewer_authority_commitment: Some(reviewer_authority_commitment),
+            resolution: Some(ResolutionEvidence {
+                decision_artifact_digest,
+                promoted_artifact_digest,
+            }),
+        };
+        validate_transition(previous, previous_event_digest, &next)?;
+        Ok(next)
+    }
+
+    pub fn validate(&self) -> Result<(), QuarantineError> {
+        if self.case_nonce == [0u8; 16] {
+            return Err(QuarantineError::ZeroCaseNonce);
+        }
+        self.payload_commitment.validate()?;
+        self.producer_artifact_digest.validate()?;
+
+        if self.reasons.is_empty() {
+            return Err(QuarantineError::MissingReason);
+        }
+        let mut unique = HashSet::new();
+        if self.reasons.iter().any(|reason| !unique.insert(*reason)) {
+            return Err(QuarantineError::DuplicateReason);
+        }
+
+        match self.sequence {
+            0 if self.previous_event_digest.is_some() => {
+                return Err(QuarantineError::InitialEventHasPredecessor);
+            }
+            0 if self.state != QuarantineState::Pending => {
+                return Err(QuarantineError::InitialEventMustBePending);
+            }
+            0 => {}
+            _ => {
+                self.previous_event_digest
+                    .as_ref()
+                    .ok_or(QuarantineError::MissingPredecessorDigest)?
+                    .validate()?;
+            }
+        }
+
+        match self.state {
+            QuarantineState::Pending => {
+                if self.reviewer_authority_commitment.is_some() || self.resolution.is_some() {
+                    return Err(QuarantineError::PendingCarriesReviewOrResolution);
+                }
+            }
+            QuarantineState::UnderReview => {
+                self.reviewer_authority_commitment
+                    .as_ref()
+                    .ok_or(QuarantineError::MissingReviewerAuthority)?
+                    .validate()?;
+                if self.resolution.is_some() {
+                    return Err(QuarantineError::ReviewCarriesResolution);
+                }
+            }
+            QuarantineState::ResolvedPromoted | QuarantineState::ResolvedDiscarded => {
+                self.reviewer_authority_commitment
+                    .as_ref()
+                    .ok_or(QuarantineError::MissingReviewerAuthority)?
+                    .validate()?;
+                self.resolution
+                    .as_ref()
+                    .ok_or(QuarantineError::MissingResolutionEvidence)?
+                    .validate_for_state(self.state)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ResolutionDisposition {
+    Promote,
+    Discard,
+}
+
+/// Validate one immutable lineage transition against the digest of its exact
+/// predecessor event.
+pub fn validate_transition(
+    previous: &QuarantineEvent,
+    previous_event_digest: ArtifactDigest,
+    next: &QuarantineEvent,
+) -> Result<(), QuarantineError> {
+    previous.validate()?;
+    next.validate()?;
+    previous_event_digest.validate()?;
+
+    if previous.state.is_terminal() {
+        return Err(QuarantineError::TerminalStateCannotTransition);
+    }
+    if previous.case_nonce != next.case_nonce {
+        return Err(QuarantineError::CaseIdentityChanged);
+    }
+    if previous.payload_commitment != next.payload_commitment {
+        return Err(QuarantineError::PayloadCommitmentChanged);
+    }
+    if previous.scope != next.scope {
+        return Err(QuarantineError::ScopeChanged);
+    }
+    if previous.reasons != next.reasons {
+        return Err(QuarantineError::ReasonsChanged);
+    }
+    if next.sequence != previous.sequence + 1 {
+        return Err(QuarantineError::InvalidSequence);
+    }
+    if next.previous_event_digest != Some(previous_event_digest) {
+        return Err(QuarantineError::PredecessorDigestMismatch);
+    }
+    if next.recorded_at_micros < previous.recorded_at_micros {
+        return Err(QuarantineError::TimestampRegressed);
+    }
+
+    match (previous.state, next.state) {
+        (QuarantineState::Pending, QuarantineState::UnderReview)
+        | (QuarantineState::UnderReview, QuarantineState::UnderReview)
+        | (QuarantineState::UnderReview, QuarantineState::ResolvedPromoted)
+        | (QuarantineState::UnderReview, QuarantineState::ResolvedDiscarded) => Ok(()),
+        _ => Err(QuarantineError::InvalidStateTransition),
+    }
+}
+
+/// Convert an existing strict FHIR conformance issue into the closed quarantine
+/// reason taxonomy without copying its human-readable message or resource id.
+pub fn reason_from_fhir_issue(issue: &ConformanceIssue) -> QuarantineReasonCode {
+    match &issue.kind {
+        ConformanceIssueKind::EmptySourceSystem => QuarantineReasonCode::EmptySourceProvenance,
+        ConformanceIssueKind::WrongResourceType => QuarantineReasonCode::WrongResourceType,
+        ConformanceIssueKind::MissingBundleType => QuarantineReasonCode::MissingBundleType,
+        ConformanceIssueKind::UnsupportedBundleType => QuarantineReasonCode::UnsupportedBundleType,
+        ConformanceIssueKind::MissingEntries => QuarantineReasonCode::MissingBundleEntries,
+        ConformanceIssueKind::InvalidPatient => QuarantineReasonCode::InvalidPatientIdentity,
+        ConformanceIssueKind::MissingPatient => QuarantineReasonCode::MissingPatient,
+        ConformanceIssueKind::MultiplePatients => QuarantineReasonCode::MultiplePatients,
+        ConformanceIssueKind::DuplicateResourceIdentity => {
+            QuarantineReasonCode::DuplicateResourceIdentity
+        }
+        ConformanceIssueKind::DuplicateFullUrlVersion => {
+            QuarantineReasonCode::DuplicateFullUrlVersion
+        }
+        ConformanceIssueKind::VersionSpecificFullUrl => {
+            QuarantineReasonCode::VersionSpecificFullUrl
+        }
+        ConformanceIssueKind::MissingObservationId => QuarantineReasonCode::MissingObservationId,
+        ConformanceIssueKind::MissingObservationStatus => {
+            QuarantineReasonCode::MissingObservationStatus
+        }
+        ConformanceIssueKind::NonPromotableObservationStatus => {
+            QuarantineReasonCode::NonPromotableObservationStatus
+        }
+        ConformanceIssueKind::MissingEffectiveTime => QuarantineReasonCode::MissingEffectiveTime,
+        ConformanceIssueKind::UnsupportedEffectiveForm => {
+            QuarantineReasonCode::UnsupportedEffectiveForm
+        }
+        ConformanceIssueKind::Projection(kind) => match kind {
+            ProjectionIssueKind::MissingPatient => QuarantineReasonCode::MissingPatient,
+            ProjectionIssueKind::SubjectMismatch => QuarantineReasonCode::SubjectMismatch,
+            ProjectionIssueKind::SubjectUnresolved => QuarantineReasonCode::SubjectUnresolved,
+            ProjectionIssueKind::InvalidObservation => QuarantineReasonCode::InvalidObservation,
+            ProjectionIssueKind::SemanticValidation => {
+                QuarantineReasonCode::SemanticValidationFailure
+            }
+        },
+        ConformanceIssueKind::DuplicateFactIdentity => QuarantineReasonCode::DuplicateFactIdentity,
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum QuarantineError {
+    #[error("quarantine case nonce must be non-zero")]
+    ZeroCaseNonce,
+    #[error("opaque commitment must be non-zero")]
+    ZeroOpaqueCommitment,
+    #[error("artifact digest must be non-zero")]
+    ZeroArtifactDigest,
+    #[error("at least one typed quarantine reason is required")]
+    MissingReason,
+    #[error("quarantine reason codes must be unique")]
+    DuplicateReason,
+    #[error("initial quarantine event cannot have a predecessor")]
+    InitialEventHasPredecessor,
+    #[error("initial quarantine event must be pending")]
+    InitialEventMustBePending,
+    #[error("non-initial quarantine event requires predecessor digest")]
+    MissingPredecessorDigest,
+    #[error("pending event cannot carry reviewer authority or resolution")]
+    PendingCarriesReviewOrResolution,
+    #[error("review/terminal event requires reviewer authority commitment")]
+    MissingReviewerAuthority,
+    #[error("under-review event cannot carry terminal resolution")]
+    ReviewCarriesResolution,
+    #[error("terminal quarantine event requires resolution evidence")]
+    MissingResolutionEvidence,
+    #[error("promoted resolution requires promoted artifact digest")]
+    MissingPromotedArtifact,
+    #[error("discard resolution cannot claim a promoted artifact")]
+    DiscardCannotPromoteArtifact,
+    #[error("resolution evidence is only valid on terminal states")]
+    ResolutionOnNonTerminalState,
+    #[error("quarantine event sequence overflow")]
+    SequenceOverflow,
+    #[error("terminal quarantine state cannot transition")]
+    TerminalStateCannotTransition,
+    #[error("quarantine case identity changed across transition")]
+    CaseIdentityChanged,
+    #[error("payload commitment changed across transition")]
+    PayloadCommitmentChanged,
+    #[error("quarantine scope changed across transition")]
+    ScopeChanged,
+    #[error("quarantine reason set changed across transition")]
+    ReasonsChanged,
+    #[error("quarantine sequence is not predecessor + 1")]
+    InvalidSequence,
+    #[error("predecessor digest does not bind the exact prior event")]
+    PredecessorDigestMismatch,
+    #[error("quarantine event timestamp regressed")]
+    TimestampRegressed,
+    #[error("invalid quarantine state transition")]
+    InvalidStateTransition,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_fhir_conformance::{ConformanceIssue, IssueSeverity};
+
+    fn artifact(byte: u8) -> ArtifactDigest {
+        ArtifactDigest {
+            algorithm: DigestAlgorithm::Sha256,
+            value: [byte; 32],
+        }
+    }
+
+    fn commitment(byte: u8) -> OpaqueCommitment {
+        OpaqueCommitment {
+            scheme: CommitmentScheme::HmacSha256,
+            value: [byte; 32],
+        }
+    }
+
+    fn pending() -> QuarantineEvent {
+        QuarantineEvent::new_pending(
+            [1u8; 16],
+            commitment(2),
+            QuarantineScope::Resource,
+            vec![QuarantineReasonCode::SubjectUnresolved],
+            artifact(3),
+            100,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn public_event_contains_only_closed_metadata_types() {
+        let event = pending();
+        assert_eq!(event.sequence, 0);
+        assert_eq!(event.state, QuarantineState::Pending);
+        assert_eq!(event.reasons, vec![QuarantineReasonCode::SubjectUnresolved]);
+    }
+
+    #[test]
+    fn zero_case_nonce_is_rejected() {
+        let error = QuarantineEvent::new_pending(
+            [0u8; 16],
+            commitment(2),
+            QuarantineScope::Resource,
+            vec![QuarantineReasonCode::SubjectMismatch],
+            artifact(3),
+            100,
+        )
+        .unwrap_err();
+        assert_eq!(error, QuarantineError::ZeroCaseNonce);
+    }
+
+    #[test]
+    fn raw_unkeyed_payload_hash_is_not_representable_as_payload_commitment() {
+        let event = pending();
+        assert!(matches!(
+            event.payload_commitment.scheme,
+            CommitmentScheme::HmacSha256 | CommitmentScheme::Blake3Keyed
+        ));
+    }
+
+    #[test]
+    fn cannot_resolve_before_review() {
+        let previous = pending();
+        let next = QuarantineEvent {
+            case_nonce: previous.case_nonce,
+            sequence: 1,
+            payload_commitment: previous.payload_commitment,
+            scope: previous.scope,
+            reasons: previous.reasons.clone(),
+            state: QuarantineState::ResolvedDiscarded,
+            recorded_at_micros: 101,
+            producer_artifact_digest: artifact(4),
+            previous_event_digest: Some(artifact(5)),
+            reviewer_authority_commitment: Some(commitment(6)),
+            resolution: Some(ResolutionEvidence {
+                decision_artifact_digest: artifact(7),
+                promoted_artifact_digest: None,
+            }),
+        };
+        let error = validate_transition(&previous, artifact(5), &next).unwrap_err();
+        assert_eq!(error, QuarantineError::InvalidStateTransition);
+    }
+
+    #[test]
+    fn reviewed_item_can_be_promoted_with_exact_lineage() {
+        let pending = pending();
+        let review = QuarantineEvent::begin_review(
+            &pending,
+            artifact(10),
+            artifact(11),
+            commitment(12),
+            101,
+        )
+        .unwrap();
+        let resolved = QuarantineEvent::resolve(
+            &review,
+            artifact(13),
+            artifact(14),
+            commitment(12),
+            ResolutionDisposition::Promote,
+            artifact(15),
+            Some(artifact(16)),
+            102,
+        )
+        .unwrap();
+        assert_eq!(resolved.state, QuarantineState::ResolvedPromoted);
+        assert_eq!(resolved.sequence, 2);
+    }
+
+    #[test]
+    fn promotion_without_promoted_artifact_is_rejected() {
+        let pending = pending();
+        let review = QuarantineEvent::begin_review(
+            &pending,
+            artifact(10),
+            artifact(11),
+            commitment(12),
+            101,
+        )
+        .unwrap();
+        let error = QuarantineEvent::resolve(
+            &review,
+            artifact(13),
+            artifact(14),
+            commitment(12),
+            ResolutionDisposition::Promote,
+            artifact(15),
+            None,
+            102,
+        )
+        .unwrap_err();
+        assert_eq!(error, QuarantineError::MissingPromotedArtifact);
+    }
+
+    #[test]
+    fn discard_cannot_claim_promoted_artifact() {
+        let pending = pending();
+        let review = QuarantineEvent::begin_review(
+            &pending,
+            artifact(10),
+            artifact(11),
+            commitment(12),
+            101,
+        )
+        .unwrap();
+        let error = QuarantineEvent::resolve(
+            &review,
+            artifact(13),
+            artifact(14),
+            commitment(12),
+            ResolutionDisposition::Discard,
+            artifact(15),
+            Some(artifact(16)),
+            102,
+        )
+        .unwrap_err();
+        assert_eq!(error, QuarantineError::DiscardCannotPromoteArtifact);
+    }
+
+    #[test]
+    fn terminal_state_cannot_reopen() {
+        let pending = pending();
+        let review = QuarantineEvent::begin_review(
+            &pending,
+            artifact(10),
+            artifact(11),
+            commitment(12),
+            101,
+        )
+        .unwrap();
+        let resolved = QuarantineEvent::resolve(
+            &review,
+            artifact(13),
+            artifact(14),
+            commitment(12),
+            ResolutionDisposition::Discard,
+            artifact(15),
+            None,
+            102,
+        )
+        .unwrap();
+        let error = QuarantineEvent::begin_review(
+            &resolved,
+            artifact(17),
+            artifact(18),
+            commitment(19),
+            103,
+        )
+        .unwrap_err();
+        assert_eq!(error, QuarantineError::TerminalStateCannotTransition);
+    }
+
+    #[test]
+    fn predecessor_digest_must_match_exact_prior_event() {
+        let previous = pending();
+        let mut next = QuarantineEvent::begin_review(
+            &previous,
+            artifact(10),
+            artifact(11),
+            commitment(12),
+            101,
+        )
+        .unwrap();
+        next.previous_event_digest = Some(artifact(99));
+        let error = validate_transition(&previous, artifact(10), &next).unwrap_err();
+        assert_eq!(error, QuarantineError::PredecessorDigestMismatch);
+    }
+
+    #[test]
+    fn fhir_reason_mapping_drops_message_and_resource_identity() {
+        let issue = ConformanceIssue {
+            severity: IssueSeverity::ResourceRejected,
+            resource_type: Some("Observation".into()),
+            resource_id: Some("patient-identifying-source-id".into()),
+            kind: ConformanceIssueKind::Projection(ProjectionIssueKind::SubjectMismatch),
+            message: "Patient/secret-a mismatched Patient/secret-b".into(),
+        };
+        assert_eq!(
+            reason_from_fhir_issue(&issue),
+            QuarantineReasonCode::SubjectMismatch
+        );
+    }
+}

--- a/crates/clinical-quarantine/src/lib.rs
+++ b/crates/clinical-quarantine/src/lib.rs
@@ -353,7 +353,11 @@ pub fn validate_transition(
     if previous.reasons != next.reasons {
         return Err(QuarantineError::ReasonsChanged);
     }
-    if next.sequence != previous.sequence + 1 {
+    let expected_sequence = previous
+        .sequence
+        .checked_add(1)
+        .ok_or(QuarantineError::SequenceOverflow)?;
+    if next.sequence != expected_sequence {
         return Err(QuarantineError::InvalidSequence);
     }
     if next.previous_event_digest != Some(previous_event_digest) {
@@ -679,6 +683,26 @@ mod tests {
         next.previous_event_digest = Some(artifact(99));
         let error = validate_transition(&previous, artifact(10), &next).unwrap_err();
         assert_eq!(error, QuarantineError::PredecessorDigestMismatch);
+    }
+
+    #[test]
+    fn transition_validation_rejects_sequence_overflow() {
+        let previous = QuarantineEvent {
+            case_nonce: [1u8; 16],
+            sequence: u32::MAX,
+            payload_commitment: commitment(2),
+            scope: QuarantineScope::Resource,
+            reasons: vec![QuarantineReasonCode::SubjectUnresolved],
+            state: QuarantineState::UnderReview,
+            recorded_at_micros: 100,
+            producer_artifact_digest: artifact(3),
+            previous_event_digest: Some(artifact(4)),
+            reviewer_authority_commitment: Some(commitment(5)),
+            resolution: None,
+        };
+        let next = previous.clone();
+        let error = validate_transition(&previous, artifact(6), &next).unwrap_err();
+        assert_eq!(error, QuarantineError::SequenceOverflow);
     }
 
     #[test]

--- a/docs/CLINICAL_QUARANTINE_LEDGER_V1.md
+++ b/docs/CLINICAL_QUARANTINE_LEDGER_V1.md
@@ -1,0 +1,119 @@
+# Clinical Quarantine & Reconciliation Ledger v1
+
+## Purpose
+
+Clinical ingestion must be allowed to say **not safe to promote yet** without either dropping evidence or placing rejected protected health information (PHI) onto a shared ledger.
+
+This tranche defines a privacy-preserving public reconciliation lineage for FHIR/clinical inputs that fail strict semantic promotion.
+
+## Split-storage rule
+
+The quarantine system has two logically separate stores:
+
+### Sensitive local/encrypted store
+
+May contain:
+
+- original FHIR/clinical payload;
+- patient identifiers;
+- source-system/resource identifiers;
+- human-readable validation messages;
+- local remediation context;
+- authorized reviewer notes.
+
+This store must use the appropriate local/institutional encryption and access-control boundary. v1 deliberately does not define its backend.
+
+### Shared reconciliation ledger
+
+`QuarantineEvent` contains only:
+
+- random opaque case nonce;
+- keyed payload commitment;
+- typed scope;
+- closed typed reason codes;
+- immutable sequence/state;
+- transition timestamp;
+- producer artifact digest;
+- exact predecessor-event digest;
+- opaque reviewer-authority commitment when review begins;
+- decision artifact digest at resolution;
+- promoted artifact digest only when promotion succeeds.
+
+It contains **no field for raw payload, patient ID, resource ID, source URL, practitioner identifier, free-form error text, or reviewer notes**.
+
+## Why keyed commitments
+
+A plain SHA-256 hash of a clinical record is deterministic. If an attacker can guess or obtain a candidate payload, they may hash it and test whether it matches a public quarantine record.
+
+v1 therefore makes the sensitive payload identity an `OpaqueCommitment` using one of:
+
+- HMAC-SHA-256;
+- keyed BLAKE3.
+
+The commitment key remains outside the shared record.
+
+This reduces confirmation/dictionary risk but does not make metadata public by default. Deployments must still apply appropriate authorization, minimization, retention, and jurisdictional policy to the ledger itself.
+
+## Immutable state machine
+
+The only valid promotion lineage is:
+
+`Pending -> UnderReview -> ResolvedPromoted`
+
+or:
+
+`Pending -> UnderReview -> ResolvedDiscarded`
+
+`UnderReview -> UnderReview` is allowed for continued/reassigned review while preserving lineage.
+
+Terminal states cannot transition.
+
+Every event after sequence zero binds the exact predecessor event digest and increments sequence by one. Payload commitment, scope, case identity, and reason set cannot change across a case lineage.
+
+## Human authority
+
+Promotion/discard resolution requires an opaque reviewer-authority commitment. This structure does not itself establish the reviewer's authority; a later verifier must bind that commitment to an authorized credential/scope decision.
+
+No direct `Pending -> Promoted` transition exists in v1.
+
+## Reason taxonomy
+
+FHIR conformance failures map into a closed `QuarantineReasonCode` taxonomy. The mapper intentionally discards the source issue's human-readable message and resource identifier.
+
+The absence of an `Other(String)` variant is deliberate: free text would become an easy accidental PHI exfiltration channel.
+
+New reason codes require an explicit code/schema review.
+
+## FHIR integration
+
+`reason_from_fhir_issue()` maps the strict FHIR promotion profile into quarantine reason codes without copying sensitive identifiers/messages.
+
+A later adapter should:
+
+1. retain the rejected raw resource only in authorized encrypted/local storage;
+2. compute a keyed commitment over the canonical payload or protected envelope;
+3. create one `Pending` public event with typed reason codes;
+4. present the local item to an authorized reconciliation workflow;
+5. append review/resolution events without rewriting history;
+6. if promoted, bind the terminal event to the digest of the exact promoted semantic artifact.
+
+## Non-goals
+
+v1 does not:
+
+- store raw clinical data;
+- choose a local PHI storage backend;
+- define reviewer credential verification;
+- automatically repair clinical records;
+- automatically promote corrected records;
+- claim that a keyed commitment makes a ledger non-sensitive;
+- replace institutional retention/legal-hold policy.
+
+## Next
+
+1. Add an encrypted/local payload-store interface whose handles are never serialized into the shared event.
+2. Bind reviewer authority commitments to verified Mycelix practitioner credentials.
+3. Integrate strict FHIR conformance reports with quarantine-event creation.
+4. Add corrected-resource reconciliation that reruns the full semantic/conformance path from the beginning.
+5. Require a fresh ClinicalFact/artifact digest at successful promotion rather than reusing the rejected payload identity.
+6. Add retention/expiry policy as a separately authorized layer rather than deleting immutable evidence silently.


### PR DESCRIPTION
## Stack

Depends on #36 -> #35 -> #33 -> #32 -> #31 -> #30. Base is `feat/medication-semantics-v1` so this PR isolates quarantine/reconciliation semantics.

## Why

Strict clinical ingestion needs a durable `not safe to promote yet` path. Simply returning an error loses reconciliation evidence; putting rejected raw FHIR/PHI on a shared DHT would create a privacy problem.

This PR defines a split-storage, privacy-preserving lineage: raw/sensitive payload stays local/encrypted while the shared record contains only closed metadata and cryptographic commitments.

## What this adds

- `crates/clinical-quarantine`
- random opaque case nonce rather than patient/resource identity
- **keyed** payload commitments (`HmacSha256` / `Blake3Keyed`) rather than public raw payload hashes
- closed `QuarantineReasonCode` taxonomy with no `Other(String)` escape hatch
- explicit scopes for bundle/resource/fact/medication/evidence quarantine
- immutable state machine:
  - `Pending -> UnderReview`
  - `UnderReview -> UnderReview`
  - `UnderReview -> ResolvedPromoted | ResolvedDiscarded`
- terminal states cannot reopen
- exact predecessor-event digest binding
- sequence monotonicity with overflow-safe validation
- invariant that case nonce, payload commitment, scope, and reason set cannot mutate across lineage
- opaque reviewer-authority commitment
- exact decision-artifact digest on resolution
- promoted artifact digest required only for successful promotion
- mapping from strict FHIR conformance issues to typed quarantine reasons **without copying message/resource ID**
- tests for direct-resolution bypass, terminal reopening, predecessor substitution, sequence overflow, and PHI-bearing source-message dropping
- `docs/CLINICAL_QUARANTINE_LEDGER_V1.md`

## Privacy invariant

The shared `QuarantineEvent` has no field for raw clinical payload, patient ID, source resource ID, source-system URL, practitioner identifier, free-form error text, or reviewer notes.

Potentially identifying payload identity is represented by a secret-keyed commitment so a public deterministic hash cannot be used as a simple confirmation oracle against guessed records.

## Storage boundary

Sensitive raw payload and reconciliation context belong in an authorized encrypted/local store. This PR intentionally does not define or silently choose that backend.

The shared ledger remains metadata and lineage only. Deployments should still treat even this minimized metadata according to applicable authorization/retention policy; a keyed commitment is not a license to make clinical metadata public.

## Authority boundary

Reviewer identity is only an opaque commitment here. A follow-on verifier must prove that the committed reviewer held an appropriate credential/scope before the resolution is accepted by a clinical workflow.

## Next

1. define local encrypted payload-store interface whose handles cannot serialize into shared events;
2. bind reviewer commitments to verified Mycelix practitioner credentials;
3. emit pending quarantine events from strict FHIR conformance rejection paths;
4. rerun the entire semantic/conformance pipeline on corrected resources before promotion;
5. bind successful resolution to a fresh promoted ClinicalFact/artifact digest;
6. add explicit retention/legal-hold policy rather than silently deleting lineage.

## Non-claims

This PR does not make a DHT suitable for raw PHI, establish reviewer authority, automatically repair records, or prove regulatory compliance. It establishes a privacy-minimized, tamper-evident reconciliation contract.