### PR TITLE
feat(health): add bounded issuer trust-chain policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "crates/medication-semantics",
     "crates/clinical-quarantine",
     "crates/clinical-authority",
+    "crates/issuer-trust",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/issuer-trust/Cargo.toml
+++ b/crates/issuer-trust/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mycelix-issuer-trust"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Bounded issuer trust-chain policy for Mycelix-Health credential authorities"
+
+[dependencies]
+thiserror = { workspace = true }
+mycelix-clinical-authority = { path = "../clinical-authority" }

--- a/crates/issuer-trust/src/lib.rs
+++ b/crates/issuer-trust/src/lib.rs
@@ -1,0 +1,685 @@
+#![deny(unsafe_code)]
+//! Bounded issuer trust-chain evaluation for Mycelix-Health.
+//!
+//! Credential author-binding proves which agent issued a record. This crate answers
+//! the separate question: was that issuer authorized, under an explicit trust
+//! policy, to issue this credential kind in this jurisdiction at this time?
+//!
+//! Trust is rooted in configured/verified anchors and may be delegated only through
+//! bounded, verified grants. A credential issuer cannot bootstrap authority by
+//! issuing a grant to itself.
+
+use mycelix_clinical_authority::{
+    CredentialKind, EvidenceDigest, JurisdictionCode, PrincipalBinding,
+};
+use std::collections::{HashSet, VecDeque};
+use thiserror::Error;
+
+pub const MAX_DELEGATION_DEPTH: u8 = 8;
+pub const MAX_TRUST_ANCHORS: usize = 64;
+pub const MAX_DELEGATION_GRANTS: usize = 4096;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TrustAnchor {
+    principal: PrincipalBinding,
+    credential_kinds: Vec<CredentialKind>,
+    jurisdictions: Vec<JurisdictionCode>,
+    valid_from_micros: i64,
+    valid_until_micros: Option<i64>,
+    max_delegation_depth: u8,
+    policy_digest: EvidenceDigest,
+    anchor_evidence_digest: EvidenceDigest,
+}
+
+impl TrustAnchor {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        principal: PrincipalBinding,
+        credential_kinds: Vec<CredentialKind>,
+        jurisdictions: Vec<JurisdictionCode>,
+        valid_from_micros: i64,
+        valid_until_micros: Option<i64>,
+        max_delegation_depth: u8,
+        policy_digest: EvidenceDigest,
+        anchor_evidence_digest: EvidenceDigest,
+    ) -> Result<Self, IssuerTrustError> {
+        validate_principal(principal)?;
+        validate_kind_set(&credential_kinds)?;
+        validate_jurisdiction_set(&jurisdictions)?;
+        validate_digest(policy_digest)?;
+        validate_digest(anchor_evidence_digest)?;
+        validate_validity_window(valid_from_micros, valid_until_micros)?;
+        if max_delegation_depth > MAX_DELEGATION_DEPTH {
+            return Err(IssuerTrustError::DelegationDepthTooLarge);
+        }
+        Ok(Self {
+            principal,
+            credential_kinds,
+            jurisdictions,
+            valid_from_micros,
+            valid_until_micros,
+            max_delegation_depth,
+            policy_digest,
+            anchor_evidence_digest,
+        })
+    }
+
+    fn active_at(&self, at_micros: i64) -> bool {
+        at_micros >= self.valid_from_micros
+            && self
+                .valid_until_micros
+                .map(|until| at_micros < until)
+                .unwrap_or(true)
+    }
+
+    fn allows(&self, kind: CredentialKind, jurisdiction: &JurisdictionCode) -> bool {
+        self.credential_kinds.contains(&kind) && self.jurisdictions.contains(jurisdiction)
+    }
+}
+
+/// Delegation grant that has already crossed its source-integrity boundary.
+///
+/// The adapter constructing this type is responsible for verifying that the grant
+/// record was authored/signed by `grantor`, that its status/revocation query is
+/// trustworthy, and that the digests bind those exact artifacts. This type has no
+/// serde implementation so raw network input cannot deserialize directly into
+/// trusted delegation evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedDelegationGrant {
+    grantor: PrincipalBinding,
+    grantee: PrincipalBinding,
+    credential_kinds: Vec<CredentialKind>,
+    jurisdictions: Vec<JurisdictionCode>,
+    valid_from_micros: i64,
+    valid_until_micros: Option<i64>,
+    revoked_at_micros: Option<i64>,
+    /// Maximum delegation depth the grantee may itself pass onward.
+    child_delegation_depth: u8,
+    grant_record_digest: EvidenceDigest,
+    status_check_evidence_digest: EvidenceDigest,
+}
+
+impl VerifiedDelegationGrant {
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_verified_record(
+        grantor: PrincipalBinding,
+        grantee: PrincipalBinding,
+        credential_kinds: Vec<CredentialKind>,
+        jurisdictions: Vec<JurisdictionCode>,
+        valid_from_micros: i64,
+        valid_until_micros: Option<i64>,
+        revoked_at_micros: Option<i64>,
+        child_delegation_depth: u8,
+        grant_record_digest: EvidenceDigest,
+        status_check_evidence_digest: EvidenceDigest,
+    ) -> Result<Self, IssuerTrustError> {
+        validate_principal(grantor)?;
+        validate_principal(grantee)?;
+        if grantor == grantee {
+            return Err(IssuerTrustError::SelfDelegationForbidden);
+        }
+        validate_kind_set(&credential_kinds)?;
+        validate_jurisdiction_set(&jurisdictions)?;
+        validate_validity_window(valid_from_micros, valid_until_micros)?;
+        if let Some(revoked_at) = revoked_at_micros {
+            if revoked_at < valid_from_micros {
+                return Err(IssuerTrustError::RevocationPredatesValidity);
+            }
+        }
+        if child_delegation_depth > MAX_DELEGATION_DEPTH {
+            return Err(IssuerTrustError::DelegationDepthTooLarge);
+        }
+        validate_digest(grant_record_digest)?;
+        validate_digest(status_check_evidence_digest)?;
+        Ok(Self {
+            grantor,
+            grantee,
+            credential_kinds,
+            jurisdictions,
+            valid_from_micros,
+            valid_until_micros,
+            revoked_at_micros,
+            child_delegation_depth,
+            grant_record_digest,
+            status_check_evidence_digest,
+        })
+    }
+
+    fn active_at(&self, at_micros: i64) -> bool {
+        if at_micros < self.valid_from_micros {
+            return false;
+        }
+        if self
+            .valid_until_micros
+            .map(|until| at_micros >= until)
+            .unwrap_or(false)
+        {
+            return false;
+        }
+        if self
+            .revoked_at_micros
+            .map(|revoked| at_micros >= revoked)
+            .unwrap_or(false)
+        {
+            return false;
+        }
+        true
+    }
+
+    fn allows(&self, kind: CredentialKind, jurisdiction: &JurisdictionCode) -> bool {
+        self.credential_kinds.contains(&kind) && self.jurisdictions.contains(jurisdiction)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IssuerAuthorityRequest {
+    pub issuer: PrincipalBinding,
+    pub credential_kind: CredentialKind,
+    pub jurisdiction: JurisdictionCode,
+    pub evaluated_at_micros: i64,
+    pub policy_digest: EvidenceDigest,
+}
+
+impl IssuerAuthorityRequest {
+    pub fn validate(&self) -> Result<(), IssuerTrustError> {
+        validate_principal(self.issuer)?;
+        self.jurisdiction
+            .validate()
+            .map_err(|_| IssuerTrustError::InvalidJurisdiction)?;
+        validate_digest(self.policy_digest)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IssuerTrustDecision {
+    Authorized,
+    Denied,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IssuerTrustDenial {
+    NoApplicableTrustAnchor,
+    NoValidTrustPath,
+    DelegationDepthExceeded,
+}
+
+pub struct IssuerTrustEvaluation {
+    pub decision: IssuerTrustDecision,
+    pub denials: Vec<IssuerTrustDenial>,
+    receipt: Option<IssuerAuthorityReceipt>,
+}
+
+impl IssuerTrustEvaluation {
+    pub fn into_receipt(self) -> Option<IssuerAuthorityReceipt> {
+        self.receipt
+    }
+}
+
+/// Non-serializable, non-cloneable proof object produced only by successful trust
+/// path evaluation. The ordered evidence digests bind the chosen anchor and every
+/// delegation hop used to authorize the issuer.
+pub struct IssuerAuthorityReceipt {
+    issuer: PrincipalBinding,
+    credential_kind: CredentialKind,
+    jurisdiction: JurisdictionCode,
+    evaluated_at_micros: i64,
+    policy_digest: EvidenceDigest,
+    path_length: u8,
+    ordered_evidence_digests: Vec<EvidenceDigest>,
+}
+
+impl IssuerAuthorityReceipt {
+    pub fn issuer(&self) -> PrincipalBinding {
+        self.issuer
+    }
+
+    pub fn credential_kind(&self) -> CredentialKind {
+        self.credential_kind
+    }
+
+    pub fn jurisdiction(&self) -> &JurisdictionCode {
+        &self.jurisdiction
+    }
+
+    pub fn evaluated_at_micros(&self) -> i64 {
+        self.evaluated_at_micros
+    }
+
+    pub fn policy_digest(&self) -> EvidenceDigest {
+        self.policy_digest
+    }
+
+    pub fn path_length(&self) -> u8 {
+        self.path_length
+    }
+
+    pub fn ordered_evidence_digests(&self) -> &[EvidenceDigest] {
+        &self.ordered_evidence_digests
+    }
+}
+
+#[derive(Clone)]
+struct PathState {
+    principal: PrincipalBinding,
+    remaining_depth: u8,
+    path_length: u8,
+    evidence: Vec<EvidenceDigest>,
+}
+
+pub fn evaluate_issuer_authority(
+    request: &IssuerAuthorityRequest,
+    anchors: &[TrustAnchor],
+    grants: &[VerifiedDelegationGrant],
+) -> Result<IssuerTrustEvaluation, IssuerTrustError> {
+    request.validate()?;
+    if anchors.len() > MAX_TRUST_ANCHORS {
+        return Err(IssuerTrustError::TooManyTrustAnchors);
+    }
+    if grants.len() > MAX_DELEGATION_GRANTS {
+        return Err(IssuerTrustError::TooManyDelegationGrants);
+    }
+
+    let mut applicable_anchors: Vec<&TrustAnchor> = anchors
+        .iter()
+        .filter(|anchor| anchor.policy_digest == request.policy_digest)
+        .filter(|anchor| anchor.active_at(request.evaluated_at_micros))
+        .filter(|anchor| anchor.allows(request.credential_kind, &request.jurisdiction))
+        .collect();
+
+    applicable_anchors.sort_by_key(|anchor| anchor.anchor_evidence_digest);
+
+    if applicable_anchors.is_empty() {
+        return Ok(denied(IssuerTrustDenial::NoApplicableTrustAnchor));
+    }
+
+    let mut queue = VecDeque::new();
+    let mut visited: HashSet<(PrincipalBinding, u8)> = HashSet::new();
+
+    for anchor in applicable_anchors {
+        let state = PathState {
+            principal: anchor.principal,
+            remaining_depth: anchor.max_delegation_depth,
+            path_length: 0,
+            evidence: vec![anchor.anchor_evidence_digest],
+        };
+        if state.principal == request.issuer {
+            return Ok(authorized(request, state));
+        }
+        if visited.insert((state.principal, state.remaining_depth)) {
+            queue.push_back(state);
+        }
+    }
+
+    let mut saw_depth_violation = false;
+
+    while let Some(state) = queue.pop_front() {
+        let mut candidates: Vec<&VerifiedDelegationGrant> = grants
+            .iter()
+            .filter(|grant| grant.grantor == state.principal)
+            .filter(|grant| grant.active_at(request.evaluated_at_micros))
+            .filter(|grant| grant.allows(request.credential_kind, &request.jurisdiction))
+            .collect();
+        candidates.sort_by_key(|grant| grant.grant_record_digest);
+
+        for grant in candidates {
+            if state.remaining_depth == 0 {
+                saw_depth_violation = true;
+                continue;
+            }
+            let maximum_child_depth = state.remaining_depth - 1;
+            if grant.child_delegation_depth > maximum_child_depth {
+                saw_depth_violation = true;
+                continue;
+            }
+
+            let path_length = state
+                .path_length
+                .checked_add(1)
+                .ok_or(IssuerTrustError::PathLengthOverflow)?;
+            let mut evidence = state.evidence.clone();
+            evidence.push(grant.grant_record_digest);
+            evidence.push(grant.status_check_evidence_digest);
+
+            let next = PathState {
+                principal: grant.grantee,
+                remaining_depth: grant.child_delegation_depth,
+                path_length,
+                evidence,
+            };
+
+            if next.principal == request.issuer {
+                return Ok(authorized(request, next));
+            }
+
+            if visited.insert((next.principal, next.remaining_depth)) {
+                queue.push_back(next);
+            }
+        }
+    }
+
+    if saw_depth_violation {
+        Ok(denied(IssuerTrustDenial::DelegationDepthExceeded))
+    } else {
+        Ok(denied(IssuerTrustDenial::NoValidTrustPath))
+    }
+}
+
+fn authorized(request: &IssuerAuthorityRequest, state: PathState) -> IssuerTrustEvaluation {
+    IssuerTrustEvaluation {
+        decision: IssuerTrustDecision::Authorized,
+        denials: Vec::new(),
+        receipt: Some(IssuerAuthorityReceipt {
+            issuer: request.issuer,
+            credential_kind: request.credential_kind,
+            jurisdiction: request.jurisdiction.clone(),
+            evaluated_at_micros: request.evaluated_at_micros,
+            policy_digest: request.policy_digest,
+            path_length: state.path_length,
+            ordered_evidence_digests: state.evidence,
+        }),
+    }
+}
+
+fn denied(reason: IssuerTrustDenial) -> IssuerTrustEvaluation {
+    IssuerTrustEvaluation {
+        decision: IssuerTrustDecision::Denied,
+        denials: vec![reason],
+        receipt: None,
+    }
+}
+
+fn validate_principal(principal: PrincipalBinding) -> Result<(), IssuerTrustError> {
+    if principal.0 == [0u8; 32] {
+        return Err(IssuerTrustError::ZeroPrincipalBinding);
+    }
+    Ok(())
+}
+
+fn validate_digest(digest: EvidenceDigest) -> Result<(), IssuerTrustError> {
+    if digest.0 == [0u8; 32] {
+        return Err(IssuerTrustError::ZeroEvidenceDigest);
+    }
+    Ok(())
+}
+
+fn validate_kind_set(kinds: &[CredentialKind]) -> Result<(), IssuerTrustError> {
+    if kinds.is_empty() {
+        return Err(IssuerTrustError::MissingCredentialKinds);
+    }
+    let mut seen = HashSet::new();
+    if kinds.iter().any(|kind| !seen.insert(*kind)) {
+        return Err(IssuerTrustError::DuplicateCredentialKind);
+    }
+    Ok(())
+}
+
+fn validate_jurisdiction_set(
+    jurisdictions: &[JurisdictionCode],
+) -> Result<(), IssuerTrustError> {
+    if jurisdictions.is_empty() {
+        return Err(IssuerTrustError::MissingJurisdictions);
+    }
+    let mut seen = HashSet::new();
+    for jurisdiction in jurisdictions {
+        jurisdiction
+            .validate()
+            .map_err(|_| IssuerTrustError::InvalidJurisdiction)?;
+        if !seen.insert((jurisdiction.system.clone(), jurisdiction.code.clone())) {
+            return Err(IssuerTrustError::DuplicateJurisdiction);
+        }
+    }
+    Ok(())
+}
+
+fn validate_validity_window(
+    valid_from_micros: i64,
+    valid_until_micros: Option<i64>,
+) -> Result<(), IssuerTrustError> {
+    if let Some(until) = valid_until_micros {
+        if until <= valid_from_micros {
+            return Err(IssuerTrustError::InvalidValidityWindow);
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IssuerTrustError {
+    #[error("principal binding must be non-zero")]
+    ZeroPrincipalBinding,
+    #[error("evidence digest must be non-zero")]
+    ZeroEvidenceDigest,
+    #[error("issuer authority requires at least one credential kind")]
+    MissingCredentialKinds,
+    #[error("issuer authority contains duplicate credential kind")]
+    DuplicateCredentialKind,
+    #[error("issuer authority requires at least one jurisdiction")]
+    MissingJurisdictions,
+    #[error("issuer authority contains invalid jurisdiction")]
+    InvalidJurisdiction,
+    #[error("issuer authority contains duplicate jurisdiction")]
+    DuplicateJurisdiction,
+    #[error("validity end must be after validity start")]
+    InvalidValidityWindow,
+    #[error("revocation cannot predate delegation validity")]
+    RevocationPredatesValidity,
+    #[error("issuer cannot delegate authority to itself")]
+    SelfDelegationForbidden,
+    #[error("delegation depth exceeds policy maximum")]
+    DelegationDepthTooLarge,
+    #[error("trust policy exceeds maximum anchor count")]
+    TooManyTrustAnchors,
+    #[error("trust policy exceeds maximum delegation grant count")]
+    TooManyDelegationGrants,
+    #[error("trust path length overflow")]
+    PathLengthOverflow,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn principal(byte: u8) -> PrincipalBinding {
+        PrincipalBinding([byte; 32])
+    }
+
+    fn digest(byte: u8) -> EvidenceDigest {
+        EvidenceDigest([byte; 32])
+    }
+
+    fn jurisdiction(code: &str) -> JurisdictionCode {
+        JurisdictionCode {
+            system: "urn:iso:std:iso:3166-2".into(),
+            code: code.into(),
+        }
+    }
+
+    fn anchor(root: u8, depth: u8) -> TrustAnchor {
+        TrustAnchor::new(
+            principal(root),
+            vec![CredentialKind::PractitionerLicense],
+            vec![jurisdiction("US-TX")],
+            0,
+            Some(1_000),
+            depth,
+            digest(90),
+            digest(root.wrapping_add(100)),
+        )
+        .unwrap()
+    }
+
+    fn grant(grantor: u8, grantee: u8, child_depth: u8, seed: u8) -> VerifiedDelegationGrant {
+        VerifiedDelegationGrant::from_verified_record(
+            principal(grantor),
+            principal(grantee),
+            vec![CredentialKind::PractitionerLicense],
+            vec![jurisdiction("US-TX")],
+            0,
+            Some(1_000),
+            None,
+            child_depth,
+            digest(seed),
+            digest(seed.wrapping_add(1)),
+        )
+        .unwrap()
+    }
+
+    fn request(issuer: u8) -> IssuerAuthorityRequest {
+        IssuerAuthorityRequest {
+            issuer: principal(issuer),
+            credential_kind: CredentialKind::PractitionerLicense,
+            jurisdiction: jurisdiction("US-TX"),
+            evaluated_at_micros: 100,
+            policy_digest: digest(90),
+        }
+    }
+
+    #[test]
+    fn trust_anchor_is_authorized_without_delegation() {
+        let result = evaluate_issuer_authority(&request(1), &[anchor(1, 2)], &[]).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Authorized);
+        let receipt = result.into_receipt().unwrap();
+        assert_eq!(receipt.path_length(), 0);
+    }
+
+    #[test]
+    fn bounded_delegation_chain_authorizes_issuer() {
+        let grants = [grant(1, 2, 1, 10), grant(2, 3, 0, 20)];
+        let result = evaluate_issuer_authority(&request(3), &[anchor(1, 2)], &grants).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Authorized);
+        let receipt = result.into_receipt().unwrap();
+        assert_eq!(receipt.path_length(), 2);
+        assert_eq!(receipt.ordered_evidence_digests().len(), 5);
+    }
+
+    #[test]
+    fn self_declared_issuer_without_anchor_is_denied() {
+        let result = evaluate_issuer_authority(&request(7), &[], &[]).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Denied);
+        assert_eq!(
+            result.denials,
+            vec![IssuerTrustDenial::NoApplicableTrustAnchor]
+        );
+    }
+
+    #[test]
+    fn self_delegation_grant_is_rejected_at_construction() {
+        let error = VerifiedDelegationGrant::from_verified_record(
+            principal(1),
+            principal(1),
+            vec![CredentialKind::PractitionerLicense],
+            vec![jurisdiction("US-TX")],
+            0,
+            Some(1_000),
+            None,
+            0,
+            digest(10),
+            digest(11),
+        )
+        .unwrap_err();
+        assert_eq!(error, IssuerTrustError::SelfDelegationForbidden);
+    }
+
+    #[test]
+    fn over_delegation_is_denied() {
+        // Root allows only one hop, but grant attempts to give the child one more
+        // delegation hop instead of zero.
+        let grants = [grant(1, 2, 1, 10)];
+        let result = evaluate_issuer_authority(&request(2), &[anchor(1, 1)], &grants).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Denied);
+        assert_eq!(
+            result.denials,
+            vec![IssuerTrustDenial::DelegationDepthExceeded]
+        );
+    }
+
+    #[test]
+    fn cycle_does_not_bootstrap_untrusted_issuer() {
+        let grants = [grant(7, 8, 1, 10), grant(8, 7, 0, 20)];
+        let result = evaluate_issuer_authority(&request(7), &[anchor(1, 2)], &grants).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Denied);
+        assert_eq!(result.denials, vec![IssuerTrustDenial::NoValidTrustPath]);
+    }
+
+    #[test]
+    fn revoked_delegation_is_not_a_trust_path() {
+        let revoked = VerifiedDelegationGrant::from_verified_record(
+            principal(1),
+            principal(2),
+            vec![CredentialKind::PractitionerLicense],
+            vec![jurisdiction("US-TX")],
+            0,
+            Some(1_000),
+            Some(50),
+            0,
+            digest(10),
+            digest(11),
+        )
+        .unwrap();
+        let result = evaluate_issuer_authority(&request(2), &[anchor(1, 1)], &[revoked]).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Denied);
+    }
+
+    #[test]
+    fn wrong_jurisdiction_does_not_transfer_authority() {
+        let ca_grant = VerifiedDelegationGrant::from_verified_record(
+            principal(1),
+            principal(2),
+            vec![CredentialKind::PractitionerLicense],
+            vec![jurisdiction("US-CA")],
+            0,
+            Some(1_000),
+            None,
+            0,
+            digest(10),
+            digest(11),
+        )
+        .unwrap();
+        let result = evaluate_issuer_authority(&request(2), &[anchor(1, 1)], &[ca_grant]).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Denied);
+    }
+
+    #[test]
+    fn wrong_credential_kind_does_not_transfer_authority() {
+        let grant = VerifiedDelegationGrant::from_verified_record(
+            principal(1),
+            principal(2),
+            vec![CredentialKind::ResearchEthicsAppointment],
+            vec![jurisdiction("US-TX")],
+            0,
+            Some(1_000),
+            None,
+            0,
+            digest(10),
+            digest(11),
+        )
+        .unwrap();
+        let result = evaluate_issuer_authority(&request(2), &[anchor(1, 1)], &[grant]).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Denied);
+    }
+
+    #[test]
+    fn expired_anchor_is_not_a_root() {
+        let expired = TrustAnchor::new(
+            principal(1),
+            vec![CredentialKind::PractitionerLicense],
+            vec![jurisdiction("US-TX")],
+            0,
+            Some(50),
+            1,
+            digest(90),
+            digest(91),
+        )
+        .unwrap();
+        let result = evaluate_issuer_authority(&request(1), &[expired], &[]).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Denied);
+    }
+
+    #[test]
+    fn policy_digest_is_an_exact_trust_root_boundary() {
+        let mut req = request(1);
+        req.policy_digest = digest(99);
+        let result = evaluate_issuer_authority(&req, &[anchor(1, 1)], &[]).unwrap();
+        assert_eq!(result.decision, IssuerTrustDecision::Denied);
+    }
+}

