### PR TITLE
feat(health): compose exact-target clinical workflow capabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ members = [
     "crates/clinical-quarantine",
     "crates/clinical-authority",
     "crates/issuer-trust",
+    "crates/clinical-integrity",
+    "crates/clinical-workflow",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-integrity/Cargo.toml
+++ b/crates/clinical-integrity/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mycelix-clinical-integrity"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Domain-separated BLAKE3 integrity identities for Mycelix-Health clinical artifacts"
+
+[dependencies]
+blake3 = "1.8.5"
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -1,0 +1,239 @@
+#![deny(unsafe_code)]
+//! Domain-separated integrity identities for Mycelix-Health clinical artifacts.
+//!
+//! Wire/storage digests are deliberately distinct from verified in-process digests.
+//! A deserialized `StoredDigest` is only a claim. `VerifiedDigest` can be obtained
+//! only by hashing canonical bytes locally or by re-verifying a stored claim against
+//! the exact canonical bytes.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const DERIVE_KEY_CONTEXT: &str = "mycelix.health.clinical-integrity.v1";
+const FRAME_VERSION: u8 = 1;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum DigestAlgorithm {
+    Blake3_256,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum DigestDomain {
+    ClinicalArtifact,
+    EvidenceCapsule,
+    MedicationOrder,
+    QuarantineEvent,
+    QuarantineDecision,
+    AuthorityPolicy,
+    IssuerTrustPolicy,
+    CredentialRecord,
+    CredentialStatusEvidence,
+    IssuerAuthorityEvidence,
+    WorkflowPolicy,
+}
+
+impl DigestDomain {
+    fn label(self) -> &'static [u8] {
+        match self {
+            Self::ClinicalArtifact => b"clinical-artifact",
+            Self::EvidenceCapsule => b"evidence-capsule",
+            Self::MedicationOrder => b"medication-order",
+            Self::QuarantineEvent => b"quarantine-event",
+            Self::QuarantineDecision => b"quarantine-decision",
+            Self::AuthorityPolicy => b"authority-policy",
+            Self::IssuerTrustPolicy => b"issuer-trust-policy",
+            Self::CredentialRecord => b"credential-record",
+            Self::CredentialStatusEvidence => b"credential-status-evidence",
+            Self::IssuerAuthorityEvidence => b"issuer-authority-evidence",
+            Self::WorkflowPolicy => b"workflow-policy",
+        }
+    }
+}
+
+/// Serializable digest claim. Deserialization does not confer verification.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct StoredDigest {
+    pub algorithm: DigestAlgorithm,
+    pub domain: DigestDomain,
+    pub value: [u8; 32],
+}
+
+impl StoredDigest {
+    pub fn validate_shape(&self) -> Result<(), IntegrityError> {
+        if self.value == [0u8; 32] {
+            return Err(IntegrityError::ZeroDigest);
+        }
+        Ok(())
+    }
+}
+
+/// In-process proof that exact canonical bytes were hashed under the stated v1
+/// algorithm/domain contract. Intentionally not serializable/deserializable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct VerifiedDigest {
+    stored: StoredDigest,
+}
+
+impl VerifiedDigest {
+    pub fn stored(self) -> StoredDigest {
+        self.stored
+    }
+
+    pub fn domain(self) -> DigestDomain {
+        self.stored.domain
+    }
+
+    pub fn value(self) -> [u8; 32] {
+        self.stored.value
+    }
+
+    pub fn require_domain(self, expected: DigestDomain) -> Result<Self, IntegrityError> {
+        if self.domain() != expected {
+            return Err(IntegrityError::WrongDomain {
+                expected,
+                actual: self.domain(),
+            });
+        }
+        Ok(self)
+    }
+}
+
+/// Hash bytes that are already in the owning artifact's canonical serialization.
+///
+/// This crate intentionally does not invent canonical JSON. Each artifact owner
+/// must define its canonical byte representation separately; this function freezes
+/// how those bytes are framed and hashed once canonicalization has occurred.
+pub fn hash_canonical_bytes(
+    domain: DigestDomain,
+    canonical_bytes: &[u8],
+) -> Result<VerifiedDigest, IntegrityError> {
+    if canonical_bytes.is_empty() {
+        return Err(IntegrityError::EmptyCanonicalBytes);
+    }
+
+    let label = domain.label();
+    let mut hasher = blake3::Hasher::new_derive_key(DERIVE_KEY_CONTEXT);
+    hasher.update(&[FRAME_VERSION]);
+    hasher.update(&(label.len() as u16).to_be_bytes());
+    hasher.update(label);
+    hasher.update(&(canonical_bytes.len() as u64).to_be_bytes());
+    hasher.update(canonical_bytes);
+
+    let value = *hasher.finalize().as_bytes();
+    if value == [0u8; 32] {
+        return Err(IntegrityError::ZeroDigest);
+    }
+
+    Ok(VerifiedDigest {
+        stored: StoredDigest {
+            algorithm: DigestAlgorithm::Blake3_256,
+            domain,
+            value,
+        },
+    })
+}
+
+/// Re-verify a stored/wire digest claim against the exact canonical bytes.
+pub fn verify_stored_digest(
+    claimed: StoredDigest,
+    canonical_bytes: &[u8],
+) -> Result<VerifiedDigest, IntegrityError> {
+    claimed.validate_shape()?;
+    if claimed.algorithm != DigestAlgorithm::Blake3_256 {
+        return Err(IntegrityError::UnsupportedAlgorithm);
+    }
+    let computed = hash_canonical_bytes(claimed.domain, canonical_bytes)?;
+    if computed.stored != claimed {
+        return Err(IntegrityError::DigestMismatch);
+    }
+    Ok(computed)
+}
+
+/// Verify that two already-verified identities are equal and belong to the exact
+/// expected semantic domain.
+pub fn require_same_digest(
+    left: VerifiedDigest,
+    right: VerifiedDigest,
+    domain: DigestDomain,
+) -> Result<(), IntegrityError> {
+    left.require_domain(domain)?;
+    right.require_domain(domain)?;
+    if left != right {
+        return Err(IntegrityError::DigestMismatch);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IntegrityError {
+    #[error("canonical artifact bytes cannot be empty")]
+    EmptyCanonicalBytes,
+    #[error("digest value cannot be all zero")]
+    ZeroDigest,
+    #[error("unsupported digest algorithm")]
+    UnsupportedAlgorithm,
+    #[error("digest domain mismatch: expected {expected:?}, got {actual:?}")]
+    WrongDomain {
+        expected: DigestDomain,
+        actual: DigestDomain,
+    },
+    #[error("digest does not match canonical artifact bytes")]
+    DigestMismatch,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_domain_and_bytes_are_deterministic() {
+        let a = hash_canonical_bytes(DigestDomain::MedicationOrder, b"canonical-order-v1").unwrap();
+        let b = hash_canonical_bytes(DigestDomain::MedicationOrder, b"canonical-order-v1").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn identical_bytes_in_different_domains_do_not_collide_by_construction() {
+        let payload = b"same-canonical-bytes";
+        let order = hash_canonical_bytes(DigestDomain::MedicationOrder, payload).unwrap();
+        let policy = hash_canonical_bytes(DigestDomain::AuthorityPolicy, payload).unwrap();
+        assert_ne!(order.value(), policy.value());
+    }
+
+    #[test]
+    fn framing_prevents_simple_concatenation_ambiguity() {
+        let a = hash_canonical_bytes(DigestDomain::ClinicalArtifact, b"ab").unwrap();
+        let b = hash_canonical_bytes(DigestDomain::ClinicalArtifact, b"a\0b").unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn stored_claim_must_be_reverified() {
+        let verified = hash_canonical_bytes(DigestDomain::EvidenceCapsule, b"capsule-v1").unwrap();
+        assert_eq!(
+            verify_stored_digest(verified.stored(), b"capsule-v1").unwrap(),
+            verified
+        );
+        assert_eq!(
+            verify_stored_digest(verified.stored(), b"different"),
+            Err(IntegrityError::DigestMismatch)
+        );
+    }
+
+    #[test]
+    fn domain_requirement_fails_closed() {
+        let digest = hash_canonical_bytes(DigestDomain::QuarantineEvent, b"event").unwrap();
+        assert!(matches!(
+            digest.require_domain(DigestDomain::MedicationOrder),
+            Err(IntegrityError::WrongDomain { .. })
+        ));
+    }
+
+    #[test]
+    fn empty_input_is_not_a_valid_artifact_identity() {
+        assert_eq!(
+            hash_canonical_bytes(DigestDomain::ClinicalArtifact, b""),
+            Err(IntegrityError::EmptyCanonicalBytes)
+        );
+    }
+}

--- a/crates/clinical-workflow/Cargo.toml
+++ b/crates/clinical-workflow/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mycelix-clinical-workflow"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Exact-target capability composition for Mycelix-Health clinical workflows"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
+mycelix-clinical-authority = { path = "../clinical-authority" }
+mycelix-clinical-evidence = { path = "../clinical-evidence" }
+mycelix-clinical-promotion = { path = "../clinical-promotion" }
+mycelix-medication-semantics = { path = "../medication-semantics" }
+mycelix-clinical-quarantine = { path = "../clinical-quarantine" }

--- a/crates/clinical-workflow/src/lib.rs
+++ b/crates/clinical-workflow/src/lib.rs
@@ -4,7 +4,7 @@
 //! A valid credential or qualification result is not sufficient on its own. This
 //! crate consumes a verifier-owned `AuthorityPermit` and rebinds it to one exact
 //! clinical artifact, purpose, policy, principal, jurisdiction, and execution time.
-//! The resulting workflow capability is non-serializable and non-cloneable.
+//! Resulting workflow capabilities intentionally implement no Clone/Copy/serde/Debug.
 
 use mycelix_clinical_authority::{
     AuthorityPermit, AuthorityPurpose, EvidenceDigest, JurisdictionCode, PrincipalBinding,
@@ -22,19 +22,14 @@ use mycelix_medication_semantics::MedicationOrder;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-const MAX_AUTHORITY_AGE_MICROS: i64 = 86_400_000_000; // 24 hours
-const MAX_FUTURE_SKEW_MICROS: i64 = 300_000_000; // 5 minutes
+const MAX_AUTHORITY_AGE_MICROS: i64 = 86_400_000_000;
+const MAX_FUTURE_SKEW_MICROS: i64 = 300_000_000;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowPolicyV1 {
     pub schema_version: u16,
-    /// Maximum age of the authority evaluation when converted into a workflow
-    /// capability. v1 caps this at 24 hours; deployments should normally be much
-    /// stricter for prescribing and other high-impact actions.
     pub max_authority_age_micros: i64,
-    /// Allowed clock skew when authority evaluation appears slightly in the future.
-    /// v1 caps this at five minutes.
     pub max_future_skew_micros: i64,
 }
 
@@ -68,8 +63,6 @@ impl WorkflowPolicyV1 {
     }
 }
 
-/// Result of combining clinical qualification and practitioner authority for one
-/// exact evidence capsule. No Clone/Copy/serde implementation is provided.
 pub struct ClinicalPresentationCapability {
     capsule_id: String,
     capsule_digest: StoredDigest,
@@ -82,40 +75,18 @@ pub struct ClinicalPresentationCapability {
 }
 
 impl ClinicalPresentationCapability {
-    pub fn capsule_id(&self) -> &str {
-        &self.capsule_id
-    }
-
-    pub fn capsule_digest(&self) -> StoredDigest {
-        self.capsule_digest
-    }
-
-    pub fn principal(&self) -> PrincipalBinding {
-        self.principal
-    }
-
-    pub fn jurisdiction(&self) -> &JurisdictionCode {
-        &self.jurisdiction
-    }
-
-    pub fn authorized_at_micros(&self) -> i64 {
-        self.authorized_at_micros
-    }
-
-    pub fn authority_policy_digest(&self) -> StoredDigest {
-        self.authority_policy_digest
-    }
-
-    pub fn workflow_policy_digest(&self) -> StoredDigest {
-        self.workflow_policy_digest
-    }
-
+    pub fn capsule_id(&self) -> &str { &self.capsule_id }
+    pub fn capsule_digest(&self) -> StoredDigest { self.capsule_digest }
+    pub fn principal(&self) -> PrincipalBinding { self.principal }
+    pub fn jurisdiction(&self) -> &JurisdictionCode { &self.jurisdiction }
+    pub fn authority_policy_digest(&self) -> StoredDigest { self.authority_policy_digest }
+    pub fn workflow_policy_digest(&self) -> StoredDigest { self.workflow_policy_digest }
+    pub fn authorized_at_micros(&self) -> i64 { self.authorized_at_micros }
     pub fn supporting_authority_evidence(&self) -> &[[u8; 32]] {
         &self.supporting_authority_evidence
     }
 }
 
-/// Single-owner capability for one exact active medication order candidate.
 pub struct MedicationActivationCapability {
     order_id: String,
     order_digest: StoredDigest,
@@ -128,41 +99,18 @@ pub struct MedicationActivationCapability {
 }
 
 impl MedicationActivationCapability {
-    pub fn order_id(&self) -> &str {
-        &self.order_id
-    }
-
-    pub fn order_digest(&self) -> StoredDigest {
-        self.order_digest
-    }
-
-    pub fn principal(&self) -> PrincipalBinding {
-        self.principal
-    }
-
-    pub fn jurisdiction(&self) -> &JurisdictionCode {
-        &self.jurisdiction
-    }
-
-    pub fn authorized_at_micros(&self) -> i64 {
-        self.authorized_at_micros
-    }
-
-    pub fn authority_policy_digest(&self) -> StoredDigest {
-        self.authority_policy_digest
-    }
-
-    pub fn workflow_policy_digest(&self) -> StoredDigest {
-        self.workflow_policy_digest
-    }
-
+    pub fn order_id(&self) -> &str { &self.order_id }
+    pub fn order_digest(&self) -> StoredDigest { self.order_digest }
+    pub fn principal(&self) -> PrincipalBinding { self.principal }
+    pub fn jurisdiction(&self) -> &JurisdictionCode { &self.jurisdiction }
+    pub fn authority_policy_digest(&self) -> StoredDigest { self.authority_policy_digest }
+    pub fn workflow_policy_digest(&self) -> StoredDigest { self.workflow_policy_digest }
+    pub fn authorized_at_micros(&self) -> i64 { self.authorized_at_micros }
     pub fn supporting_authority_evidence(&self) -> &[[u8; 32]] {
         &self.supporting_authority_evidence
     }
 }
 
-/// Single-owner capability for one exact quarantine event and one exact terminal
-/// disposition. The safe `resolve` method consumes the capability.
 pub struct QuarantineResolutionCapability {
     case_nonce: [u8; 16],
     sequence: u32,
@@ -175,39 +123,15 @@ pub struct QuarantineResolutionCapability {
 }
 
 impl QuarantineResolutionCapability {
-    pub fn case_nonce(&self) -> [u8; 16] {
-        self.case_nonce
-    }
+    pub fn case_nonce(&self) -> [u8; 16] { self.case_nonce }
+    pub fn sequence(&self) -> u32 { self.sequence }
+    pub fn event_digest(&self) -> StoredDigest { self.event_digest.stored() }
+    pub fn disposition(&self) -> ResolutionDisposition { self.disposition }
+    pub fn principal(&self) -> PrincipalBinding { self.principal }
+    pub fn authority_policy_digest(&self) -> StoredDigest { self.authority_policy_digest }
+    pub fn workflow_policy_digest(&self) -> StoredDigest { self.workflow_policy_digest }
+    pub fn authorized_at_micros(&self) -> i64 { self.authorized_at_micros }
 
-    pub fn sequence(&self) -> u32 {
-        self.sequence
-    }
-
-    pub fn event_digest(&self) -> StoredDigest {
-        self.event_digest.stored()
-    }
-
-    pub fn disposition(&self) -> ResolutionDisposition {
-        self.disposition
-    }
-
-    pub fn principal(&self) -> PrincipalBinding {
-        self.principal
-    }
-
-    pub fn authority_policy_digest(&self) -> StoredDigest {
-        self.authority_policy_digest
-    }
-
-    pub fn workflow_policy_digest(&self) -> StoredDigest {
-        self.workflow_policy_digest
-    }
-
-    pub fn authorized_at_micros(&self) -> i64 {
-        self.authorized_at_micros
-    }
-
-    /// Consume this capability to create exactly one permitted terminal transition.
     #[allow(clippy::too_many_arguments)]
     pub fn resolve(
         self,
@@ -254,7 +178,6 @@ pub fn authorize_clinical_presentation(
 ) -> Result<ClinicalPresentationCapability, WorkflowError> {
     let capsule_digest = hash_evidence_capsule(capsule)?;
     let workflow_policy_digest = workflow_policy.verified_digest()?;
-
     let evidence = verify_authority_binding(
         &authority,
         capsule_digest,
@@ -489,302 +412,4 @@ pub enum WorkflowError {
     QuarantineTargetChanged,
     #[error("quarantine transition failed: {0}")]
     Quarantine(String),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use mycelix_clinical_authority::{
-        evaluate_authority, AuthorityRequest, CredentialKind, ResolvedCredentialEvidence, ScopeCode,
-    };
-    use mycelix_clinical_integrity::DigestDomain;
-    use mycelix_clinical_semantics::{CodeableConcept, Coding, Quantity, Ratio, SubjectRef, UCUM_SYSTEM};
-    use mycelix_medication_semantics::{
-        AdministrationTiming, DosageInstruction, DoseAmount, MedicationOrderProvenance,
-        MedicationRequestIntent, MedicationRequestStatus, RequesterAuthorityRef,
-    };
-
-    fn principal(byte: u8) -> PrincipalBinding {
-        PrincipalBinding([byte; 32])
-    }
-
-    fn jurisdiction() -> JurisdictionCode {
-        JurisdictionCode {
-            system: "urn:iso:std:iso:3166-2".into(),
-            code: "US-TX".into(),
-        }
-    }
-
-    fn scope(code: &str) -> ScopeCode {
-        ScopeCode {
-            system: "https://mycelix.health/authority-scope/v1".into(),
-            code: code.into(),
-        }
-    }
-
-    fn authority_policy_digest(bytes: &[u8]) -> VerifiedDigest {
-        hash_canonical_bytes(DigestDomain::AuthorityPolicy, bytes).unwrap()
-    }
-
-    fn workflow_policy() -> WorkflowPolicyV1 {
-        WorkflowPolicyV1 {
-            schema_version: 1,
-            max_authority_age_micros: 60_000_000,
-            max_future_skew_micros: 1_000_000,
-        }
-    }
-
-    fn credential(
-        p: PrincipalBinding,
-        scope_code: &str,
-        seed: u8,
-    ) -> ResolvedCredentialEvidence {
-        ResolvedCredentialEvidence::from_verified_record(
-            CredentialKind::PractitionerLicense,
-            p,
-            vec![jurisdiction()],
-            vec![scope(scope_code)],
-            0,
-            Some(10_000_000_000),
-            None,
-            EvidenceDigest([seed; 32]),
-            EvidenceDigest([seed.wrapping_add(1); 32]),
-            EvidenceDigest([seed.wrapping_add(2); 32]),
-        )
-        .unwrap()
-    }
-
-    fn authority_for(
-        target: VerifiedDigest,
-        policy: VerifiedDigest,
-        purpose: AuthorityPurpose,
-        p: PrincipalBinding,
-        scope_code: &str,
-        evaluated_at: i64,
-    ) -> AuthorityPermit {
-        let request = AuthorityRequest {
-            principal: p,
-            target_artifact_digest: EvidenceDigest(target.value()),
-            policy_digest: EvidenceDigest(policy.value()),
-            purpose,
-            jurisdiction: jurisdiction(),
-            required_credential_kinds: vec![CredentialKind::PractitionerLicense],
-            required_scopes: vec![scope(scope_code)],
-            evaluated_at_micros: evaluated_at,
-        };
-        evaluate_authority(&request, &[credential(p, scope_code, 11)])
-            .unwrap()
-            .into_permit()
-            .expect("authority should be granted")
-    }
-
-    fn concept(system: &str, code: &str) -> CodeableConcept {
-        CodeableConcept {
-            coding: vec![Coding {
-                system: system.into(),
-                code: code.into(),
-                display: None,
-                version: None,
-            }],
-            text: None,
-        }
-    }
-
-    fn quantity(value: f64, code: &str) -> Quantity {
-        Quantity {
-            value,
-            display_unit: Some(code.into()),
-            system: UCUM_SYSTEM.into(),
-            code: code.into(),
-        }
-    }
-
-    fn medication_order(id: &str) -> MedicationOrder {
-        MedicationOrder {
-            order_id: id.into(),
-            subject: SubjectRef {
-                resource_type: "Patient".into(),
-                id: "patient-a".into(),
-            },
-            medication: concept("http://www.nlm.nih.gov/research/umls/rxnorm", "860975"),
-            product_strength: Some(Ratio {
-                numerator: quantity(500.0, "mg"),
-                denominator: quantity(1.0, "{tablet}"),
-            }),
-            status: MedicationRequestStatus::Active,
-            intent: MedicationRequestIntent::Order,
-            dosage: vec![DosageInstruction {
-                sequence: Some(1),
-                narrative_sig: Some("Take one tablet twice daily".into()),
-                patient_instruction: None,
-                timing: AdministrationTiming::Scheduled {
-                    frequency: 2,
-                    period: quantity(1.0, "d"),
-                },
-                route: concept("http://snomed.info/sct", "26643006"),
-                method: None,
-                site: None,
-                dose: DoseAmount::Quantity(quantity(1.0, "{tablet}")),
-                rate: None,
-                max_dose_per_period: Some(Ratio {
-                    numerator: quantity(2.0, "{tablet}"),
-                    denominator: quantity(1.0, "d"),
-                }),
-                max_dose_per_administration: Some(quantity(1.0, "{tablet}")),
-                max_dose_per_lifetime: None,
-            }],
-            dispense_quantity: Some(quantity(60.0, "{tablet}")),
-            refills_authorized: Some(1),
-            requester: Some(RequesterAuthorityRef {
-                requester_reference: "Practitioner/123".into(),
-                credential_reference: Some("mycelix:credential:abc".into()),
-            }),
-            authored_at_micros: Some(1),
-            provenance: MedicationOrderProvenance {
-                source_system: "https://ehr.example/fhir".into(),
-                source_resource_id: id.into(),
-                source_version: Some("1".into()),
-                recorded_at_micros: 1,
-            },
-        }
-    }
-
-    #[test]
-    fn medication_capability_is_bound_to_exact_order_digest() {
-        let p = principal(1);
-        let policy = authority_policy_digest(b"prescribing-policy-v1");
-        let order_a = medication_order("order-a");
-        let order_b = medication_order("order-b");
-        let authority = authority_for(
-            hash_medication_order(&order_a).unwrap(),
-            policy,
-            AuthorityPurpose::Prescribe,
-            p,
-            "prescribe",
-            100,
-        );
-
-        let error = authorize_medication_activation(
-            &order_b,
-            authority,
-            policy,
-            &workflow_policy(),
-            p,
-            &jurisdiction(),
-            200,
-        )
-        .unwrap_err();
-        assert!(matches!(error, WorkflowError::TargetDigestMismatch));
-    }
-
-    #[test]
-    fn clinical_review_authority_cannot_be_replayed_as_prescribing_authority() {
-        let p = principal(2);
-        let policy = authority_policy_digest(b"clinical-review-policy-v1");
-        let order = medication_order("order-a");
-        let authority = authority_for(
-            hash_medication_order(&order).unwrap(),
-            policy,
-            AuthorityPurpose::ClinicalReview,
-            p,
-            "prescribe",
-            100,
-        );
-        let error = authorize_medication_activation(
-            &order,
-            authority,
-            policy,
-            &workflow_policy(),
-            p,
-            &jurisdiction(),
-            200,
-        )
-        .unwrap_err();
-        assert!(matches!(error, WorkflowError::WrongAuthorityPurpose { .. }));
-    }
-
-    #[test]
-    fn wrong_authenticated_principal_is_rejected() {
-        let authorized = principal(3);
-        let attacker = principal(4);
-        let policy = authority_policy_digest(b"prescribing-policy-v1");
-        let order = medication_order("order-a");
-        let authority = authority_for(
-            hash_medication_order(&order).unwrap(),
-            policy,
-            AuthorityPurpose::Prescribe,
-            authorized,
-            "prescribe",
-            100,
-        );
-        let error = authorize_medication_activation(
-            &order,
-            authority,
-            policy,
-            &workflow_policy(),
-            attacker,
-            &jurisdiction(),
-            200,
-        )
-        .unwrap_err();
-        assert!(matches!(error, WorkflowError::PrincipalMismatch));
-    }
-
-    #[test]
-    fn stale_authority_is_rejected() {
-        let p = principal(5);
-        let policy = authority_policy_digest(b"prescribing-policy-v1");
-        let order = medication_order("order-a");
-        let authority = authority_for(
-            hash_medication_order(&order).unwrap(),
-            policy,
-            AuthorityPurpose::Prescribe,
-            p,
-            "prescribe",
-            0,
-        );
-        let error = authorize_medication_activation(
-            &order,
-            authority,
-            policy,
-            &WorkflowPolicyV1 {
-                schema_version: 1,
-                max_authority_age_micros: 10,
-                max_future_skew_micros: 0,
-            },
-            p,
-            &jurisdiction(),
-            11,
-        )
-        .unwrap_err();
-        assert!(matches!(error, WorkflowError::AuthorityEvaluationStale));
-    }
-
-    #[test]
-    fn correct_medication_authority_produces_exact_capability() {
-        let p = principal(6);
-        let policy = authority_policy_digest(b"prescribing-policy-v1");
-        let order = medication_order("order-a");
-        let digest = hash_medication_order(&order).unwrap();
-        let authority = authority_for(
-            digest,
-            policy,
-            AuthorityPurpose::Prescribe,
-            p,
-            "prescribe",
-            100,
-        );
-        let capability = authorize_medication_activation(
-            &order,
-            authority,
-            policy,
-            &workflow_policy(),
-            p,
-            &jurisdiction(),
-            200,
-        )
-        .unwrap();
-        assert_eq!(capability.order_id(), "order-a");
-        assert_eq!(capability.order_digest().value, digest.value());
-    }
 }

--- a/crates/clinical-workflow/src/lib.rs
+++ b/crates/clinical-workflow/src/lib.rs
@@ -1,0 +1,790 @@
+#![deny(unsafe_code)]
+//! Exact-target capability composition for Mycelix-Health.
+//!
+//! A valid credential or qualification result is not sufficient on its own. This
+//! crate consumes a verifier-owned `AuthorityPermit` and rebinds it to one exact
+//! clinical artifact, purpose, policy, principal, jurisdiction, and execution time.
+//! The resulting workflow capability is non-serializable and non-cloneable.
+
+use mycelix_clinical_authority::{
+    AuthorityPermit, AuthorityPurpose, EvidenceDigest, JurisdictionCode, PrincipalBinding,
+};
+use mycelix_clinical_evidence::ClinicalEvidenceCapsule;
+use mycelix_clinical_integrity::{
+    hash_canonical_bytes, DigestDomain, IntegrityError, StoredDigest, VerifiedDigest,
+};
+use mycelix_clinical_promotion::{evaluate_for_clinical_presentation, GateDecision};
+use mycelix_clinical_quarantine::{
+    ArtifactDigest, DigestAlgorithm as QuarantineDigestAlgorithm, OpaqueCommitment, QuarantineEvent,
+    QuarantineState, ResolutionDisposition,
+};
+use mycelix_medication_semantics::MedicationOrder;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const MAX_AUTHORITY_AGE_MICROS: i64 = 86_400_000_000; // 24 hours
+const MAX_FUTURE_SKEW_MICROS: i64 = 300_000_000; // 5 minutes
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct WorkflowPolicyV1 {
+    pub schema_version: u16,
+    /// Maximum age of the authority evaluation when converted into a workflow
+    /// capability. v1 caps this at 24 hours; deployments should normally be much
+    /// stricter for prescribing and other high-impact actions.
+    pub max_authority_age_micros: i64,
+    /// Allowed clock skew when authority evaluation appears slightly in the future.
+    /// v1 caps this at five minutes.
+    pub max_future_skew_micros: i64,
+}
+
+impl WorkflowPolicyV1 {
+    pub fn validate(&self) -> Result<(), WorkflowError> {
+        if self.schema_version != 1 {
+            return Err(WorkflowError::UnsupportedWorkflowPolicyVersion(
+                self.schema_version,
+            ));
+        }
+        if self.max_authority_age_micros <= 0
+            || self.max_authority_age_micros > MAX_AUTHORITY_AGE_MICROS
+        {
+            return Err(WorkflowError::InvalidAuthorityAgePolicy);
+        }
+        if self.max_future_skew_micros < 0
+            || self.max_future_skew_micros > MAX_FUTURE_SKEW_MICROS
+        {
+            return Err(WorkflowError::InvalidFutureSkewPolicy);
+        }
+        Ok(())
+    }
+
+    pub fn verified_digest(&self) -> Result<VerifiedDigest, WorkflowError> {
+        self.validate()?;
+        hash_json(
+            DigestDomain::WorkflowPolicy,
+            b"mycelix-health/workflow-policy-v1",
+            self,
+        )
+    }
+}
+
+/// Result of combining clinical qualification and practitioner authority for one
+/// exact evidence capsule. No Clone/Copy/serde implementation is provided.
+pub struct ClinicalPresentationCapability {
+    capsule_id: String,
+    capsule_digest: StoredDigest,
+    principal: PrincipalBinding,
+    jurisdiction: JurisdictionCode,
+    authority_policy_digest: StoredDigest,
+    workflow_policy_digest: StoredDigest,
+    authorized_at_micros: i64,
+    supporting_authority_evidence: Vec<[u8; 32]>,
+}
+
+impl ClinicalPresentationCapability {
+    pub fn capsule_id(&self) -> &str {
+        &self.capsule_id
+    }
+
+    pub fn capsule_digest(&self) -> StoredDigest {
+        self.capsule_digest
+    }
+
+    pub fn principal(&self) -> PrincipalBinding {
+        self.principal
+    }
+
+    pub fn jurisdiction(&self) -> &JurisdictionCode {
+        &self.jurisdiction
+    }
+
+    pub fn authorized_at_micros(&self) -> i64 {
+        self.authorized_at_micros
+    }
+
+    pub fn authority_policy_digest(&self) -> StoredDigest {
+        self.authority_policy_digest
+    }
+
+    pub fn workflow_policy_digest(&self) -> StoredDigest {
+        self.workflow_policy_digest
+    }
+
+    pub fn supporting_authority_evidence(&self) -> &[[u8; 32]] {
+        &self.supporting_authority_evidence
+    }
+}
+
+/// Single-owner capability for one exact active medication order candidate.
+pub struct MedicationActivationCapability {
+    order_id: String,
+    order_digest: StoredDigest,
+    principal: PrincipalBinding,
+    jurisdiction: JurisdictionCode,
+    authority_policy_digest: StoredDigest,
+    workflow_policy_digest: StoredDigest,
+    authorized_at_micros: i64,
+    supporting_authority_evidence: Vec<[u8; 32]>,
+}
+
+impl MedicationActivationCapability {
+    pub fn order_id(&self) -> &str {
+        &self.order_id
+    }
+
+    pub fn order_digest(&self) -> StoredDigest {
+        self.order_digest
+    }
+
+    pub fn principal(&self) -> PrincipalBinding {
+        self.principal
+    }
+
+    pub fn jurisdiction(&self) -> &JurisdictionCode {
+        &self.jurisdiction
+    }
+
+    pub fn authorized_at_micros(&self) -> i64 {
+        self.authorized_at_micros
+    }
+
+    pub fn authority_policy_digest(&self) -> StoredDigest {
+        self.authority_policy_digest
+    }
+
+    pub fn workflow_policy_digest(&self) -> StoredDigest {
+        self.workflow_policy_digest
+    }
+
+    pub fn supporting_authority_evidence(&self) -> &[[u8; 32]] {
+        &self.supporting_authority_evidence
+    }
+}
+
+/// Single-owner capability for one exact quarantine event and one exact terminal
+/// disposition. The safe `resolve` method consumes the capability.
+pub struct QuarantineResolutionCapability {
+    case_nonce: [u8; 16],
+    sequence: u32,
+    event_digest: VerifiedDigest,
+    disposition: ResolutionDisposition,
+    principal: PrincipalBinding,
+    authority_policy_digest: StoredDigest,
+    workflow_policy_digest: StoredDigest,
+    authorized_at_micros: i64,
+}
+
+impl QuarantineResolutionCapability {
+    pub fn case_nonce(&self) -> [u8; 16] {
+        self.case_nonce
+    }
+
+    pub fn sequence(&self) -> u32 {
+        self.sequence
+    }
+
+    pub fn event_digest(&self) -> StoredDigest {
+        self.event_digest.stored()
+    }
+
+    pub fn disposition(&self) -> ResolutionDisposition {
+        self.disposition
+    }
+
+    pub fn principal(&self) -> PrincipalBinding {
+        self.principal
+    }
+
+    pub fn authority_policy_digest(&self) -> StoredDigest {
+        self.authority_policy_digest
+    }
+
+    pub fn workflow_policy_digest(&self) -> StoredDigest {
+        self.workflow_policy_digest
+    }
+
+    pub fn authorized_at_micros(&self) -> i64 {
+        self.authorized_at_micros
+    }
+
+    /// Consume this capability to create exactly one permitted terminal transition.
+    #[allow(clippy::too_many_arguments)]
+    pub fn resolve(
+        self,
+        previous: &QuarantineEvent,
+        producer_artifact_digest: ArtifactDigest,
+        reviewer_authority_commitment: OpaqueCommitment,
+        decision_artifact_digest: ArtifactDigest,
+        promoted_artifact_digest: Option<ArtifactDigest>,
+        recorded_at_micros: i64,
+    ) -> Result<QuarantineEvent, WorkflowError> {
+        if previous.case_nonce != self.case_nonce || previous.sequence != self.sequence {
+            return Err(WorkflowError::QuarantineTargetChanged);
+        }
+        let actual = hash_quarantine_event(previous)?;
+        if actual != self.event_digest {
+            return Err(WorkflowError::TargetDigestMismatch);
+        }
+
+        QuarantineEvent::resolve(
+            previous,
+            ArtifactDigest {
+                algorithm: QuarantineDigestAlgorithm::Blake3,
+                value: self.event_digest.value(),
+            },
+            producer_artifact_digest,
+            reviewer_authority_commitment,
+            self.disposition,
+            decision_artifact_digest,
+            promoted_artifact_digest,
+            recorded_at_micros,
+        )
+        .map_err(|error| WorkflowError::Quarantine(error.to_string()))
+    }
+}
+
+pub fn authorize_clinical_presentation(
+    capsule: &ClinicalEvidenceCapsule,
+    authority: AuthorityPermit,
+    authority_policy_digest: VerifiedDigest,
+    workflow_policy: &WorkflowPolicyV1,
+    authenticated_principal: PrincipalBinding,
+    jurisdiction: &JurisdictionCode,
+    execution_at_micros: i64,
+) -> Result<ClinicalPresentationCapability, WorkflowError> {
+    let capsule_digest = hash_evidence_capsule(capsule)?;
+    let workflow_policy_digest = workflow_policy.verified_digest()?;
+
+    let evidence = verify_authority_binding(
+        &authority,
+        capsule_digest,
+        authority_policy_digest,
+        AuthorityPurpose::ClinicalReview,
+        authenticated_principal,
+        jurisdiction,
+        workflow_policy,
+        execution_at_micros,
+    )?;
+
+    let gate = evaluate_for_clinical_presentation(capsule)
+        .map_err(|error| WorkflowError::Qualification(error.to_string()))?;
+    if gate.decision != GateDecision::EligibleForClinicalPresentation {
+        return Err(WorkflowError::ClinicalQualificationDenied(gate.decision));
+    }
+
+    Ok(ClinicalPresentationCapability {
+        capsule_id: capsule.capsule_id.clone(),
+        capsule_digest: capsule_digest.stored(),
+        principal: authenticated_principal,
+        jurisdiction: jurisdiction.clone(),
+        authority_policy_digest: authority_policy_digest.stored(),
+        workflow_policy_digest: workflow_policy_digest.stored(),
+        authorized_at_micros: execution_at_micros,
+        supporting_authority_evidence: evidence,
+    })
+}
+
+pub fn authorize_medication_activation(
+    order: &MedicationOrder,
+    authority: AuthorityPermit,
+    authority_policy_digest: VerifiedDigest,
+    workflow_policy: &WorkflowPolicyV1,
+    authenticated_principal: PrincipalBinding,
+    jurisdiction: &JurisdictionCode,
+    execution_at_micros: i64,
+) -> Result<MedicationActivationCapability, WorkflowError> {
+    order
+        .validate_active_order_candidate()
+        .map_err(|error| WorkflowError::Medication(error.to_string()))?;
+
+    let order_digest = hash_medication_order(order)?;
+    let workflow_policy_digest = workflow_policy.verified_digest()?;
+    let evidence = verify_authority_binding(
+        &authority,
+        order_digest,
+        authority_policy_digest,
+        AuthorityPurpose::Prescribe,
+        authenticated_principal,
+        jurisdiction,
+        workflow_policy,
+        execution_at_micros,
+    )?;
+
+    Ok(MedicationActivationCapability {
+        order_id: order.order_id.clone(),
+        order_digest: order_digest.stored(),
+        principal: authenticated_principal,
+        jurisdiction: jurisdiction.clone(),
+        authority_policy_digest: authority_policy_digest.stored(),
+        workflow_policy_digest: workflow_policy_digest.stored(),
+        authorized_at_micros: execution_at_micros,
+        supporting_authority_evidence: evidence,
+    })
+}
+
+pub fn authorize_quarantine_resolution(
+    event: &QuarantineEvent,
+    disposition: ResolutionDisposition,
+    authority: AuthorityPermit,
+    authority_policy_digest: VerifiedDigest,
+    workflow_policy: &WorkflowPolicyV1,
+    authenticated_principal: PrincipalBinding,
+    jurisdiction: &JurisdictionCode,
+    execution_at_micros: i64,
+) -> Result<QuarantineResolutionCapability, WorkflowError> {
+    if event.state != QuarantineState::UnderReview {
+        return Err(WorkflowError::QuarantineNotUnderReview);
+    }
+    let event_digest = hash_quarantine_event(event)?;
+    let workflow_policy_digest = workflow_policy.verified_digest()?;
+    verify_authority_binding(
+        &authority,
+        event_digest,
+        authority_policy_digest,
+        AuthorityPurpose::ClinicalReview,
+        authenticated_principal,
+        jurisdiction,
+        workflow_policy,
+        execution_at_micros,
+    )?;
+
+    Ok(QuarantineResolutionCapability {
+        case_nonce: event.case_nonce,
+        sequence: event.sequence,
+        event_digest,
+        disposition,
+        principal: authenticated_principal,
+        authority_policy_digest: authority_policy_digest.stored(),
+        workflow_policy_digest: workflow_policy_digest.stored(),
+        authorized_at_micros: execution_at_micros,
+    })
+}
+
+pub fn hash_evidence_capsule(
+    capsule: &ClinicalEvidenceCapsule,
+) -> Result<VerifiedDigest, WorkflowError> {
+    hash_json(
+        DigestDomain::EvidenceCapsule,
+        b"mycelix-health/clinical-evidence-capsule-v1",
+        capsule,
+    )
+}
+
+pub fn hash_medication_order(order: &MedicationOrder) -> Result<VerifiedDigest, WorkflowError> {
+    hash_json(
+        DigestDomain::MedicationOrder,
+        b"mycelix-health/medication-order-v1",
+        order,
+    )
+}
+
+pub fn hash_quarantine_event(event: &QuarantineEvent) -> Result<VerifiedDigest, WorkflowError> {
+    hash_json(
+        DigestDomain::QuarantineEvent,
+        b"mycelix-health/quarantine-event-v1",
+        event,
+    )
+}
+
+fn hash_json<T: Serialize>(
+    domain: DigestDomain,
+    schema_tag: &[u8],
+    value: &T,
+) -> Result<VerifiedDigest, WorkflowError> {
+    let encoded = serde_json::to_vec(value)
+        .map_err(|error| WorkflowError::CanonicalSerialization(error.to_string()))?;
+    let mut framed = Vec::with_capacity(schema_tag.len() + 1 + encoded.len());
+    framed.extend_from_slice(schema_tag);
+    framed.push(0);
+    framed.extend_from_slice(&encoded);
+    Ok(hash_canonical_bytes(domain, &framed)?)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn verify_authority_binding(
+    authority: &AuthorityPermit,
+    target_digest: VerifiedDigest,
+    authority_policy_digest: VerifiedDigest,
+    expected_purpose: AuthorityPurpose,
+    authenticated_principal: PrincipalBinding,
+    jurisdiction: &JurisdictionCode,
+    workflow_policy: &WorkflowPolicyV1,
+    execution_at_micros: i64,
+) -> Result<Vec<[u8; 32]>, WorkflowError> {
+    authority_policy_digest.require_domain(DigestDomain::AuthorityPolicy)?;
+    workflow_policy.validate()?;
+
+    if authority.target_artifact_digest().0 != target_digest.value() {
+        return Err(WorkflowError::TargetDigestMismatch);
+    }
+    if authority.policy_digest().0 != authority_policy_digest.value() {
+        return Err(WorkflowError::AuthorityPolicyDigestMismatch);
+    }
+    if authority.purpose() != expected_purpose {
+        return Err(WorkflowError::WrongAuthorityPurpose {
+            expected: expected_purpose,
+            actual: authority.purpose(),
+        });
+    }
+    if authority.principal() != authenticated_principal {
+        return Err(WorkflowError::PrincipalMismatch);
+    }
+    if authority.jurisdiction() != jurisdiction {
+        return Err(WorkflowError::JurisdictionMismatch);
+    }
+
+    let delta = execution_at_micros as i128 - authority.evaluated_at_micros() as i128;
+    if delta < -(workflow_policy.max_future_skew_micros as i128) {
+        return Err(WorkflowError::AuthorityEvaluationFromFuture);
+    }
+    if delta > workflow_policy.max_authority_age_micros as i128 {
+        return Err(WorkflowError::AuthorityEvaluationStale);
+    }
+
+    Ok(authority
+        .supporting_evidence_digests()
+        .iter()
+        .map(|digest: &EvidenceDigest| digest.0)
+        .collect())
+}
+
+#[derive(Debug, Error)]
+pub enum WorkflowError {
+    #[error("unsupported workflow policy version {0}")]
+    UnsupportedWorkflowPolicyVersion(u16),
+    #[error("workflow authority age must be > 0 and <= 24 hours")]
+    InvalidAuthorityAgePolicy,
+    #[error("workflow future-skew allowance must be between 0 and 5 minutes")]
+    InvalidFutureSkewPolicy,
+    #[error("failed to serialize exact artifact under its v1 canonical JSON contract: {0}")]
+    CanonicalSerialization(String),
+    #[error(transparent)]
+    Integrity(#[from] IntegrityError),
+    #[error("authority target digest does not match exact workflow artifact")]
+    TargetDigestMismatch,
+    #[error("authority policy digest does not match the verified policy identity")]
+    AuthorityPolicyDigestMismatch,
+    #[error("authority purpose mismatch: expected {expected:?}, got {actual:?}")]
+    WrongAuthorityPurpose {
+        expected: AuthorityPurpose,
+        actual: AuthorityPurpose,
+    },
+    #[error("authority principal does not match authenticated workflow principal")]
+    PrincipalMismatch,
+    #[error("authority jurisdiction does not match workflow jurisdiction")]
+    JurisdictionMismatch,
+    #[error("authority evaluation is too far in the future for workflow policy")]
+    AuthorityEvaluationFromFuture,
+    #[error("authority evaluation is stale for workflow policy")]
+    AuthorityEvaluationStale,
+    #[error("clinical qualification gate denied presentation: {0:?}")]
+    ClinicalQualificationDenied(GateDecision),
+    #[error("clinical qualification validation failed: {0}")]
+    Qualification(String),
+    #[error("medication semantics rejected activation: {0}")]
+    Medication(String),
+    #[error("quarantine item must be under review before terminal resolution")]
+    QuarantineNotUnderReview,
+    #[error("quarantine target changed after capability issuance")]
+    QuarantineTargetChanged,
+    #[error("quarantine transition failed: {0}")]
+    Quarantine(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_authority::{
+        evaluate_authority, AuthorityRequest, CredentialKind, ResolvedCredentialEvidence, ScopeCode,
+    };
+    use mycelix_clinical_integrity::DigestDomain;
+    use mycelix_clinical_semantics::{CodeableConcept, Coding, Quantity, Ratio, SubjectRef, UCUM_SYSTEM};
+    use mycelix_medication_semantics::{
+        AdministrationTiming, DosageInstruction, DoseAmount, MedicationOrderProvenance,
+        MedicationRequestIntent, MedicationRequestStatus, RequesterAuthorityRef,
+    };
+
+    fn principal(byte: u8) -> PrincipalBinding {
+        PrincipalBinding([byte; 32])
+    }
+
+    fn jurisdiction() -> JurisdictionCode {
+        JurisdictionCode {
+            system: "urn:iso:std:iso:3166-2".into(),
+            code: "US-TX".into(),
+        }
+    }
+
+    fn scope(code: &str) -> ScopeCode {
+        ScopeCode {
+            system: "https://mycelix.health/authority-scope/v1".into(),
+            code: code.into(),
+        }
+    }
+
+    fn authority_policy_digest(bytes: &[u8]) -> VerifiedDigest {
+        hash_canonical_bytes(DigestDomain::AuthorityPolicy, bytes).unwrap()
+    }
+
+    fn workflow_policy() -> WorkflowPolicyV1 {
+        WorkflowPolicyV1 {
+            schema_version: 1,
+            max_authority_age_micros: 60_000_000,
+            max_future_skew_micros: 1_000_000,
+        }
+    }
+
+    fn credential(
+        p: PrincipalBinding,
+        scope_code: &str,
+        seed: u8,
+    ) -> ResolvedCredentialEvidence {
+        ResolvedCredentialEvidence::from_verified_record(
+            CredentialKind::PractitionerLicense,
+            p,
+            vec![jurisdiction()],
+            vec![scope(scope_code)],
+            0,
+            Some(10_000_000_000),
+            None,
+            EvidenceDigest([seed; 32]),
+            EvidenceDigest([seed.wrapping_add(1); 32]),
+            EvidenceDigest([seed.wrapping_add(2); 32]),
+        )
+        .unwrap()
+    }
+
+    fn authority_for(
+        target: VerifiedDigest,
+        policy: VerifiedDigest,
+        purpose: AuthorityPurpose,
+        p: PrincipalBinding,
+        scope_code: &str,
+        evaluated_at: i64,
+    ) -> AuthorityPermit {
+        let request = AuthorityRequest {
+            principal: p,
+            target_artifact_digest: EvidenceDigest(target.value()),
+            policy_digest: EvidenceDigest(policy.value()),
+            purpose,
+            jurisdiction: jurisdiction(),
+            required_credential_kinds: vec![CredentialKind::PractitionerLicense],
+            required_scopes: vec![scope(scope_code)],
+            evaluated_at_micros: evaluated_at,
+        };
+        evaluate_authority(&request, &[credential(p, scope_code, 11)])
+            .unwrap()
+            .into_permit()
+            .expect("authority should be granted")
+    }
+
+    fn concept(system: &str, code: &str) -> CodeableConcept {
+        CodeableConcept {
+            coding: vec![Coding {
+                system: system.into(),
+                code: code.into(),
+                display: None,
+                version: None,
+            }],
+            text: None,
+        }
+    }
+
+    fn quantity(value: f64, code: &str) -> Quantity {
+        Quantity {
+            value,
+            display_unit: Some(code.into()),
+            system: UCUM_SYSTEM.into(),
+            code: code.into(),
+        }
+    }
+
+    fn medication_order(id: &str) -> MedicationOrder {
+        MedicationOrder {
+            order_id: id.into(),
+            subject: SubjectRef {
+                resource_type: "Patient".into(),
+                id: "patient-a".into(),
+            },
+            medication: concept("http://www.nlm.nih.gov/research/umls/rxnorm", "860975"),
+            product_strength: Some(Ratio {
+                numerator: quantity(500.0, "mg"),
+                denominator: quantity(1.0, "{tablet}"),
+            }),
+            status: MedicationRequestStatus::Active,
+            intent: MedicationRequestIntent::Order,
+            dosage: vec![DosageInstruction {
+                sequence: Some(1),
+                narrative_sig: Some("Take one tablet twice daily".into()),
+                patient_instruction: None,
+                timing: AdministrationTiming::Scheduled {
+                    frequency: 2,
+                    period: quantity(1.0, "d"),
+                },
+                route: concept("http://snomed.info/sct", "26643006"),
+                method: None,
+                site: None,
+                dose: DoseAmount::Quantity(quantity(1.0, "{tablet}")),
+                rate: None,
+                max_dose_per_period: Some(Ratio {
+                    numerator: quantity(2.0, "{tablet}"),
+                    denominator: quantity(1.0, "d"),
+                }),
+                max_dose_per_administration: Some(quantity(1.0, "{tablet}")),
+                max_dose_per_lifetime: None,
+            }],
+            dispense_quantity: Some(quantity(60.0, "{tablet}")),
+            refills_authorized: Some(1),
+            requester: Some(RequesterAuthorityRef {
+                requester_reference: "Practitioner/123".into(),
+                credential_reference: Some("mycelix:credential:abc".into()),
+            }),
+            authored_at_micros: Some(1),
+            provenance: MedicationOrderProvenance {
+                source_system: "https://ehr.example/fhir".into(),
+                source_resource_id: id.into(),
+                source_version: Some("1".into()),
+                recorded_at_micros: 1,
+            },
+        }
+    }
+
+    #[test]
+    fn medication_capability_is_bound_to_exact_order_digest() {
+        let p = principal(1);
+        let policy = authority_policy_digest(b"prescribing-policy-v1");
+        let order_a = medication_order("order-a");
+        let order_b = medication_order("order-b");
+        let authority = authority_for(
+            hash_medication_order(&order_a).unwrap(),
+            policy,
+            AuthorityPurpose::Prescribe,
+            p,
+            "prescribe",
+            100,
+        );
+
+        let error = authorize_medication_activation(
+            &order_b,
+            authority,
+            policy,
+            &workflow_policy(),
+            p,
+            &jurisdiction(),
+            200,
+        )
+        .unwrap_err();
+        assert!(matches!(error, WorkflowError::TargetDigestMismatch));
+    }
+
+    #[test]
+    fn clinical_review_authority_cannot_be_replayed_as_prescribing_authority() {
+        let p = principal(2);
+        let policy = authority_policy_digest(b"clinical-review-policy-v1");
+        let order = medication_order("order-a");
+        let authority = authority_for(
+            hash_medication_order(&order).unwrap(),
+            policy,
+            AuthorityPurpose::ClinicalReview,
+            p,
+            "prescribe",
+            100,
+        );
+        let error = authorize_medication_activation(
+            &order,
+            authority,
+            policy,
+            &workflow_policy(),
+            p,
+            &jurisdiction(),
+            200,
+        )
+        .unwrap_err();
+        assert!(matches!(error, WorkflowError::WrongAuthorityPurpose { .. }));
+    }
+
+    #[test]
+    fn wrong_authenticated_principal_is_rejected() {
+        let authorized = principal(3);
+        let attacker = principal(4);
+        let policy = authority_policy_digest(b"prescribing-policy-v1");
+        let order = medication_order("order-a");
+        let authority = authority_for(
+            hash_medication_order(&order).unwrap(),
+            policy,
+            AuthorityPurpose::Prescribe,
+            authorized,
+            "prescribe",
+            100,
+        );
+        let error = authorize_medication_activation(
+            &order,
+            authority,
+            policy,
+            &workflow_policy(),
+            attacker,
+            &jurisdiction(),
+            200,
+        )
+        .unwrap_err();
+        assert!(matches!(error, WorkflowError::PrincipalMismatch));
+    }
+
+    #[test]
+    fn stale_authority_is_rejected() {
+        let p = principal(5);
+        let policy = authority_policy_digest(b"prescribing-policy-v1");
+        let order = medication_order("order-a");
+        let authority = authority_for(
+            hash_medication_order(&order).unwrap(),
+            policy,
+            AuthorityPurpose::Prescribe,
+            p,
+            "prescribe",
+            0,
+        );
+        let error = authorize_medication_activation(
+            &order,
+            authority,
+            policy,
+            &WorkflowPolicyV1 {
+                schema_version: 1,
+                max_authority_age_micros: 10,
+                max_future_skew_micros: 0,
+            },
+            p,
+            &jurisdiction(),
+            11,
+        )
+        .unwrap_err();
+        assert!(matches!(error, WorkflowError::AuthorityEvaluationStale));
+    }
+
+    #[test]
+    fn correct_medication_authority_produces_exact_capability() {
+        let p = principal(6);
+        let policy = authority_policy_digest(b"prescribing-policy-v1");
+        let order = medication_order("order-a");
+        let digest = hash_medication_order(&order).unwrap();
+        let authority = authority_for(
+            digest,
+            policy,
+            AuthorityPurpose::Prescribe,
+            p,
+            "prescribe",
+            100,
+        );
+        let capability = authorize_medication_activation(
+            &order,
+            authority,
+            policy,
+            &workflow_policy(),
+            p,
+            &jurisdiction(),
+            200,
+        )
+        .unwrap();
+        assert_eq!(capability.order_id(), "order-a");
+        assert_eq!(capability.order_digest().value, digest.value());
+    }
+}

--- a/crates/clinical-workflow/src/lib.rs
+++ b/crates/clinical-workflow/src/lib.rs
@@ -75,13 +75,34 @@ pub struct ClinicalPresentationCapability {
 }
 
 impl ClinicalPresentationCapability {
-    pub fn capsule_id(&self) -> &str { &self.capsule_id }
-    pub fn capsule_digest(&self) -> StoredDigest { self.capsule_digest }
-    pub fn principal(&self) -> PrincipalBinding { self.principal }
-    pub fn jurisdiction(&self) -> &JurisdictionCode { &self.jurisdiction }
-    pub fn authority_policy_digest(&self) -> StoredDigest { self.authority_policy_digest }
-    pub fn workflow_policy_digest(&self) -> StoredDigest { self.workflow_policy_digest }
-    pub fn authorized_at_micros(&self) -> i64 { self.authorized_at_micros }
+    pub fn capsule_id(&self) -> &str {
+        &self.capsule_id
+    }
+
+    pub fn capsule_digest(&self) -> StoredDigest {
+        self.capsule_digest
+    }
+
+    pub fn principal(&self) -> PrincipalBinding {
+        self.principal
+    }
+
+    pub fn jurisdiction(&self) -> &JurisdictionCode {
+        &self.jurisdiction
+    }
+
+    pub fn authority_policy_digest(&self) -> StoredDigest {
+        self.authority_policy_digest
+    }
+
+    pub fn workflow_policy_digest(&self) -> StoredDigest {
+        self.workflow_policy_digest
+    }
+
+    pub fn authorized_at_micros(&self) -> i64 {
+        self.authorized_at_micros
+    }
+
     pub fn supporting_authority_evidence(&self) -> &[[u8; 32]] {
         &self.supporting_authority_evidence
     }
@@ -99,13 +120,34 @@ pub struct MedicationActivationCapability {
 }
 
 impl MedicationActivationCapability {
-    pub fn order_id(&self) -> &str { &self.order_id }
-    pub fn order_digest(&self) -> StoredDigest { self.order_digest }
-    pub fn principal(&self) -> PrincipalBinding { self.principal }
-    pub fn jurisdiction(&self) -> &JurisdictionCode { &self.jurisdiction }
-    pub fn authority_policy_digest(&self) -> StoredDigest { self.authority_policy_digest }
-    pub fn workflow_policy_digest(&self) -> StoredDigest { self.workflow_policy_digest }
-    pub fn authorized_at_micros(&self) -> i64 { self.authorized_at_micros }
+    pub fn order_id(&self) -> &str {
+        &self.order_id
+    }
+
+    pub fn order_digest(&self) -> StoredDigest {
+        self.order_digest
+    }
+
+    pub fn principal(&self) -> PrincipalBinding {
+        self.principal
+    }
+
+    pub fn jurisdiction(&self) -> &JurisdictionCode {
+        &self.jurisdiction
+    }
+
+    pub fn authority_policy_digest(&self) -> StoredDigest {
+        self.authority_policy_digest
+    }
+
+    pub fn workflow_policy_digest(&self) -> StoredDigest {
+        self.workflow_policy_digest
+    }
+
+    pub fn authorized_at_micros(&self) -> i64 {
+        self.authorized_at_micros
+    }
+
     pub fn supporting_authority_evidence(&self) -> &[[u8; 32]] {
         &self.supporting_authority_evidence
     }
@@ -123,14 +165,37 @@ pub struct QuarantineResolutionCapability {
 }
 
 impl QuarantineResolutionCapability {
-    pub fn case_nonce(&self) -> [u8; 16] { self.case_nonce }
-    pub fn sequence(&self) -> u32 { self.sequence }
-    pub fn event_digest(&self) -> StoredDigest { self.event_digest.stored() }
-    pub fn disposition(&self) -> ResolutionDisposition { self.disposition }
-    pub fn principal(&self) -> PrincipalBinding { self.principal }
-    pub fn authority_policy_digest(&self) -> StoredDigest { self.authority_policy_digest }
-    pub fn workflow_policy_digest(&self) -> StoredDigest { self.workflow_policy_digest }
-    pub fn authorized_at_micros(&self) -> i64 { self.authorized_at_micros }
+    pub fn case_nonce(&self) -> [u8; 16] {
+        self.case_nonce
+    }
+
+    pub fn sequence(&self) -> u32 {
+        self.sequence
+    }
+
+    pub fn event_digest(&self) -> StoredDigest {
+        self.event_digest.stored()
+    }
+
+    pub fn disposition(&self) -> ResolutionDisposition {
+        self.disposition
+    }
+
+    pub fn principal(&self) -> PrincipalBinding {
+        self.principal
+    }
+
+    pub fn authority_policy_digest(&self) -> StoredDigest {
+        self.authority_policy_digest
+    }
+
+    pub fn workflow_policy_digest(&self) -> StoredDigest {
+        self.workflow_policy_digest
+    }
+
+    pub fn authorized_at_micros(&self) -> i64 {
+        self.authorized_at_micros
+    }
 
     #[allow(clippy::too_many_arguments)]
     pub fn resolve(

--- a/crates/clinical-workflow/tests/workflow_capabilities.rs
+++ b/crates/clinical-workflow/tests/workflow_capabilities.rs
@@ -1,0 +1,389 @@
+use mycelix_clinical_authority::{
+    evaluate_authority, AuthorityPermit, AuthorityPurpose, AuthorityRequest, CredentialKind,
+    EvidenceDigest, JurisdictionCode, PrincipalBinding, ResolvedCredentialEvidence, ScopeCode,
+};
+use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, VerifiedDigest};
+use mycelix_clinical_quarantine::{
+    ArtifactDigest, CommitmentScheme, DigestAlgorithm, OpaqueCommitment, QuarantineEvent,
+    QuarantineReasonCode, QuarantineScope, ResolutionDisposition,
+};
+use mycelix_clinical_semantics::{CodeableConcept, Coding, Quantity, Ratio, SubjectRef, UCUM_SYSTEM};
+use mycelix_clinical_workflow::{
+    authorize_medication_activation, authorize_quarantine_resolution, hash_medication_order,
+    hash_quarantine_event, WorkflowError, WorkflowPolicyV1,
+};
+use mycelix_medication_semantics::{
+    AdministrationTiming, DosageInstruction, DoseAmount, MedicationOrder, MedicationOrderProvenance,
+    MedicationRequestIntent, MedicationRequestStatus, RequesterAuthorityRef,
+};
+
+fn principal(byte: u8) -> PrincipalBinding {
+    PrincipalBinding([byte; 32])
+}
+
+fn jurisdiction() -> JurisdictionCode {
+    JurisdictionCode {
+        system: "urn:iso:std:iso:3166-2".into(),
+        code: "US-TX".into(),
+    }
+}
+
+fn scope(code: &str) -> ScopeCode {
+    ScopeCode {
+        system: "https://mycelix.health/authority-scope/v1".into(),
+        code: code.into(),
+    }
+}
+
+fn policy_digest(bytes: &[u8]) -> VerifiedDigest {
+    hash_canonical_bytes(DigestDomain::AuthorityPolicy, bytes).unwrap()
+}
+
+fn workflow_policy() -> WorkflowPolicyV1 {
+    WorkflowPolicyV1 {
+        schema_version: 1,
+        max_authority_age_micros: 60_000_000,
+        max_future_skew_micros: 1_000_000,
+    }
+}
+
+fn credential(
+    p: PrincipalBinding,
+    scope_code: &str,
+    seed: u8,
+) -> ResolvedCredentialEvidence {
+    ResolvedCredentialEvidence::from_verified_record(
+        CredentialKind::PractitionerLicense,
+        p,
+        vec![jurisdiction()],
+        vec![scope(scope_code)],
+        0,
+        Some(10_000_000_000),
+        None,
+        EvidenceDigest([seed; 32]),
+        EvidenceDigest([seed.wrapping_add(1); 32]),
+        EvidenceDigest([seed.wrapping_add(2); 32]),
+    )
+    .unwrap()
+}
+
+fn authority_for(
+    target: VerifiedDigest,
+    policy: VerifiedDigest,
+    purpose: AuthorityPurpose,
+    p: PrincipalBinding,
+    scope_code: &str,
+    evaluated_at: i64,
+) -> AuthorityPermit {
+    let request = AuthorityRequest {
+        principal: p,
+        target_artifact_digest: EvidenceDigest(target.value()),
+        policy_digest: EvidenceDigest(policy.value()),
+        purpose,
+        jurisdiction: jurisdiction(),
+        required_credential_kinds: vec![CredentialKind::PractitionerLicense],
+        required_scopes: vec![scope(scope_code)],
+        evaluated_at_micros: evaluated_at,
+    };
+    evaluate_authority(&request, &[credential(p, scope_code, 11)])
+        .unwrap()
+        .into_permit()
+        .expect("authority should be granted")
+}
+
+fn concept(system: &str, code: &str) -> CodeableConcept {
+    CodeableConcept {
+        coding: vec![Coding {
+            system: system.into(),
+            code: code.into(),
+            display: None,
+            version: None,
+        }],
+        text: None,
+    }
+}
+
+fn quantity(value: f64, code: &str) -> Quantity {
+    Quantity {
+        value,
+        display_unit: Some(code.into()),
+        system: UCUM_SYSTEM.into(),
+        code: code.into(),
+    }
+}
+
+fn medication_order(id: &str) -> MedicationOrder {
+    MedicationOrder {
+        order_id: id.into(),
+        subject: SubjectRef {
+            resource_type: "Patient".into(),
+            id: "patient-a".into(),
+        },
+        medication: concept("http://www.nlm.nih.gov/research/umls/rxnorm", "860975"),
+        product_strength: Some(Ratio {
+            numerator: quantity(500.0, "mg"),
+            denominator: quantity(1.0, "{tablet}"),
+        }),
+        status: MedicationRequestStatus::Active,
+        intent: MedicationRequestIntent::Order,
+        dosage: vec![DosageInstruction {
+            sequence: Some(1),
+            narrative_sig: Some("Take one tablet twice daily".into()),
+            patient_instruction: None,
+            timing: AdministrationTiming::Scheduled {
+                frequency: 2,
+                period: quantity(1.0, "d"),
+            },
+            route: concept("http://snomed.info/sct", "26643006"),
+            method: None,
+            site: None,
+            dose: DoseAmount::Quantity(quantity(1.0, "{tablet}")),
+            rate: None,
+            max_dose_per_period: Some(Ratio {
+                numerator: quantity(2.0, "{tablet}"),
+                denominator: quantity(1.0, "d"),
+            }),
+            max_dose_per_administration: Some(quantity(1.0, "{tablet}")),
+            max_dose_per_lifetime: None,
+        }],
+        dispense_quantity: Some(quantity(60.0, "{tablet}")),
+        refills_authorized: Some(1),
+        requester: Some(RequesterAuthorityRef {
+            requester_reference: "Practitioner/123".into(),
+            credential_reference: Some("mycelix:credential:abc".into()),
+        }),
+        authored_at_micros: Some(1),
+        provenance: MedicationOrderProvenance {
+            source_system: "https://ehr.example/fhir".into(),
+            source_resource_id: id.into(),
+            source_version: Some("1".into()),
+            recorded_at_micros: 1,
+        },
+    }
+}
+
+fn expect_workflow_error<T>(result: Result<T, WorkflowError>) -> WorkflowError {
+    match result {
+        Ok(_) => panic!("expected workflow denial"),
+        Err(error) => error,
+    }
+}
+
+#[test]
+fn medication_authority_cannot_cross_order_boundary() {
+    let p = principal(1);
+    let policy = policy_digest(b"prescribing-policy-v1");
+    let order_a = medication_order("order-a");
+    let order_b = medication_order("order-b");
+    let authority = authority_for(
+        hash_medication_order(&order_a).unwrap(),
+        policy,
+        AuthorityPurpose::Prescribe,
+        p,
+        "prescribe",
+        100,
+    );
+
+    let error = expect_workflow_error(authorize_medication_activation(
+        &order_b,
+        authority,
+        policy,
+        &workflow_policy(),
+        p,
+        &jurisdiction(),
+        200,
+    ));
+    assert!(matches!(error, WorkflowError::TargetDigestMismatch));
+}
+
+#[test]
+fn clinical_review_authority_cannot_be_replayed_as_prescribing() {
+    let p = principal(2);
+    let policy = policy_digest(b"review-policy-v1");
+    let order = medication_order("order-a");
+    let authority = authority_for(
+        hash_medication_order(&order).unwrap(),
+        policy,
+        AuthorityPurpose::ClinicalReview,
+        p,
+        "prescribe",
+        100,
+    );
+
+    let error = expect_workflow_error(authorize_medication_activation(
+        &order,
+        authority,
+        policy,
+        &workflow_policy(),
+        p,
+        &jurisdiction(),
+        200,
+    ));
+    assert!(matches!(error, WorkflowError::WrongAuthorityPurpose { .. }));
+}
+
+#[test]
+fn authenticated_principal_substitution_is_rejected() {
+    let authorized = principal(3);
+    let attacker = principal(4);
+    let policy = policy_digest(b"prescribing-policy-v1");
+    let order = medication_order("order-a");
+    let authority = authority_for(
+        hash_medication_order(&order).unwrap(),
+        policy,
+        AuthorityPurpose::Prescribe,
+        authorized,
+        "prescribe",
+        100,
+    );
+
+    let error = expect_workflow_error(authorize_medication_activation(
+        &order,
+        authority,
+        policy,
+        &workflow_policy(),
+        attacker,
+        &jurisdiction(),
+        200,
+    ));
+    assert!(matches!(error, WorkflowError::PrincipalMismatch));
+}
+
+#[test]
+fn stale_authority_cannot_be_converted_to_fresh_workflow_capability() {
+    let p = principal(5);
+    let policy = policy_digest(b"prescribing-policy-v1");
+    let order = medication_order("order-a");
+    let authority = authority_for(
+        hash_medication_order(&order).unwrap(),
+        policy,
+        AuthorityPurpose::Prescribe,
+        p,
+        "prescribe",
+        0,
+    );
+    let strict = WorkflowPolicyV1 {
+        schema_version: 1,
+        max_authority_age_micros: 10,
+        max_future_skew_micros: 0,
+    };
+
+    let error = expect_workflow_error(authorize_medication_activation(
+        &order,
+        authority,
+        policy,
+        &strict,
+        p,
+        &jurisdiction(),
+        11,
+    ));
+    assert!(matches!(error, WorkflowError::AuthorityEvaluationStale));
+}
+
+#[test]
+fn successful_medication_capability_is_bound_to_exact_digest() {
+    let p = principal(6);
+    let policy = policy_digest(b"prescribing-policy-v1");
+    let order = medication_order("order-a");
+    let digest = hash_medication_order(&order).unwrap();
+    let authority = authority_for(
+        digest,
+        policy,
+        AuthorityPurpose::Prescribe,
+        p,
+        "prescribe",
+        100,
+    );
+
+    let capability = authorize_medication_activation(
+        &order,
+        authority,
+        policy,
+        &workflow_policy(),
+        p,
+        &jurisdiction(),
+        200,
+    )
+    .unwrap();
+    assert_eq!(capability.order_id(), "order-a");
+    assert_eq!(capability.order_digest().value, digest.value());
+}
+
+#[test]
+fn quarantine_capability_rejects_changed_event() {
+    let pending = QuarantineEvent::new_pending(
+        [1; 16],
+        OpaqueCommitment {
+            scheme: CommitmentScheme::HmacSha256,
+            value: [2; 32],
+        },
+        QuarantineScope::ClinicalFact,
+        vec![QuarantineReasonCode::SemanticValidationFailure],
+        ArtifactDigest {
+            algorithm: DigestAlgorithm::Blake3,
+            value: [3; 32],
+        },
+        100,
+    )
+    .unwrap();
+    let review = QuarantineEvent::begin_review(
+        &pending,
+        ArtifactDigest {
+            algorithm: DigestAlgorithm::Blake3,
+            value: [4; 32],
+        },
+        ArtifactDigest {
+            algorithm: DigestAlgorithm::Blake3,
+            value: [5; 32],
+        },
+        OpaqueCommitment {
+            scheme: CommitmentScheme::HmacSha256,
+            value: [6; 32],
+        },
+        110,
+    )
+    .unwrap();
+
+    let p = principal(7);
+    let policy = policy_digest(b"clinical-review-policy-v1");
+    let authority = authority_for(
+        hash_quarantine_event(&review).unwrap(),
+        policy,
+        AuthorityPurpose::ClinicalReview,
+        p,
+        "clinical-review",
+        120,
+    );
+    let capability = authorize_quarantine_resolution(
+        &review,
+        ResolutionDisposition::Discard,
+        authority,
+        policy,
+        &workflow_policy(),
+        p,
+        &jurisdiction(),
+        130,
+    )
+    .unwrap();
+
+    let mut changed = review.clone();
+    changed.sequence += 1;
+    let error = expect_workflow_error(capability.resolve(
+        &changed,
+        ArtifactDigest {
+            algorithm: DigestAlgorithm::Blake3,
+            value: [7; 32],
+        },
+        OpaqueCommitment {
+            scheme: CommitmentScheme::HmacSha256,
+            value: [8; 32],
+        },
+        ArtifactDigest {
+            algorithm: DigestAlgorithm::Blake3,
+            value: [9; 32],
+        },
+        None,
+        140,
+    ));
+    assert!(matches!(error, WorkflowError::QuarantineTargetChanged));
+}

--- a/docs/CLINICAL_INTEGRITY_DIGEST_V1.md
+++ b/docs/CLINICAL_INTEGRITY_DIGEST_V1.md
@@ -1,0 +1,58 @@
+# Clinical Integrity Digest v1
+
+## Purpose
+
+Clinical artifact identity must say **what was hashed, under which semantic domain, and by which algorithm**. A bare 32-byte value is not enough.
+
+`mycelix-clinical-integrity` defines the v1 integrity contract used by high-assurance clinical workflow boundaries.
+
+## Algorithm
+
+v1 uses **BLAKE3-256 derive-key mode** with the fixed context:
+
+`mycelix.health.clinical-integrity.v1`
+
+The framed hash input is:
+
+1. frame version byte (`1`)
+2. big-endian domain-label length (`u16`)
+3. exact domain label bytes
+4. big-endian canonical-payload length (`u64`)
+5. exact canonical artifact bytes
+
+The domain is therefore part of the cryptographic input, not metadata attached after hashing.
+
+## Domain separation
+
+v1 domains include clinical artifacts, evidence capsules, medication orders, quarantine events/decisions, authority policies, issuer-trust policies, credential/status/issuer evidence, and workflow policy.
+
+The same canonical bytes under two different domains must produce different identities.
+
+## Stored versus verified digests
+
+`StoredDigest` is serializable and may cross a wire/storage boundary. It is only a **claim**.
+
+`VerifiedDigest` intentionally does not implement serde. It can be produced only by:
+
+- locally hashing canonical bytes; or
+- re-verifying a `StoredDigest` against the exact canonical bytes.
+
+Safe workflow code should depend on `VerifiedDigest`, not on untrusted stored bytes.
+
+## Canonicalization
+
+This crate deliberately does not claim that arbitrary JSON is canonical.
+
+Each owning artifact defines its own v1 canonical byte contract before calling `hash_canonical_bytes`. The initial workflow adapters use compact serde JSON over fixed Rust struct schemas and prepend an explicit schema tag before hashing. Any schema/field-order/encoding migration that changes canonical bytes changes the artifact identity and must be treated as a new versioned contract.
+
+Long-term cross-language interoperability should move these artifact encodings to a separately specified canonical serialization profile rather than assuming generic JSON equivalence.
+
+## Sensitive payloads
+
+This digest contract is for integrity identities of artifacts that are appropriate to identify deterministically.
+
+Rejected/raw clinical payloads that could enable confirmation attacks continue to use the separate **keyed commitment** boundary defined by the clinical quarantine layer. A BLAKE3 integrity digest is not a substitute for a keyed privacy-preserving commitment.
+
+## Non-claims
+
+A correct digest proves byte identity under this contract. It does not establish semantic correctness, clinical validity, authorization, consent, or regulatory compliance.

--- a/docs/CLINICAL_WORKFLOW_CAPABILITIES_V1.md
+++ b/docs/CLINICAL_WORKFLOW_CAPABILITIES_V1.md
@@ -1,0 +1,93 @@
+# Clinical Workflow Capabilities v1
+
+## Purpose
+
+A valid credential, authority decision, or qualified clinical assertion must not become a reusable role token.
+
+The v1 workflow boundary converts those upstream results into **single-owner, exact-target capabilities** for specific clinical workflow steps.
+
+## Central invariant
+
+> A valid permit for the wrong artifact, purpose, policy, principal, jurisdiction, or time is invalid.
+
+## Inputs checked at capability conversion
+
+The workflow layer requires and checks:
+
+- exact artifact digest computed under the correct clinical-integrity domain;
+- exact authority-policy digest;
+- exact authority purpose;
+- authenticated workflow principal;
+- exact jurisdiction;
+- bounded authority-evaluation age;
+- bounded future clock skew;
+- domain-specific safety state (for example, active medication-order semantics or supervised clinical qualification).
+
+The upstream `AuthorityPermit` is consumed by the conversion function. The resulting workflow capability implements no `Clone`, `Copy`, `Serialize`, `Deserialize`, or `Debug`.
+
+## Clinical presentation
+
+`authorize_clinical_presentation` requires:
+
+- `AuthorityPurpose::ClinicalReview`;
+- authority bound to the exact evidence-capsule digest;
+- the evidence capsule to pass the existing supervised-clinical qualification gate;
+- matching principal/jurisdiction/policy/freshness.
+
+This composes evidence qualification and human professional authority rather than letting either stand alone.
+
+## Medication activation
+
+`authorize_medication_activation` requires:
+
+- the exact `MedicationOrder` to pass `validate_active_order_candidate`;
+- `AuthorityPurpose::Prescribe`;
+- authority bound to the exact medication-order digest;
+- matching principal/jurisdiction/policy/freshness.
+
+A clinical-review permit cannot be replayed as prescribing authority, and prescribing authority for order A cannot activate order B.
+
+This still does not authorize dispensing or administration. Those are separate authority purposes and should receive separate workflow capabilities.
+
+## Quarantine resolution
+
+`authorize_quarantine_resolution` requires:
+
+- an exact `UnderReview` quarantine event;
+- `AuthorityPurpose::ClinicalReview`;
+- authority bound to that event's exact digest;
+- one exact terminal disposition (`Promote` or `Discard`).
+
+The returned `QuarantineResolutionCapability::resolve` consumes itself and re-hashes the event before creating the transition. If case identity, sequence, or event bytes changed after authorization, resolution fails closed.
+
+## Freshness
+
+`WorkflowPolicyV1` is itself domain-separated and hashed.
+
+v1 allows deployments to choose stricter values but refuses policies that permit:
+
+- authority older than 24 hours; or
+- future clock skew above five minutes.
+
+High-impact workflows such as prescribing should normally use substantially shorter authority lifetimes.
+
+## Canonical artifact identity
+
+The initial v1 adapters hash explicit schema-tagged compact JSON encodings for their fixed Rust structures. This is intentionally versioned and treated as an internal canonicalization contract, not a claim that arbitrary JSON is canonical across languages.
+
+Cross-language canonical serialization should be standardized separately before these digests become an external protocol contract.
+
+## Remaining hardening
+
+The next integration steps should:
+
+1. make clinician-facing CDS endpoints require `ClinicalPresentationCapability`;
+2. make prescription activation/signing require `MedicationActivationCapability`;
+3. route quarantine terminal transitions exclusively through `QuarantineResolutionCapability`;
+4. resolve FHIR requester/practitioner references to the authenticated `PrincipalBinding` rather than trusting textual references;
+5. migrate legacy bare `EvidenceDigest([u8; 32])` fields toward domain-aware verified digest types;
+6. add separate capability paths for dispense, administer, trial eligibility review, and research ethics review.
+
+## Non-claims
+
+A workflow capability proves that the configured software checks were satisfied for one exact workflow target. It does not establish clinical effectiveness, legal authority by itself, regulatory approval, correct treatment, or fitness for an intended use without the upstream evidence and external validation those policies require.


### PR DESCRIPTION
## Stack

Depends on #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30. Base is `feat/issuer-trust-policy-v1` so this PR isolates digest identity and workflow-capability composition.

## Why

The stack now has typed clinical semantics, evidence, qualification, medication semantics, quarantine lineage, practitioner authority, and issuer trust. The next risk is **cross-layer bypass**: a valid permit for one artifact/purpose must not authorize another artifact or workflow.

This PR converts upstream authority into exact-target, single-owner workflow capabilities and freezes the v1 digest/domain contract used at that boundary.

## What this adds

### `crates/clinical-integrity`

- BLAKE3-256 derive-key digest profile with fixed context
- explicit semantic digest domains
- length-framed domain separation
- serializable `StoredDigest` as an untrusted claim
- non-serializable `VerifiedDigest` produced only by local hashing/re-verification
- exact stored-digest verification against canonical bytes
- tests proving deterministic identity, domain separation, mismatch rejection, and empty-input rejection

### `crates/clinical-workflow`

- `WorkflowPolicyV1` with exact policy digest
- max authority age capped at 24h
- future clock-skew allowance capped at 5m
- `ClinicalPresentationCapability`
- `MedicationActivationCapability`
- `QuarantineResolutionCapability`
- all workflow capabilities intentionally implement no `Clone`, `Copy`, serde, or `Debug`
- authority permit is consumed during capability conversion
- exact target digest, authority policy, purpose, principal, jurisdiction, and freshness are rechecked
- clinical presentation additionally requires the supervised-clinical qualification gate
- medication activation additionally requires exact active-order semantics and `AuthorityPurpose::Prescribe`
- quarantine resolution requires exact `UnderReview` event + exact terminal disposition; the capability consumes itself to produce the terminal transition
- adversarial tests for cross-order replay, purpose substitution, principal substitution, stale authority, and quarantine target mutation

## Central invariant

> A valid permit for the wrong artifact, purpose, policy, principal, jurisdiction, or time is invalid.

Examples:

- authority for medication order A cannot activate order B;
- `ClinicalReview` authority cannot be replayed as `Prescribe`;
- a capability cannot be reused under another authenticated principal;
- stale authority cannot be converted to a fresh clinical capability;
- a quarantine event changed after authorization cannot be resolved with the old capability.

## Digest contract

A bare public 32-byte value is no longer sufficient at the final workflow boundary. `clinical-integrity` binds BLAKE3-256 to an explicit semantic domain. Wire/storage digests remain claims until reverified into `VerifiedDigest`.

The initial workflow artifact encodings are explicit schema-tagged compact JSON over fixed Rust structures. This is an internal v1 canonicalization contract, not a claim that arbitrary JSON is cross-language canonical. A future protocol-facing canonical encoding should be separately specified.

Sensitive rejected/raw clinical payload identity continues to use the quarantine layer's keyed commitments rather than deterministic public digests.

## Safe composition chain

`trust root`
-> `issuer authority`
-> `resolved credential`
-> `AuthorityPermit`
-> exact clinical artifact digest
-> domain safety/qualification checks
-> `WorkflowCapability`
-> one exact supervised workflow step

## Remaining integration work

1. make clinician-facing CDS endpoints require `ClinicalPresentationCapability`;
2. make prescription activation/signing require `MedicationActivationCapability`;
3. route quarantine terminal transitions exclusively through `QuarantineResolutionCapability`;
4. bind FHIR requester/practitioner references to authenticated principals;
5. migrate earlier bare `EvidenceDigest([u8;32])` fields to the domain-aware integrity type;
6. add distinct dispense/administer/trial/research-ethics workflow capabilities.

## Non-claims

This PR does not establish legal authority, clinical effectiveness, regulatory approval, safe dose selection, or fitness for intended use. It makes the software composition boundary explicit and fail-closed for one exact artifact/action.