### PR TITLE
feat(health): add verifier-oriented practitioner authority policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ members = [
     "crates/fhir-conformance",
     "crates/medication-semantics",
     "crates/clinical-quarantine",
+    "crates/clinical-authority",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-authority/Cargo.toml
+++ b/crates/clinical-authority/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mycelix-clinical-authority"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Typed practitioner authority policy and single-use verifier permits for Mycelix-Health"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/clinical-authority/src/lib.rs
+++ b/crates/clinical-authority/src/lib.rs
@@ -1,0 +1,909 @@
+#![deny(unsafe_code)]
+//! Typed practitioner authority policy for Mycelix-Health.
+//!
+//! This crate deliberately separates three questions:
+//! 1. What does a credential claim?
+//! 2. Has an adapter actually resolved/verified that credential, its issuer trust,
+//!    and revocation status?
+//! 3. Does that verified evidence satisfy the exact policy for one target action?
+//!
+//! The output permit is intentionally non-serializable and non-cloneable. It is
+//! bound to one principal, one target artifact, one policy, one jurisdiction, and
+//! one authority purpose.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashSet};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct CodeRef {
+    pub system: String,
+    pub code: String,
+}
+
+impl CodeRef {
+    pub fn validate(&self) -> Result<(), AuthorityError> {
+        validate_token("code.system", &self.system, 256)?;
+        validate_token("code.code", &self.code, 128)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct JurisdictionCode {
+    /// Coding system or namespace, e.g. ISO-3166-2 or an organization policy URI.
+    pub system: String,
+    pub code: String,
+}
+
+impl JurisdictionCode {
+    pub fn validate(&self) -> Result<(), AuthorityError> {
+        validate_token("jurisdiction.system", &self.system, 256)?;
+        validate_token("jurisdiction.code", &self.code, 128)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct ScopeCode {
+    /// Scope namespace. This may later map to a standards-based code system or a
+    /// versioned Mycelix policy vocabulary.
+    pub system: String,
+    pub code: String,
+}
+
+impl ScopeCode {
+    pub fn validate(&self) -> Result<(), AuthorityError> {
+        validate_token("scope.system", &self.system, 256)?;
+        validate_token("scope.code", &self.code, 128)
+    }
+}
+
+fn validate_token(field: &'static str, value: &str, max_len: usize) -> Result<(), AuthorityError> {
+    if value.trim().is_empty() {
+        return Err(AuthorityError::MissingField(field));
+    }
+    if value.len() > max_len {
+        return Err(AuthorityError::FieldTooLong(field));
+    }
+    Ok(())
+}
+
+/// Strict typed claims schema for a practitioner-license credential.
+///
+/// Deliberately omits names, license numbers, addresses, and other identifiers not
+/// needed for authority policy evaluation. Those may remain in an appropriately
+/// protected source credential but are not needed to decide scope/jurisdiction.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PractitionerLicenseClaimsV1 {
+    pub schema_version: u16,
+    pub license_class: CodeRef,
+    pub jurisdictions: Vec<JurisdictionCode>,
+    pub scopes: Vec<ScopeCode>,
+}
+
+impl PractitionerLicenseClaimsV1 {
+    pub fn validate(&self) -> Result<(), AuthorityError> {
+        if self.schema_version != 1 {
+            return Err(AuthorityError::UnsupportedClaimsSchemaVersion(
+                self.schema_version,
+            ));
+        }
+        self.license_class.validate()?;
+        validate_nonempty_unique_jurisdictions(&self.jurisdictions)?;
+        validate_nonempty_unique_scopes(&self.scopes)?;
+        Ok(())
+    }
+}
+
+pub fn parse_practitioner_license_claims(
+    json: &str,
+) -> Result<PractitionerLicenseClaimsV1, AuthorityError> {
+    if json.trim().is_empty() {
+        return Err(AuthorityError::EmptyClaims);
+    }
+    let claims: PractitionerLicenseClaimsV1 =
+        serde_json::from_str(json).map_err(|_| AuthorityError::InvalidClaimsJson)?;
+    claims.validate()?;
+    Ok(claims)
+}
+
+fn validate_nonempty_unique_jurisdictions(
+    values: &[JurisdictionCode],
+) -> Result<(), AuthorityError> {
+    if values.is_empty() {
+        return Err(AuthorityError::MissingJurisdictionClaims);
+    }
+    let mut seen = HashSet::new();
+    for value in values {
+        value.validate()?;
+        if !seen.insert((value.system.clone(), value.code.clone())) {
+            return Err(AuthorityError::DuplicateJurisdictionClaim);
+        }
+    }
+    Ok(())
+}
+
+fn validate_nonempty_unique_scopes(values: &[ScopeCode]) -> Result<(), AuthorityError> {
+    if values.is_empty() {
+        return Err(AuthorityError::MissingScopeClaims);
+    }
+    let mut seen = HashSet::new();
+    for value in values {
+        value.validate()?;
+        if !seen.insert((value.system.clone(), value.code.clone())) {
+            return Err(AuthorityError::DuplicateScopeClaim);
+        }
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct PrincipalBinding(pub [u8; 32]);
+
+impl PrincipalBinding {
+    fn validate(self) -> Result<(), AuthorityError> {
+        if self.0 == [0u8; 32] {
+            return Err(AuthorityError::ZeroPrincipalBinding);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct EvidenceDigest(pub [u8; 32]);
+
+impl EvidenceDigest {
+    fn validate(self) -> Result<(), AuthorityError> {
+        if self.0 == [0u8; 32] {
+            return Err(AuthorityError::ZeroEvidenceDigest);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CredentialKind {
+    PractitionerLicense,
+    ControlledSubstanceRegistration,
+    OrganizationDelegation,
+    SpecialtyCertification,
+    ResearchEthicsAppointment,
+}
+
+/// Evidence that has already crossed the credential-resolution trust boundary.
+///
+/// This type intentionally has no serde implementation. It should be constructed
+/// only by a trusted adapter after checking the source credential record, holder
+/// binding, issuer authority, expiration, and revocation evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedCredentialEvidence {
+    credential_kind: CredentialKind,
+    principal: PrincipalBinding,
+    jurisdictions: Vec<JurisdictionCode>,
+    scopes: Vec<ScopeCode>,
+    valid_from_micros: i64,
+    valid_until_micros: Option<i64>,
+    revoked_at_micros: Option<i64>,
+    credential_record_digest: EvidenceDigest,
+    issuer_authority_evidence_digest: EvidenceDigest,
+    status_check_evidence_digest: EvidenceDigest,
+}
+
+impl ResolvedCredentialEvidence {
+    /// Construct from a credential adapter that has already verified the source
+    /// record and issuer/revocation evidence. This constructor validates shape and
+    /// temporal consistency but cannot itself prove external issuer legitimacy;
+    /// that proof is represented by `issuer_authority_evidence_digest` and must be
+    /// produced by the adapter's trusted registry/policy path.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_verified_record(
+        credential_kind: CredentialKind,
+        principal: PrincipalBinding,
+        jurisdictions: Vec<JurisdictionCode>,
+        scopes: Vec<ScopeCode>,
+        valid_from_micros: i64,
+        valid_until_micros: Option<i64>,
+        revoked_at_micros: Option<i64>,
+        credential_record_digest: EvidenceDigest,
+        issuer_authority_evidence_digest: EvidenceDigest,
+        status_check_evidence_digest: EvidenceDigest,
+    ) -> Result<Self, AuthorityError> {
+        principal.validate()?;
+        validate_nonempty_unique_jurisdictions(&jurisdictions)?;
+        validate_nonempty_unique_scopes(&scopes)?;
+        credential_record_digest.validate()?;
+        issuer_authority_evidence_digest.validate()?;
+        status_check_evidence_digest.validate()?;
+        if let Some(valid_until) = valid_until_micros {
+            if valid_until <= valid_from_micros {
+                return Err(AuthorityError::InvalidCredentialValidityWindow);
+            }
+        }
+        if let Some(revoked_at) = revoked_at_micros {
+            if revoked_at < valid_from_micros {
+                return Err(AuthorityError::RevocationPredatesValidity);
+            }
+        }
+
+        Ok(Self {
+            credential_kind,
+            principal,
+            jurisdictions,
+            scopes,
+            valid_from_micros,
+            valid_until_micros,
+            revoked_at_micros,
+            credential_record_digest,
+            issuer_authority_evidence_digest,
+            status_check_evidence_digest,
+        })
+    }
+
+    pub fn credential_kind(&self) -> CredentialKind {
+        self.credential_kind
+    }
+
+    pub fn principal(&self) -> PrincipalBinding {
+        self.principal
+    }
+
+    fn supports_jurisdiction(&self, required: &JurisdictionCode) -> bool {
+        self.jurisdictions.iter().any(|value| value == required)
+    }
+
+    fn supports_scope(&self, required: &ScopeCode) -> bool {
+        self.scopes.iter().any(|value| value == required)
+    }
+
+    fn is_active_at(&self, at_micros: i64) -> CredentialTemporalState {
+        if at_micros < self.valid_from_micros {
+            return CredentialTemporalState::NotYetValid;
+        }
+        if let Some(revoked_at) = self.revoked_at_micros {
+            if at_micros >= revoked_at {
+                return CredentialTemporalState::Revoked;
+            }
+        }
+        if let Some(valid_until) = self.valid_until_micros {
+            if at_micros >= valid_until {
+                return CredentialTemporalState::Expired;
+            }
+        }
+        CredentialTemporalState::Active
+    }
+
+    fn supporting_digests(&self) -> [EvidenceDigest; 3] {
+        [
+            self.credential_record_digest,
+            self.issuer_authority_evidence_digest,
+            self.status_check_evidence_digest,
+        ]
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CredentialTemporalState {
+    Active,
+    NotYetValid,
+    Expired,
+    Revoked,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthorityPurpose {
+    ClinicalReview,
+    Prescribe,
+    Dispense,
+    Administer,
+    TrialEligibilityReview,
+    ResearchEthicsReview,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AuthorityRequest {
+    pub principal: PrincipalBinding,
+    pub target_artifact_digest: EvidenceDigest,
+    pub policy_digest: EvidenceDigest,
+    pub purpose: AuthorityPurpose,
+    pub jurisdiction: JurisdictionCode,
+    pub required_credential_kinds: Vec<CredentialKind>,
+    pub required_scopes: Vec<ScopeCode>,
+    pub evaluated_at_micros: i64,
+}
+
+impl AuthorityRequest {
+    pub fn validate(&self) -> Result<(), AuthorityError> {
+        self.principal.validate()?;
+        self.target_artifact_digest.validate()?;
+        self.policy_digest.validate()?;
+        self.jurisdiction.validate()?;
+        if self.required_credential_kinds.is_empty() {
+            return Err(AuthorityError::MissingCredentialRequirements);
+        }
+        if self.required_scopes.is_empty() {
+            return Err(AuthorityError::MissingScopeRequirements);
+        }
+
+        let mut kinds = HashSet::new();
+        if self
+            .required_credential_kinds
+            .iter()
+            .any(|kind| !kinds.insert(*kind))
+        {
+            return Err(AuthorityError::DuplicateCredentialRequirement);
+        }
+
+        let mut scopes = HashSet::new();
+        for scope in &self.required_scopes {
+            scope.validate()?;
+            if !scopes.insert((scope.system.clone(), scope.code.clone())) {
+                return Err(AuthorityError::DuplicateScopeRequirement);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthorityDenial {
+    PrincipalMismatch,
+    CredentialNotYetValid(CredentialKind),
+    CredentialExpired(CredentialKind),
+    CredentialRevoked(CredentialKind),
+    JurisdictionNotCovered(CredentialKind),
+    MissingRequiredCredential(CredentialKind),
+    MissingRequiredScope(ScopeCode),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AuthorityDecision {
+    Granted,
+    Denied,
+}
+
+pub struct AuthorityEvaluation {
+    pub decision: AuthorityDecision,
+    pub denials: Vec<AuthorityDenial>,
+    permit: Option<AuthorityPermit>,
+}
+
+impl AuthorityEvaluation {
+    /// Consume the evaluation and obtain the non-cloneable permit if granted.
+    pub fn into_permit(self) -> Option<AuthorityPermit> {
+        self.permit
+    }
+}
+
+/// Opaque, single-owner authority capability for one exact target/policy decision.
+///
+/// No `Clone`, `Copy`, `Serialize`, or `Deserialize` implementation is provided.
+/// Downstream APIs can consume this value by ownership when executing the one
+/// authorized workflow step.
+pub struct AuthorityPermit {
+    principal: PrincipalBinding,
+    target_artifact_digest: EvidenceDigest,
+    policy_digest: EvidenceDigest,
+    purpose: AuthorityPurpose,
+    jurisdiction: JurisdictionCode,
+    evaluated_at_micros: i64,
+    supporting_evidence_digests: Vec<EvidenceDigest>,
+}
+
+impl AuthorityPermit {
+    pub fn principal(&self) -> PrincipalBinding {
+        self.principal
+    }
+
+    pub fn target_artifact_digest(&self) -> EvidenceDigest {
+        self.target_artifact_digest
+    }
+
+    pub fn policy_digest(&self) -> EvidenceDigest {
+        self.policy_digest
+    }
+
+    pub fn purpose(&self) -> AuthorityPurpose {
+        self.purpose
+    }
+
+    pub fn jurisdiction(&self) -> &JurisdictionCode {
+        &self.jurisdiction
+    }
+
+    pub fn evaluated_at_micros(&self) -> i64 {
+        self.evaluated_at_micros
+    }
+
+    pub fn supporting_evidence_digests(&self) -> &[EvidenceDigest] {
+        &self.supporting_evidence_digests
+    }
+}
+
+pub fn evaluate_authority(
+    request: &AuthorityRequest,
+    credentials: &[ResolvedCredentialEvidence],
+) -> Result<AuthorityEvaluation, AuthorityError> {
+    request.validate()?;
+
+    let principal_credentials: Vec<&ResolvedCredentialEvidence> = credentials
+        .iter()
+        .filter(|credential| credential.principal == request.principal)
+        .collect();
+
+    if principal_credentials.is_empty() && !credentials.is_empty() {
+        return Ok(denied(vec![AuthorityDenial::PrincipalMismatch]));
+    }
+
+    let mut denials = Vec::new();
+    let mut qualifying = Vec::new();
+
+    for required_kind in &request.required_credential_kinds {
+        let matching_kind: Vec<&ResolvedCredentialEvidence> = principal_credentials
+            .iter()
+            .copied()
+            .filter(|credential| credential.credential_kind == *required_kind)
+            .collect();
+
+        if matching_kind.is_empty() {
+            denials.push(AuthorityDenial::MissingRequiredCredential(*required_kind));
+            continue;
+        }
+
+        let mut kind_has_active = false;
+        let mut kind_has_jurisdiction = false;
+
+        for credential in matching_kind {
+            match credential.is_active_at(request.evaluated_at_micros) {
+                CredentialTemporalState::Active => {
+                    kind_has_active = true;
+                    if credential.supports_jurisdiction(&request.jurisdiction) {
+                        kind_has_jurisdiction = true;
+                        qualifying.push(credential);
+                    }
+                }
+                CredentialTemporalState::NotYetValid => {
+                    denials.push(AuthorityDenial::CredentialNotYetValid(*required_kind));
+                }
+                CredentialTemporalState::Expired => {
+                    denials.push(AuthorityDenial::CredentialExpired(*required_kind));
+                }
+                CredentialTemporalState::Revoked => {
+                    denials.push(AuthorityDenial::CredentialRevoked(*required_kind));
+                }
+            }
+        }
+
+        if !kind_has_active {
+            if !denials.iter().any(|denial| {
+                matches!(
+                    denial,
+                    AuthorityDenial::CredentialNotYetValid(kind)
+                        | AuthorityDenial::CredentialExpired(kind)
+                        | AuthorityDenial::CredentialRevoked(kind)
+                        if kind == required_kind
+                )
+            }) {
+                denials.push(AuthorityDenial::MissingRequiredCredential(*required_kind));
+            }
+        } else if !kind_has_jurisdiction {
+            denials.push(AuthorityDenial::JurisdictionNotCovered(*required_kind));
+        }
+    }
+
+    if denials.is_empty() {
+        for required_scope in &request.required_scopes {
+            if !qualifying
+                .iter()
+                .any(|credential| credential.supports_scope(required_scope))
+            {
+                denials.push(AuthorityDenial::MissingRequiredScope(required_scope.clone()));
+            }
+        }
+    }
+
+    dedupe_denials(&mut denials);
+    if !denials.is_empty() {
+        return Ok(denied(denials));
+    }
+
+    let mut evidence = BTreeSet::new();
+    for credential in qualifying {
+        for digest in credential.supporting_digests() {
+            evidence.insert(digest);
+        }
+    }
+
+    Ok(AuthorityEvaluation {
+        decision: AuthorityDecision::Granted,
+        denials: Vec::new(),
+        permit: Some(AuthorityPermit {
+            principal: request.principal,
+            target_artifact_digest: request.target_artifact_digest,
+            policy_digest: request.policy_digest,
+            purpose: request.purpose,
+            jurisdiction: request.jurisdiction.clone(),
+            evaluated_at_micros: request.evaluated_at_micros,
+            supporting_evidence_digests: evidence.into_iter().collect(),
+        }),
+    })
+}
+
+fn denied(denials: Vec<AuthorityDenial>) -> AuthorityEvaluation {
+    AuthorityEvaluation {
+        decision: AuthorityDecision::Denied,
+        denials,
+        permit: None,
+    }
+}
+
+fn dedupe_denials(denials: &mut Vec<AuthorityDenial>) {
+    let mut seen = HashSet::new();
+    denials.retain(|denial| {
+        let key = format!("{denial:?}");
+        seen.insert(key)
+    });
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AuthorityError {
+    #[error("credential claims are empty")]
+    EmptyClaims,
+    #[error("credential claims are not valid strict v1 JSON")]
+    InvalidClaimsJson,
+    #[error("unsupported practitioner claims schema version {0}")]
+    UnsupportedClaimsSchemaVersion(u16),
+    #[error("required field is empty: {0}")]
+    MissingField(&'static str),
+    #[error("field exceeds maximum length: {0}")]
+    FieldTooLong(&'static str),
+    #[error("practitioner claims require at least one jurisdiction")]
+    MissingJurisdictionClaims,
+    #[error("practitioner claims contain duplicate jurisdiction")]
+    DuplicateJurisdictionClaim,
+    #[error("practitioner claims require at least one scope")]
+    MissingScopeClaims,
+    #[error("practitioner claims contain duplicate scope")]
+    DuplicateScopeClaim,
+    #[error("principal binding must be non-zero")]
+    ZeroPrincipalBinding,
+    #[error("evidence digest must be non-zero")]
+    ZeroEvidenceDigest,
+    #[error("credential validity end must be after validity start")]
+    InvalidCredentialValidityWindow,
+    #[error("credential revocation cannot predate its validity start")]
+    RevocationPredatesValidity,
+    #[error("authority request requires at least one credential kind")]
+    MissingCredentialRequirements,
+    #[error("authority request contains duplicate credential kind")]
+    DuplicateCredentialRequirement,
+    #[error("authority request requires at least one scope")]
+    MissingScopeRequirements,
+    #[error("authority request contains duplicate scope")]
+    DuplicateScopeRequirement,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn principal(byte: u8) -> PrincipalBinding {
+        PrincipalBinding([byte; 32])
+    }
+
+    fn digest(byte: u8) -> EvidenceDigest {
+        EvidenceDigest([byte; 32])
+    }
+
+    fn jurisdiction(code: &str) -> JurisdictionCode {
+        JurisdictionCode {
+            system: "urn:iso:std:iso:3166-2".into(),
+            code: code.into(),
+        }
+    }
+
+    fn scope(code: &str) -> ScopeCode {
+        ScopeCode {
+            system: "https://mycelix.health/authority-scope/v1".into(),
+            code: code.into(),
+        }
+    }
+
+    fn credential(
+        kind: CredentialKind,
+        principal_binding: PrincipalBinding,
+        jurisdictions: Vec<JurisdictionCode>,
+        scopes: Vec<ScopeCode>,
+        valid_from: i64,
+        valid_until: Option<i64>,
+        revoked_at: Option<i64>,
+        seed: u8,
+    ) -> ResolvedCredentialEvidence {
+        ResolvedCredentialEvidence::from_verified_record(
+            kind,
+            principal_binding,
+            jurisdictions,
+            scopes,
+            valid_from,
+            valid_until,
+            revoked_at,
+            digest(seed),
+            digest(seed.wrapping_add(1)),
+            digest(seed.wrapping_add(2)),
+        )
+        .unwrap()
+    }
+
+    fn request(kinds: Vec<CredentialKind>, scopes: Vec<ScopeCode>) -> AuthorityRequest {
+        AuthorityRequest {
+            principal: principal(1),
+            target_artifact_digest: digest(40),
+            policy_digest: digest(41),
+            purpose: AuthorityPurpose::ClinicalReview,
+            jurisdiction: jurisdiction("US-TX"),
+            required_credential_kinds: kinds,
+            required_scopes: scopes,
+            evaluated_at_micros: 100,
+        }
+    }
+
+    #[test]
+    fn strict_practitioner_claims_parse() {
+        let claims = parse_practitioner_license_claims(
+            r#"{
+                "schema_version": 1,
+                "license_class": {"system":"urn:example:license","code":"physician"},
+                "jurisdictions": [{"system":"urn:iso:std:iso:3166-2","code":"US-TX"}],
+                "scopes": [{"system":"https://mycelix.health/authority-scope/v1","code":"clinical-review"}]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(claims.schema_version, 1);
+    }
+
+    #[test]
+    fn unknown_claim_fields_fail_closed() {
+        let error = parse_practitioner_license_claims(
+            r#"{
+                "schema_version": 1,
+                "license_class": {"system":"urn:example:license","code":"physician"},
+                "jurisdictions": [{"system":"urn:iso:std:iso:3166-2","code":"US-TX"}],
+                "scopes": [{"system":"https://mycelix.health/authority-scope/v1","code":"clinical-review"}],
+                "magic_admin": true
+            }"#,
+        )
+        .unwrap_err();
+        assert_eq!(error, AuthorityError::InvalidClaimsJson);
+    }
+
+    #[test]
+    fn active_license_with_exact_scope_and_jurisdiction_grants() {
+        let license = credential(
+            CredentialKind::PractitionerLicense,
+            principal(1),
+            vec![jurisdiction("US-TX")],
+            vec![scope("clinical-review")],
+            0,
+            Some(1_000),
+            None,
+            10,
+        );
+        let result = evaluate_authority(
+            &request(
+                vec![CredentialKind::PractitionerLicense],
+                vec![scope("clinical-review")],
+            ),
+            &[license],
+        )
+        .unwrap();
+        assert_eq!(result.decision, AuthorityDecision::Granted);
+        let permit = result.into_permit().expect("granted request needs permit");
+        assert_eq!(permit.target_artifact_digest(), digest(40));
+        assert_eq!(permit.policy_digest(), digest(41));
+    }
+
+    #[test]
+    fn wrong_principal_cannot_borrow_someone_elses_license() {
+        let license = credential(
+            CredentialKind::PractitionerLicense,
+            principal(2),
+            vec![jurisdiction("US-TX")],
+            vec![scope("clinical-review")],
+            0,
+            Some(1_000),
+            None,
+            10,
+        );
+        let result = evaluate_authority(
+            &request(
+                vec![CredentialKind::PractitionerLicense],
+                vec![scope("clinical-review")],
+            ),
+            &[license],
+        )
+        .unwrap();
+        assert_eq!(result.decision, AuthorityDecision::Denied);
+        assert_eq!(result.denials, vec![AuthorityDenial::PrincipalMismatch]);
+    }
+
+    #[test]
+    fn revoked_license_is_denied() {
+        let license = credential(
+            CredentialKind::PractitionerLicense,
+            principal(1),
+            vec![jurisdiction("US-TX")],
+            vec![scope("clinical-review")],
+            0,
+            Some(1_000),
+            Some(50),
+            10,
+        );
+        let result = evaluate_authority(
+            &request(
+                vec![CredentialKind::PractitionerLicense],
+                vec![scope("clinical-review")],
+            ),
+            &[license],
+        )
+        .unwrap();
+        assert!(result
+            .denials
+            .contains(&AuthorityDenial::CredentialRevoked(
+                CredentialKind::PractitionerLicense
+            )));
+    }
+
+    #[test]
+    fn expired_license_is_denied() {
+        let license = credential(
+            CredentialKind::PractitionerLicense,
+            principal(1),
+            vec![jurisdiction("US-TX")],
+            vec![scope("clinical-review")],
+            0,
+            Some(100),
+            None,
+            10,
+        );
+        let result = evaluate_authority(
+            &request(
+                vec![CredentialKind::PractitionerLicense],
+                vec![scope("clinical-review")],
+            ),
+            &[license],
+        )
+        .unwrap();
+        assert!(result
+            .denials
+            .contains(&AuthorityDenial::CredentialExpired(
+                CredentialKind::PractitionerLicense
+            )));
+    }
+
+    #[test]
+    fn wrong_jurisdiction_is_denied() {
+        let license = credential(
+            CredentialKind::PractitionerLicense,
+            principal(1),
+            vec![jurisdiction("US-CA")],
+            vec![scope("clinical-review")],
+            0,
+            Some(1_000),
+            None,
+            10,
+        );
+        let result = evaluate_authority(
+            &request(
+                vec![CredentialKind::PractitionerLicense],
+                vec![scope("clinical-review")],
+            ),
+            &[license],
+        )
+        .unwrap();
+        assert!(result
+            .denials
+            .contains(&AuthorityDenial::JurisdictionNotCovered(
+                CredentialKind::PractitionerLicense
+            )));
+    }
+
+    #[test]
+    fn missing_scope_is_denied() {
+        let license = credential(
+            CredentialKind::PractitionerLicense,
+            principal(1),
+            vec![jurisdiction("US-TX")],
+            vec![scope("clinical-review")],
+            0,
+            Some(1_000),
+            None,
+            10,
+        );
+        let result = evaluate_authority(
+            &request(
+                vec![CredentialKind::PractitionerLicense],
+                vec![scope("prescribe-non-controlled")],
+            ),
+            &[license],
+        )
+        .unwrap();
+        assert!(result.denials.contains(&AuthorityDenial::MissingRequiredScope(
+            scope("prescribe-non-controlled")
+        )));
+    }
+
+    #[test]
+    fn controlled_prescribing_can_require_two_independent_credentials() {
+        let license = credential(
+            CredentialKind::PractitionerLicense,
+            principal(1),
+            vec![jurisdiction("US-TX")],
+            vec![scope("prescribe")],
+            0,
+            Some(1_000),
+            None,
+            10,
+        );
+        let controlled = credential(
+            CredentialKind::ControlledSubstanceRegistration,
+            principal(1),
+            vec![jurisdiction("US-TX")],
+            vec![scope("controlled-schedule-ii")],
+            0,
+            Some(500),
+            None,
+            20,
+        );
+        let req = request(
+            vec![
+                CredentialKind::PractitionerLicense,
+                CredentialKind::ControlledSubstanceRegistration,
+            ],
+            vec![scope("prescribe"), scope("controlled-schedule-ii")],
+        );
+        let result = evaluate_authority(&req, &[license, controlled]).unwrap();
+        assert_eq!(result.decision, AuthorityDecision::Granted);
+    }
+
+    #[test]
+    fn missing_controlled_registration_fails_closed() {
+        let license = credential(
+            CredentialKind::PractitionerLicense,
+            principal(1),
+            vec![jurisdiction("US-TX")],
+            vec![scope("prescribe")],
+            0,
+            Some(1_000),
+            None,
+            10,
+        );
+        let req = request(
+            vec![
+                CredentialKind::PractitionerLicense,
+                CredentialKind::ControlledSubstanceRegistration,
+            ],
+            vec![scope("prescribe"), scope("controlled-schedule-ii")],
+        );
+        let result = evaluate_authority(&req, &[license]).unwrap();
+        assert!(result.denials.contains(&AuthorityDenial::MissingRequiredCredential(
+            CredentialKind::ControlledSubstanceRegistration
+        )));
+    }
+
+    #[test]
+    fn resolved_credential_requires_issuer_and_status_evidence() {
+        let error = ResolvedCredentialEvidence::from_verified_record(
+            CredentialKind::PractitionerLicense,
+            principal(1),
+            vec![jurisdiction("US-TX")],
+            vec![scope("clinical-review")],
+            0,
+            Some(1_000),
+            None,
+            digest(10),
+            EvidenceDigest([0u8; 32]),
+            digest(12),
+        )
+        .unwrap_err();
+        assert_eq!(error, AuthorityError::ZeroEvidenceDigest);
+    }
+}

--- a/docs/CLINICAL_AUTHORITY_POLICY_V1.md
+++ b/docs/CLINICAL_AUTHORITY_POLICY_V1.md
@@ -1,0 +1,156 @@
+# Clinical Authority Policy v1
+
+## Purpose
+
+Mycelix-Health already has DHT-level author binding for credential issuance and issuer-only immutable revocation. That proves who committed a credential/revocation. It does **not** by itself prove that the issuer is a legitimate licensing authority, that the credential covers the relevant jurisdiction/scope, or that a practitioner may perform a particular clinical action.
+
+`mycelix-clinical-authority` defines the policy/evidence boundary between verified credential records and a concrete clinical authority capability.
+
+## Three separate questions
+
+The design keeps these distinct:
+
+1. **Claims semantics** — what does the credential say?
+2. **Credential resolution** — did a trusted adapter verify the source record, holder binding, issuer authority, validity window, and revocation state?
+3. **Action policy** — does the resulting verified evidence satisfy the exact policy for this action, jurisdiction, scope, target artifact, and evaluation time?
+
+None may substitute for another.
+
+## Typed practitioner claims
+
+`PractitionerLicenseClaimsV1` contains only the authority-relevant subset:
+
+- schema version;
+- coded license class;
+- coded jurisdictions;
+- coded scopes.
+
+It deliberately omits names, license numbers, addresses, and other identifiers not needed for policy evaluation.
+
+The parser uses a strict v1 JSON schema (`deny_unknown_fields`). Legacy/generic claim JSON remains readable as a credential record but cannot silently qualify for a v1 authority permit.
+
+## Resolved credential evidence
+
+`ResolvedCredentialEvidence` is intentionally not serializable. A trusted adapter should construct it only after checking:
+
+- holder/principal binding;
+- credential record integrity;
+- issuer authority/trust for the credential kind and jurisdiction;
+- validity dates;
+- revocation/status evidence;
+- typed jurisdiction and scope claims.
+
+The object binds three independent evidence digests:
+
+1. credential record digest;
+2. issuer-authority evidence digest;
+3. status/revocation-check evidence digest.
+
+This matters because author binding alone does not establish that the author is a recognized licensing board or delegated authority.
+
+## Authority request
+
+An `AuthorityRequest` binds:
+
+- exact principal;
+- exact target artifact digest;
+- exact policy digest;
+- authority purpose;
+- exact jurisdiction;
+- required credential kinds;
+- required scopes;
+- evaluation time.
+
+There is no wildcard jurisdiction behavior in v1.
+
+## Credential composition
+
+A policy may require multiple independent credentials.
+
+For example, a controlled-substance prescribing policy can require both:
+
+- `PractitionerLicense` with a prescribing scope; and
+- `ControlledSubstanceRegistration` with the required schedule scope.
+
+The current Mycelix credential zome only has a generic `PractitionerLicense` credential type, so controlled-substance registration remains a future credential/adaptor integration rather than being fabricated from the practitioner license.
+
+## Temporal semantics
+
+Credential evidence is evaluated at the request's exact time:
+
+- before validity start -> not yet valid;
+- at/after revocation -> revoked;
+- at/after validity end -> expired;
+- otherwise active.
+
+Historical evaluation may therefore distinguish an action taken before a later revocation from one attempted after revocation.
+
+## Opaque capability
+
+On success, `evaluate_authority()` returns `AuthorityPermit`.
+
+The permit intentionally implements none of:
+
+- `Clone`;
+- `Copy`;
+- `Serialize`;
+- `Deserialize`.
+
+It is bound to one principal, target artifact, policy, purpose, jurisdiction, time, and supporting evidence set. Downstream code should consume it by ownership for the one authorized workflow step.
+
+The permit is not a durable role token or wire credential.
+
+## Integration targets
+
+### Quarantine review
+
+A quarantine reviewer should need:
+
+- authority request target = exact quarantine event digest;
+- purpose = `ClinicalReview` (or a narrower future reconciliation purpose);
+- jurisdiction/policy derived from the clinical source/workflow;
+- required practitioner/reviewer scope;
+- resolved current credential evidence.
+
+Only then should the system accept a `Pending -> UnderReview` or resolution transition as authorized.
+
+### Medication ordering
+
+An active `MedicationOrder` candidate should not become an actionable prescription from FHIR `intent=order` alone.
+
+A prescribing workflow should require:
+
+1. typed medication-order semantics;
+2. target digest of that exact order;
+3. appropriate jurisdiction;
+4. practitioner-license credential evidence;
+5. prescribing scope;
+6. additional registration/schedule evidence when policy requires it;
+7. an authority permit consumed by the activation/signing workflow.
+
+## Trust-registry gap
+
+The current health credential zome binds `issuer_did` to the committing agent and enforces issuer-only revocation. A follow-on tranche still needs a typed trust registry/policy describing **which issuers are authorized to issue which credential kinds for which jurisdictions/scopes**.
+
+Until that exists, an adapter must not equate a self-consistent issuer DID with a recognized licensing authority.
+
+## Non-goals
+
+v1 does not:
+
+- verify a licensing board over the public internet;
+- define national/state professional licensing law;
+- define all clinical scopes globally;
+- make generic credential JSON authoritative;
+- make a provider clinically competent merely because a credential is active;
+- authorize treatment, prescribing, dispensing, or research outside the exact policy request;
+- replace human/institutional credentialing processes where legally required.
+
+## Next
+
+1. Add typed issuer-authority/trust registry records.
+2. Build a Holochain credential adapter that resolves current credential + immutable revocation lineage and emits `ResolvedCredentialEvidence`.
+3. Bind quarantine review transitions to an authority permit.
+4. Bind medication activation/signing to an authority permit.
+5. Extend credential kinds for controlled-substance registrations and other independent authorities rather than hiding them inside generic JSON.
+6. Add supersession/rotation semantics for licensing authorities and policy artifacts.


### PR DESCRIPTION
## Stack

Depends on #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30. Base is `feat/clinical-quarantine-ledger-v1` so this PR isolates practitioner authority policy/evidence semantics.

## Why

The current credential zome correctly binds credential issuance to the committing issuer agent and enforces issuer-only immutable revocation. That establishes provenance, but it does not establish that the issuer is a legitimate licensing authority or that a practitioner credential covers the exact jurisdiction/scope/action being attempted.

Clinical workflows need an explicit verifier boundary rather than checking `credential_type == PractitionerLicense` or trusting generic JSON claims.

## What this adds

- `crates/clinical-authority`
- strict `PractitionerLicenseClaimsV1` schema
  - coded license class
  - exact jurisdictions
  - exact scopes
  - no names/license numbers/addresses required for policy evaluation
  - unknown fields fail closed
- non-serializable `ResolvedCredentialEvidence`
- separate evidence digests for:
  1. exact credential record
  2. issuer-authority/trust evidence
  3. revocation/status check
- temporal credential evaluation (`not yet valid`, `active`, `expired`, `revoked`)
- exact principal binding
- exact jurisdiction matching; no wildcard behavior in v1
- policies that can require multiple independent credential kinds
- example support for practitioner license + controlled-substance registration rather than hiding both authorities inside one generic credential
- `AuthorityRequest` bound to:
  - principal
  - exact target artifact digest
  - exact policy digest
  - purpose
  - jurisdiction
  - required credential kinds/scopes
  - evaluation time
- non-serializable, non-cloneable `AuthorityPermit`
- permit binds all supporting evidence digests
- tests for strict claims, unknown fields, principal substitution, revocation, expiry, jurisdiction mismatch, scope mismatch, and multi-credential controlled-prescribing policy
- `docs/CLINICAL_AUTHORITY_POLICY_V1.md`

## Central invariant

Credential provenance is not authority.

A usable clinical authority decision must bind the exact credential record, issuer legitimacy evidence, current status/revocation evidence, holder/principal, jurisdiction, scope, action target, and policy.

## Existing credential gap made explicit

The current health credential zome has a generic JSON `claims` field and a `PractitionerLicense` type. Legacy credentials remain readable, but generic/legacy claims cannot silently produce a strict v1 authority permit.

A follow-on adapter must resolve current Holochain credential + revocation lineage and map only strict typed claims into `ResolvedCredentialEvidence`.

## Capability properties

`AuthorityPermit` intentionally implements none of `Clone`, `Copy`, `Serialize`, or `Deserialize`. It is intended to be consumed by ownership for one exact workflow step rather than reused as a durable role token.

## Next

1. add typed issuer-authority/trust registry records;
2. build Holochain credential-resolution adapter;
3. bind quarantine review/resolution transitions to an authority permit;
4. bind medication activation/signing to an authority permit;
5. add independent credential kinds for controlled-substance registrations and other external authorities;
6. bind authority policy supersession/rotation to immutable lineage.

## Non-claims

This PR does not decide who is legally licensed, verify external licensing boards, authorize treatment, or replace jurisdiction-specific credentialing rules. It defines the typed evidence/policy contract that a trusted adapter must satisfy.