--- a/docs/ISSUER_TRUST_POLICY_V1.md
+++ b/docs/ISSUER_TRUST_POLICY_V1.md
@@ -1,0 +1,159 @@
+# Issuer Trust Policy v1
+
+## Purpose
+
+Health credential author-binding proves which agent issued a credential. It does not prove that the issuer was authorized to issue that credential kind.
+
+`mycelix-issuer-trust` defines the missing trust-root and delegation semantics for credential issuers.
+
+## Central invariant
+
+> No issuer may become trusted solely because it says it is trusted or because it signs its own credential/grant.
+
+A successful issuer-authority decision must trace to an explicit trust anchor under one exact policy digest.
+
+## Trust anchors
+
+A `TrustAnchor` binds:
+
+- issuer principal binding;
+- allowed credential kinds;
+- exact jurisdictions;
+- validity window;
+- maximum delegation depth;
+- exact trust-policy digest;
+- anchor evidence digest.
+
+Trust anchors should come from an independently governed/configured policy source. They are not learned from the candidate issuer's own credential record.
+
+## Verified delegation grants
+
+`VerifiedDelegationGrant` is intentionally not serializable. A trusted Holochain/external adapter must first verify:
+
+- grant record integrity;
+- grantor author/signature binding;
+- grantee identity;
+- current revocation/status evidence;
+- validity window.
+
+Only then is the grant admitted to trust-path evaluation.
+
+A grant binds:
+
+- grantor and grantee;
+- allowed credential kinds;
+- exact jurisdictions;
+- validity/revocation state;
+- bounded child delegation depth;
+- grant-record digest;
+- status-check evidence digest.
+
+Self-delegation is rejected.
+
+## Bounded delegation
+
+Delegation depth is monotonically decreasing.
+
+If a parent has remaining depth `N`, a child grant may confer at most `N - 1` additional delegation hops.
+
+The evaluator caps maximum policy depth at 8. This prevents accidental/unbounded transitive trust and constrains graph traversal.
+
+Example:
+
+`root(depth=2) -> state board(depth=1) -> delegated board service(depth=0)`
+
+The depth-0 issuer may issue the allowed credential but cannot delegate issuer authority onward.
+
+## Exact scope
+
+v1 has no wildcard behavior.
+
+Every trust hop must allow the requested:
+
+- credential kind; and
+- jurisdiction.
+
+A California-only delegation cannot authorize Texas practitioner licenses. A research-ethics delegation cannot authorize practitioner licenses.
+
+## Temporal and revocation semantics
+
+Trust anchors and grants are evaluated at one exact time.
+
+Expired, not-yet-valid, and revoked grants do not form a trust path.
+
+Historical evaluation can therefore preserve the distinction between an issuer that was authorized at the time of issuance and one whose authority was revoked later.
+
+## Cycle resistance
+
+The evaluator tracks visited `(principal, remaining_depth)` states. Cyclic grants that have no path to a valid trust anchor cannot bootstrap trust.
+
+A graph such as:
+
+`A -> B -> A`
+
+has no authority unless one of those states is independently reachable from an applicable anchor under the same policy.
+
+## Determinism and resource bounds
+
+Applicable anchors and candidate grants are ordered by evidence digest before traversal so equivalent input sets produce a stable selected path.
+
+v1 caps:
+
+- trust anchors: 64;
+- delegation grants: 4096;
+- delegation depth: 8.
+
+This keeps issuer verification bounded even when evaluating hostile or malformed trust graphs.
+
+## Receipt
+
+Successful evaluation returns a non-serializable, non-cloneable `IssuerAuthorityReceipt` bound to:
+
+- exact issuer;
+- credential kind;
+- jurisdiction;
+- evaluation time;
+- trust-policy digest;
+- selected path length;
+- ordered evidence digests for the anchor and every delegation/status hop.
+
+A practitioner-credential adapter can use this receipt as evidence that the credential issuer had an authorized trust path. The clinical authority layer then separately verifies the practitioner's holder binding, credential status, jurisdiction, and action scope.
+
+## Separation of powers
+
+The intended chain is:
+
+`trust policy/root`
+→ `issuer authority receipt`
+→ `verified practitioner credential`
+→ `clinical authority evaluation`
+→ `single-use action permit`
+
+No layer is allowed to self-assert the output of the previous one.
+
+## Current integration gap
+
+The current health credentials zome does not yet contain typed issuer-trust grants/anchors. This crate is therefore the pure policy engine first.
+
+A follow-on Holochain tranche should define author-bound trust-policy/grant entries and immutable revocation/supersession semantics rather than embedding trust decisions inside generic credential JSON.
+
+## Non-goals
+
+v1 does not:
+
+- decide which real-world boards/regulators are legitimate;
+- fetch government licensing registries;
+- infer trust from a DID alone;
+- permit unbounded delegation;
+- permit wildcard jurisdiction/credential-kind authority;
+- replace jurisdiction-specific legal policy;
+- make the chosen trust-anchor governance automatically correct.
+
+## Next
+
+1. Define Holochain trust-anchor/delegation/revocation entries with strict author binding.
+2. Require grantor authority at DHT validation where feasible, not only coordinator code.
+3. Bind trust-policy version/supersession to exact predecessor lineage.
+4. Build issuer trust receipts into `ResolvedCredentialEvidence` construction.
+5. Add external-registry adapters for jurisdictions where authoritative licensing sources exist.
+6. Add independent policy review/audit for root-anchor changes because root compromise is the highest-impact trust event.


