### PR TITLE
security(provider): enforce provider ownership in DHT validation

### DIFF
--- a/docs/PROVIDER_INTEGRITY_AUTHORITY_V1.md
+++ b/docs/PROVIDER_INTEGRITY_AUTHORITY_V1.md
@@ -1,0 +1,65 @@
+# Provider Integrity Authority v1
+
+## Purpose
+
+This tranche moves provider ownership and cross-entry attachment checks from coordinator assumptions into DHT validation.
+
+The threat model includes a modified coordinator. If a rule matters to integrity, it must not depend only on the normal coordinator calling sequence.
+
+## Invariants
+
+1. A provider profile update must be authored by the original profile author.
+2. Provider NPI and legacy `mycelix_identity_hash` cannot be rebound through an update.
+3. `created_at` is immutable and `updated_at` is monotonic.
+4. Legacy `License` and `BoardCertification` entries may only be created by the referenced provider-record author.
+5. Legacy license/certification records are immutable. A changed claim is a new record/evidence event rather than mutation of history.
+6. Provider-patient relationship v1 creation requires the author to be the author of either the referenced provider record or referenced patient record.
+7. Relationship v1 records are immutable.
+8. Provider-to-license and provider-to-certification links must agree with the target entry's `provider_hash`, and provider + attachment + link must share the provider owner author.
+9. Provider-to-patient links may only be created by one of the referenced record authors.
+10. Provider update links must connect provider records authored by the same provider owner.
+11. Discovery/index links may only publish a provider record by that provider record's author.
+12. Reserved provider-to-records, provider-to-prescriptions, and provider-to-trials links fail closed until explicit authority semantics exist.
+13. Entry deletes and link deletes are original-author-only.
+
+## Non-claims
+
+### Provider ownership is not professional licensure
+
+A provider author can still submit a legacy `License` record about themselves. The integrity zome proves who authored/attached the record; it does not prove the external issuing authority, current registry status, jurisdictional scope, or legal authority.
+
+High-assurance flows must continue through:
+
+`issuer-trust -> resolved credential evidence -> clinical-authority -> exact workflow capability`
+
+### NPI format is not NPI verification
+
+The provider entry only checks the legacy 10-digit shape. NPI existence, ownership, enumeration type, deactivation, and current registry state require authoritative external evidence.
+
+### Relationship v1 is not bilateral consent
+
+The existing relationship schema contains provider/patient references but no consent-evidence digest or consent artifact reference. Integrity therefore cannot reconstruct the coordinator's `require_authorization(...)` decision from the relationship entry alone.
+
+A future relationship v2 should bind:
+
+- exact provider principal/binding;
+- exact patient principal/binding;
+- relationship purpose and scope;
+- consent artifact/evidence digest;
+- consent policy/version;
+- effective period;
+- revocation/termination lineage.
+
+Until then, `ProviderPatientRelationship` must not be used as standalone proof of bilateral patient consent.
+
+## Migration
+
+Existing provider, license, certification, and relationship entries remain readable. This tranche hardens new validation/update/link behavior and does not reinterpret legacy records as verified clinical authority.
+
+## Follow-on
+
+1. Build provider-principal adapters only from hardened provider lineage or stronger evidence.
+2. Add consent-evidence-bearing provider-patient relationship v2.
+3. Deprecate authority-significant use of `verify_provider_credentials`; its legacy status flags inspect provider-submitted records and do not replace issuer-trust/clinical-authority evaluation.
+4. Add external NPI/licensure registry adapters with provenance, freshness, and revocation evidence.
+5. Route medication requester resolution through `ResolvedPractitionerPrincipal` and then `AuthorityPermit`.

--- a/zomes/provider/integrity/src/lib.rs
+++ b/zomes/provider/integrity/src/lib.rs
@@ -4,8 +4,13 @@
 // Commercial licensing: see COMMERCIAL_LICENSE.md at repository root
 //! Healthcare Provider Credentials and Licensing Integrity Zome
 //!
-//! Defines entry types for healthcare providers, credentials,
-//! licenses, and specializations with verification tracking.
+//! Defines provider profiles and legacy provider-owned license/certification
+//! records. This zome enforces ownership and cross-entry attachment authority at
+//! DHT validation so a modified coordinator cannot bypass those checks.
+//!
+//! IMPORTANT: a provider-authored `License`/`BoardCertification` record is not
+//! proof of external licensure. High-assurance clinical authority must use the
+//! separate issuer-trust + clinical-authority stack.
 
 use hdi::prelude::*;
 