### PR DESCRIPTION
## Stack

Depends on #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30. Base is `feat/practitioner-authority-policy-v1` so this PR isolates issuer trust-root/delegation semantics.

## Why

Credential author-binding proves which agent issued a credential. It does not prove that the issuer was authorized to issue that credential kind.

Without a separate issuer-trust boundary, a perfectly author-bound self-declared issuer could still create a valid-looking `PractitionerLicense` credential.

## What this adds

- `crates/issuer-trust`
- explicit `TrustAnchor` roots bound to:
  - principal
  - credential kinds
  - exact jurisdictions
  - validity window
  - maximum delegation depth
  - exact trust-policy digest
  - anchor evidence digest
- non-serializable `VerifiedDelegationGrant`
- exact grantor/grantee binding
- grant validity + revocation semantics
- exact credential-kind/jurisdiction constraints at every hop
- self-delegation rejection
- monotonically decreasing delegation depth
- maximum delegation depth = 8
- bounded evaluator inputs (64 anchors / 4096 grants)
- cycle-resistant graph traversal
- deterministic candidate ordering by evidence digest
- non-serializable/non-cloneable `IssuerAuthorityReceipt`
- ordered evidence path from trust anchor through every delegation/status hop
- tests for direct root authority, bounded delegation, self-declared issuers, self-delegation, over-delegation, cycles, revocation, jurisdiction mismatch, credential-kind mismatch, expired anchors, and policy-digest mismatch
- `docs/ISSUER_TRUST_POLICY_V1.md`