@@ -39,7 +44,7 @@ pub struct Provider {
     pub accepting_patients: bool,
     /// Telehealth capable
     pub telehealth_enabled: bool,
-    /// Mycelix identity link
+    /// Legacy Mycelix identity link. This is not an authenticated-principal proof.
     pub mycelix_identity_hash: Option<ActionHash>,
     /// MATL trust score based on patient outcomes and feedback
     pub matl_trust_score: f64,
@@ -100,7 +105,10 @@ pub struct ProviderContact {
     pub website: Option<String>,
 }
 
-/// Medical license credential
+/// Legacy provider-owned license record.
+///
+/// This records what the provider submitted. It is deliberately not treated as
+/// external licensing-authority evidence by the high-assurance authority stack.
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq)]
 pub struct License {
@@ -112,7 +120,7 @@ pub struct License {
     pub issued_date: String,
     pub expiration_date: String,
     pub status: LicenseStatus,
-    /// Verification from external source
+    /// Legacy verification source metadata; not sufficient authority evidence.
     pub verification_source: Option<String>,
     pub verified_at: Option<Timestamp>,
     pub verified_by: Option<AgentPubKey>,
@@ -142,7 +150,7 @@ pub enum LicenseStatus {
     Restricted,
 }
 
-/// Board certification
+/// Legacy provider-owned board-certification record.
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq)]
 pub struct BoardCertification {
@@ -164,7 +172,11 @@ pub enum CertificationStatus {
     Revoked,
 }
 
-/// Provider-patient relationship
+/// Provider-patient relationship.
+///
+/// v1 integrity proves that the author is one of the referenced record authors;
+/// it does NOT prove bilateral consent. Coordinator-side consent checks remain a
+/// separate layer until a consent-evidence-bearing relationship v2 is introduced.
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq)]
 pub struct ProviderPatientRelationship {
@@ -214,55 +226,162 @@ pub enum LinkTypes {
 pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
     match op.flattened::<EntryTypes, LinkTypes>()? {
         FlatOp::StoreEntry(store_entry) => match store_entry {
-            OpEntry::CreateEntry { app_entry, .. } => match app_entry {
-                EntryTypes::Provider(provider) => validate_provider(&provider),
-                EntryTypes::License(license) => validate_license(&license),
-                EntryTypes::BoardCertification(cert) => validate_certification(&cert),
-                EntryTypes::ProviderPatientRelationship(rel) => validate_relationship(&rel),
-            },
-            OpEntry::UpdateEntry { app_entry, .. } => match app_entry {
-                EntryTypes::Provider(provider) => validate_provider(&provider),
-                EntryTypes::License(license) => validate_license(&license),
-                EntryTypes::BoardCertification(cert) => validate_certification(&cert),
-                EntryTypes::ProviderPatientRelationship(rel) => validate_relationship(&rel),
-            },
+            OpEntry::CreateEntry { app_entry, action } => {
+                validate_create_entry(EntryCreationAction::Create(action), app_entry)
+            }
+            OpEntry::UpdateEntry {
+                app_entry, action, ..
+            } => validate_update_entry(action, app_entry),
             _ => Ok(ValidateCallbackResult::Valid),
         },
+        FlatOp::RegisterCreateLink {
+            link_type,
+            base_address,
+            target_address,
+            action,
+            ..
+        } => validate_create_link(link_type, base_address, target_address, action),
+        FlatOp::RegisterDeleteLink {
+            original_action,
+            action,
+            ..
+        } => {
+            if action.author != original_action.author {
+                return invalid("Only the original link creator can delete a provider link");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+        FlatOp::RegisterUpdate(update) => {
+            let action = match &update {
+                OpUpdate::Entry { action, .. }
+                | OpUpdate::PrivateEntry { action, .. }
+                | OpUpdate::Agent { action, .. }
+                | OpUpdate::CapClaim { action, .. }
+                | OpUpdate::CapGrant { action, .. } => action,
+            };
+            let original = must_get_action(action.original_action_address.clone())?;
+            if *original.action().author() != action.author {
+                return invalid("Only the original entry author can update a provider entry");
+            }
+            match update {
+                OpUpdate::Entry { app_entry, action } => validate_update_entry(action, app_entry),
+                _ => Ok(ValidateCallbackResult::Valid),
+            }
+        }
+        FlatOp::RegisterDelete(OpDelete { action }) => {
+            let original = must_get_action(action.deletes_address.clone())?;
+            if *original.action().author() != action.author {
+                return invalid("Only the original entry author can delete a provider entry");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
         _ => Ok(ValidateCallbackResult::Valid),
     }
 }
 
+fn validate_create_entry(
+    action: EntryCreationAction,
+    entry: EntryTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    match entry {
+        EntryTypes::Provider(provider) => validate_provider(&provider),
+        EntryTypes::License(license) => {
+            let shape = validate_license(&license)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_provider_owner(action.author(), &license.provider_hash)
+        }
+        EntryTypes::BoardCertification(cert) => {
+            let shape = validate_certification(&cert)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_provider_owner(action.author(), &cert.provider_hash)
+        }
+        EntryTypes::ProviderPatientRelationship(rel) => {
+            let shape = validate_relationship(&rel)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_relationship_participant(action.author(), &rel)
+        }
+    }
+}
+
+fn validate_update_entry(
+    action: Update,
+    entry: EntryTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    let original_action = must_get_action(action.original_action_address.clone())?;
+    if *original_action.action().author() != action.author {
+        return invalid("Only the original entry author can update a provider entry");
+    }
+
+    match entry {
+        EntryTypes::Provider(provider) => {
+            let original_record = must_get_valid_record(action.original_action_address.clone())?;
+            let original: Provider = decode_entry(&original_record, "provider")?;
+
+            // NPI and identity binding are identity-bearing fields. A profile may
+            // evolve, but those identifiers cannot be rebound through an update.
+            if original.npi != provider.npi {
+                return invalid("Provider NPI is immutable; create a new provider identity");
+            }
+            if original.mycelix_identity_hash != provider.mycelix_identity_hash {
+                return invalid(
+                    "Provider legacy identity binding is immutable; use a verified binding lineage",
+                );
+            }
+            if original.created_at != provider.created_at {
+                return invalid("Provider created_at is immutable");
+            }
+            if provider.updated_at < original.updated_at || provider.updated_at < provider.created_at {
+                return invalid("Provider updated_at must be monotonic and not predate created_at");
+            }
+            validate_provider(&provider)
+        }
+        EntryTypes::License(_) => invalid(
+            "Legacy provider license records are immutable; create a new evidence record",
+        ),
+        EntryTypes::BoardCertification(_) => invalid(
+            "Legacy board certification records are immutable; create a new evidence record",
+        ),
+        EntryTypes::ProviderPatientRelationship(_) => invalid(
+            "Provider-patient relationship v1 records are immutable; create a new relationship event",
+        ),
+    }
+}
+
 fn validate_provider(provider: &Provider) -> ExternResult<ValidateCallbackResult> {
-    if provider.first_name.is_empty() || provider.last_name.is_empty() {
-        return Ok(ValidateCallbackResult::Invalid(
-            "Provider first and last name are required".to_string(),
-        ));
+    if provider.first_name.trim().is_empty() || provider.last_name.trim().is_empty() {
+        return invalid("Provider first and last name are required");
     }
 
-    if provider.title.is_empty() {
-        return Ok(ValidateCallbackResult::Invalid(
-            "Provider title is required".to_string(),
-        ));
+    if provider.title.trim().is_empty() {
+        return invalid("Provider title is required");
     }
 
-    if provider.specialty.is_empty() {
-        return Ok(ValidateCallbackResult::Invalid(
-            "Provider specialty is required".to_string(),
-        ));
+    if provider.specialty.trim().is_empty() {
+        return invalid("Provider specialty is required");
     }
 
-    if provider.matl_trust_score < 0.0 || provider.matl_trust_score > 1.0 {
-        return Ok(ValidateCallbackResult::Invalid(
-            "MATL trust score must be between 0.0 and 1.0".to_string(),
-        ));
+    if !provider.matl_trust_score.is_finite()
+        || provider.matl_trust_score < 0.0
+        || provider.matl_trust_score > 1.0
+    {
+        return invalid("MATL trust score must be finite and between 0.0 and 1.0");
     }
 
-    // Validate NPI format if provided (US 10-digit standard)
+    if provider.updated_at < provider.created_at {
+        return invalid("Provider updated_at cannot predate created_at");
+    }
+
+    // Format validation only. NPI existence/ownership requires authoritative
+    // registry evidence and is never inferred from this field alone.
     if let Some(ref npi) = provider.npi {
         if npi.len() != 10 || !npi.chars().all(|c| c.is_ascii_digit()) {
-            return Ok(ValidateCallbackResult::Invalid(
-                "NPI must be a 10-digit number".to_string(),
-            ));
+            return invalid("NPI must be a 10-digit number");
         }
     }
 
@@ -270,40 +389,277 @@ fn validate_provider(provider: &Provider) -> ExternResult<ValidateCallbackResult
 }
 
 fn validate_license(license: &License) -> ExternResult<ValidateCallbackResult> {
-    if license.license_number.is_empty() {
-        return Ok(ValidateCallbackResult::Invalid(
-            "License number is required".to_string(),
-        ));
+    if license.license_number.trim().is_empty() {
+        return invalid("License number is required");
     }
-
-    if license.issuing_authority.is_empty() {
-        return Ok(ValidateCallbackResult::Invalid(
-            "Issuing authority is required".to_string(),
-        ));
+    if license.issuing_authority.trim().is_empty() {
+        return invalid("Issuing authority is required");
     }
-
+    if license.jurisdiction.trim().is_empty() {
+        return invalid("License jurisdiction is required");
+    }
+    if license.issued_date.trim().is_empty() || license.expiration_date.trim().is_empty() {
+        return invalid("License issue and expiration dates are required");
+    }
     Ok(ValidateCallbackResult::Valid)
 }
 
 fn validate_certification(cert: &BoardCertification) -> ExternResult<ValidateCallbackResult> {
-    if cert.board_name.is_empty() {
-        return Ok(ValidateCallbackResult::Invalid(
-            "Board name is required".to_string(),
-        ));
+    if cert.board_name.trim().is_empty() {
+        return invalid("Board name is required");
     }
-
-    if cert.specialty.is_empty() {
-        return Ok(ValidateCallbackResult::Invalid(
-            "Specialty is required".to_string(),
-        ));
+    if cert.specialty.trim().is_empty() {
+        return invalid("Specialty is required");
     }
-
+    if cert.initial_certification_date.trim().is_empty() || cert.expiration_date.trim().is_empty() {
+        return invalid("Certification issue and expiration dates are required");
+    }
     Ok(ValidateCallbackResult::Valid)
 }
 
 fn validate_relationship(
-    _rel: &ProviderPatientRelationship,
+    rel: &ProviderPatientRelationship,
 ) -> ExternResult<ValidateCallbackResult> {
-    // Relationship validation - hashes must exist (checked at runtime)
+    if rel.provider_hash == rel.patient_hash {
+        return invalid("Provider and patient references cannot be the same action");
+    }
+    if let Some(end) = rel.end_date {
+        if end < rel.start_date {
+            return invalid("Provider-patient relationship end cannot predate start");
+        }
+        if rel.is_active {
+            return invalid("Ended provider-patient relationship cannot remain active");
+        }
+    }
     Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_provider_owner(
+    author: &AgentPubKey,
+    provider_hash: &ActionHash,
+) -> ExternResult<ValidateCallbackResult> {
+    let provider_record = must_get_valid_record(provider_hash.clone())?;
+    let _: Provider = decode_entry(&provider_record, "provider")?;
+    if provider_record.action().author() != author {
+        return invalid("Only the provider profile author may attach this legacy record");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_relationship_participant(
+    author: &AgentPubKey,
+    rel: &ProviderPatientRelationship,
+) -> ExternResult<ValidateCallbackResult> {
+    let provider_record = must_get_valid_record(rel.provider_hash.clone())?;
+    let _: Provider = decode_entry(&provider_record, "provider")?;
+    let patient_record = must_get_valid_record(rel.patient_hash.clone())?;
+
+    if provider_record.action().author() != author && patient_record.action().author() != author {
+        return invalid("Only a referenced provider/patient record author may create the relationship");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_create_link(
+    link_type: LinkTypes,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    action: CreateLink,
+) -> ExternResult<ValidateCallbackResult> {
+    match link_type {
+        LinkTypes::ProviderToLicenses => {
+            let provider_hash = require_action_hash(base_address, "provider link base")?;
+            let license_hash = require_action_hash(target_address, "license link target")?;
+            let provider_record = must_get_valid_record(provider_hash.clone())?;
+            let _: Provider = decode_entry(&provider_record, "provider")?;
+            let license_record = must_get_valid_record(license_hash)?;
+            let license: License = decode_entry(&license_record, "license")?;
+
+            if license.provider_hash != provider_hash {
+                return invalid("License link target does not belong to provider link base");
+            }
+            if provider_record.action().author() != &action.author
+                || license_record.action().author() != &action.author
+            {
+                return invalid("Only provider owner may create provider-to-license link");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+        LinkTypes::ProviderToCertifications => {
+            let provider_hash = require_action_hash(base_address, "provider link base")?;
+            let cert_hash = require_action_hash(target_address, "certification link target")?;
+            let provider_record = must_get_valid_record(provider_hash.clone())?;
+            let _: Provider = decode_entry(&provider_record, "provider")?;
+            let cert_record = must_get_valid_record(cert_hash)?;
+            let cert: BoardCertification = decode_entry(&cert_record, "board certification")?;
+
+            if cert.provider_hash != provider_hash {
+                return invalid("Certification link target does not belong to provider link base");
+            }
+            if provider_record.action().author() != &action.author
+                || cert_record.action().author() != &action.author
+            {
+                return invalid("Only provider owner may create provider-to-certification link");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+        LinkTypes::ProviderToPatients => {
+            let provider_hash = require_action_hash(base_address, "provider link base")?;
+            let patient_hash = require_action_hash(target_address, "patient link target")?;
+            let provider_record = must_get_valid_record(provider_hash)?;
+            let _: Provider = decode_entry(&provider_record, "provider")?;
+            let patient_record = must_get_valid_record(patient_hash)?;
+
+            if provider_record.action().author() != &action.author
+                && patient_record.action().author() != &action.author
+            {
+                return invalid("Only a referenced provider/patient record author may create patient link");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+        LinkTypes::ProviderUpdates => {
+            let original_hash = require_action_hash(base_address, "provider update base")?;
+            let updated_hash = require_action_hash(target_address, "provider update target")?;
+            let original = must_get_valid_record(original_hash)?;
+            let updated = must_get_valid_record(updated_hash)?;
+            let _: Provider = decode_entry(&original, "provider update base")?;
+            let _: Provider = decode_entry(&updated, "provider update target")?;
+            if original.action().author() != &action.author
+                || updated.action().author() != &action.author
+            {
+                return invalid("Provider update link must be authored by provider owner");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+        LinkTypes::AllProviders | LinkTypes::ProvidersBySpecialty | LinkTypes::ProvidersByLocation => {
+            let target = require_action_hash(target_address, "provider index target")?;
+            let provider_record = must_get_valid_record(target)?;
+            let _: Provider = decode_entry(&provider_record, "provider index target")?;
+            if provider_record.action().author() != &action.author {
+                return invalid("Only provider owner may publish provider index links");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+        LinkTypes::ProviderToRecords
+        | LinkTypes::ProviderToPrescriptions
+        | LinkTypes::ProviderToTrials => invalid(
+            "Reserved provider link type is disabled until an explicit authority contract exists",
+        ),
+    }
+}
+
+fn require_action_hash(
+    hash: AnyLinkableHash,
+    field: &'static str,
+) -> ExternResult<ActionHash> {
+    hash.into_action_hash().ok_or(wasm_error!(WasmErrorInner::Guest(
+        format!("{field} must be an ActionHash")
+    )))
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(byte: u8) -> AgentPubKey {
+        AgentPubKey::from_raw_36(vec![byte; 36])
+    }
+
+    fn action_hash(byte: u8) -> ActionHash {
+        ActionHash::from_raw_36(vec![byte; 36])
+    }
+
+    fn provider() -> Provider {
+        Provider {
+            npi: Some("1234567890".into()),
+            provider_type: ProviderType::Physician,
+            first_name: "Ada".into(),
+            last_name: "Example".into(),
+            title: "MD".into(),
+            specialty: "Internal Medicine".into(),
+            sub_specialties: vec![],
+            organization: None,
+            locations: vec![],
+            contact: ProviderContact {
+                email: "a@example.invalid".into(),
+                phone_office: "000".into(),
+                phone_emergency: None,
+                website: None,
+            },
+            languages: vec!["en".into()],
+            accepting_patients: true,
+            telehealth_enabled: false,
+            mycelix_identity_hash: None,
+            matl_trust_score: 0.5,
+            epistemic_level: EpistemicLevel::Unverified,
+            created_at: Timestamp::from_micros(10),
+            updated_at: Timestamp::from_micros(10),
+        }
+    }
+
+    #[test]
+    fn non_finite_matl_score_is_rejected() {
+        let mut p = provider();
+        p.matl_trust_score = f64::NAN;
+        let result = validate_provider(&p).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn relationship_cannot_self_reference_same_action() {
+        let hash = action_hash(1);
+        let rel = ProviderPatientRelationship {
+            provider_hash: hash.clone(),
+            patient_hash: hash,
+            relationship_type: RelationshipType::PrimaryCare,
+            start_date: Timestamp::from_micros(1),
+            end_date: None,
+            is_active: true,
+            notes: None,
+        };
+        let result = validate_relationship(&rel).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn ended_relationship_cannot_be_active() {
+        let rel = ProviderPatientRelationship {
+            provider_hash: action_hash(1),
+            patient_hash: action_hash(2),
+            relationship_type: RelationshipType::PrimaryCare,
+            start_date: Timestamp::from_micros(1),
+            end_date: Some(Timestamp::from_micros(2)),
+            is_active: true,
+            notes: None,
+        };
+        let result = validate_relationship(&rel).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn provider_shape_accepts_finite_score_and_monotonic_time() {
+        assert_eq!(validate_provider(&provider()).unwrap(), ValidateCallbackResult::Valid);
+    }
+
+    #[test]
+    fn distinct_agents_are_not_equal() {
+        assert_ne!(agent(1), agent(2));
+    }
 }


### PR DESCRIPTION
## Stack

Depends on #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30. This PR implements the core of issue #41 at the provider integrity boundary.

## Why

The normal provider coordinator already checks creator ownership before profile updates and before adding licenses/certifications, but those are coordinator-side checks. A modified coordinator can bypass them unless the integrity zome independently enforces the same authority relationship.

## What this changes

- provider updates require original-author continuity in DHT validation;
- NPI, legacy `mycelix_identity_hash`, and `created_at` cannot be rebound through updates;
- `updated_at` must be monotonic;
- non-finite MATL trust scores are rejected;
- legacy provider-owned License/BoardCertification creation requires the referenced provider-record author;
- legacy license/certification records become immutable evidence records;
- provider-patient relationship v1 creation requires one referenced record author and is immutable;
- provider-to-license/certification links validate exact target ownership and `provider_hash` consistency;
- provider-to-patient links require one referenced record author;
- provider-update links require author continuity across both provider records;
- provider discovery/index links can only publish the author's provider record;
- reserved provider-to-records/provider-to-prescriptions/provider-to-trials link types fail closed until explicit authority semantics are implemented;
- entry/link deletion is original-author-only;
- `docs/PROVIDER_INTEGRITY_AUTHORITY_V1.md` documents the exact guarantees and non-claims.

## Important non-claims

### Provider ownership != licensure

A provider-authored legacy License or BoardCertification record remains self-submitted evidence. It is not accepted as external licensing authority. High-assurance workflows must use issuer-trust -> resolved credential -> clinical-authority -> workflow capability.

### NPI shape != NPI verification

The legacy field remains format-only. Authoritative registry evidence is separate.

### Relationship v1 != bilateral consent

The v1 relationship schema has no consent evidence reference, so DHT validation cannot prove the coordinator's `require_authorization(...)` decision. Issue #43 tracks a consent-evidence-bearing v2 relationship. Until then, the v1 record must not be used as standalone proof of bilateral consent.

## Central invariant

A modified coordinator must not be able to attach identity/credential records to another provider, rewrite provider identity-bearing fields, or manufacture authority-sensitive provider links that the integrity zome would reject.

## Follow-on

1. complete issue #41 with adversarial conductor/HDI integration tests;
2. add relationship v2 from issue #43;
3. deprecate authority-significant use of legacy `verify_provider_credentials`;
4. build MedicationRequest requester resolution through the hardened provider-principal + authority chain.