## Central invariant

No issuer may become trusted solely because it says it is trusted, signs its own credential, or participates in a trust cycle.

A successful issuer-authority decision must trace to an explicit applicable trust anchor under one exact policy digest.

## Bounded delegation example

`root(depth=2) -> state board(depth=1) -> delegated service(depth=0)`

The depth-0 issuer may issue the permitted credential kind in the permitted jurisdiction but cannot delegate issuer authority onward.

## Separation of powers

The intended chain is:

`trust root/policy`
-> `issuer authority receipt`
-> `resolved practitioner credential`
-> `clinical authority policy`
-> `single-use action permit`

No layer self-asserts the output of the previous one.

## Next

1. define Holochain trust-anchor/delegation/revocation entries with strict author binding;
2. require grantor authority at the DHT validation boundary where feasible;
3. bind trust-policy supersession/rotation to exact predecessor lineage;
4. use `IssuerAuthorityReceipt` when constructing `ResolvedCredentialEvidence`;
5. add external authoritative registry adapters where jurisdictions provide them;
6. put root-anchor changes behind especially strong governance/audit because root compromise is the highest-impact trust event.

## Non-claims

This PR does not decide which real-world regulators are legitimate, fetch licensing databases, or replace jurisdiction-specific law. It defines bounded trust-chain semantics that such adapters/policies can safely feed.