### PR TITLE
feat(health): require coverage-aware safety evidence for medication activation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "crates/clinical-workflow",
     "crates/provider-principal",
     "crates/fhir-medication-semantics",
+    "crates/medication-safety",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -23,6 +23,10 @@ pub enum DigestDomain {
     EvidenceCapsule,
     MedicationOrder,
     MedicationRequestArtifact,
+    MedicationSafetyContext,
+    MedicationSafetyKnowledge,
+    MedicationSafetyPolicy,
+    MedicationSafetyEvaluation,
     QuarantineEvent,
     QuarantineDecision,
     AuthorityPolicy,
@@ -40,6 +44,10 @@ impl DigestDomain {
             Self::EvidenceCapsule => b"evidence-capsule",
             Self::MedicationOrder => b"medication-order",
             Self::MedicationRequestArtifact => b"medication-request-artifact",
+            Self::MedicationSafetyContext => b"medication-safety-context",
+            Self::MedicationSafetyKnowledge => b"medication-safety-knowledge",
+            Self::MedicationSafetyPolicy => b"medication-safety-policy",
+            Self::MedicationSafetyEvaluation => b"medication-safety-evaluation",
             Self::QuarantineEvent => b"quarantine-event",
             Self::QuarantineDecision => b"quarantine-decision",
             Self::AuthorityPolicy => b"authority-policy",
@@ -200,9 +208,12 @@ mod tests {
         let order = hash_canonical_bytes(DigestDomain::MedicationOrder, payload).unwrap();
         let request =
             hash_canonical_bytes(DigestDomain::MedicationRequestArtifact, payload).unwrap();
+        let safety =
+            hash_canonical_bytes(DigestDomain::MedicationSafetyEvaluation, payload).unwrap();
         let policy = hash_canonical_bytes(DigestDomain::AuthorityPolicy, payload).unwrap();
         assert_ne!(order.value(), request.value());
-        assert_ne!(request.value(), policy.value());
+        assert_ne!(request.value(), safety.value());
+        assert_ne!(safety.value(), policy.value());
     }
 
     #[test]

--- a/crates/clinical-workflow/Cargo.toml
+++ b/crates/clinical-workflow/Cargo.toml
@@ -15,4 +15,5 @@ mycelix-clinical-evidence = { path = "../clinical-evidence" }
 mycelix-clinical-promotion = { path = "../clinical-promotion" }
 mycelix-medication-semantics = { path = "../medication-semantics" }
 mycelix-fhir-medication-semantics = { path = "../fhir-medication-semantics" }
+mycelix-medication-safety = { path = "../medication-safety" }
 mycelix-clinical-quarantine = { path = "../clinical-quarantine" }

--- a/crates/clinical-workflow/src/lib.rs
+++ b/crates/clinical-workflow/src/lib.rs
@@ -1,9 +1,10 @@
 #![deny(unsafe_code)]
 //! Exact-target capability composition for Mycelix-Health.
 //!
-//! A valid credential or qualification result is not sufficient on its own. This
-//! crate consumes a verifier-owned `AuthorityPermit` and rebinds it to one exact
-//! clinical artifact, purpose, policy, principal, jurisdiction, and execution time.
+//! A valid credential, requester identity, qualification result, or medication-safety
+//! result is not sufficient on its own. This crate composes verifier-owned evidence
+//! into exact-purpose, exact-target workflow capabilities.
+//!
 //! Resulting workflow capabilities intentionally implement no Clone/Copy/serde/Debug.
 
 use mycelix_clinical_authority::{
@@ -19,17 +20,23 @@ use mycelix_clinical_quarantine::{
     QuarantineState, ResolutionDisposition,
 };
 use mycelix_fhir_medication_semantics::MedicationRequestArtifact;
+use mycelix_medication_safety::MedicationSafetyClearance;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-const MAX_AUTHORITY_AGE_MICROS: i64 = 86_400_000_000;
+const MAX_EVIDENCE_AGE_MICROS: i64 = 86_400_000_000;
 const MAX_FUTURE_SKEW_MICROS: i64 = 300_000_000;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct WorkflowPolicyV1 {
     pub schema_version: u16,
+    /// Maximum age of the professional authority decision.
     pub max_authority_age_micros: i64,
+    /// Maximum age of the external-practitioner -> Mycelix-principal resolution.
+    pub max_requester_resolution_age_micros: i64,
+    /// Maximum time between medication safety clearance and activation.
+    pub max_safety_clearance_age_micros: i64,
     pub max_future_skew_micros: i64,
 }
 
@@ -40,11 +47,18 @@ impl WorkflowPolicyV1 {
                 self.schema_version,
             ));
         }
-        if self.max_authority_age_micros <= 0
-            || self.max_authority_age_micros > MAX_AUTHORITY_AGE_MICROS
-        {
-            return Err(WorkflowError::InvalidAuthorityAgePolicy);
-        }
+        validate_age_policy(
+            self.max_authority_age_micros,
+            WorkflowError::InvalidAuthorityAgePolicy,
+        )?;
+        validate_age_policy(
+            self.max_requester_resolution_age_micros,
+            WorkflowError::InvalidRequesterResolutionAgePolicy,
+        )?;
+        validate_age_policy(
+            self.max_safety_clearance_age_micros,
+            WorkflowError::InvalidSafetyClearanceAgePolicy,
+        )?;
         if self.max_future_skew_micros < 0
             || self.max_future_skew_micros > MAX_FUTURE_SKEW_MICROS
         {
@@ -61,6 +75,13 @@ impl WorkflowPolicyV1 {
             self,
         )
     }
+}
+
+fn validate_age_policy(age: i64, error: WorkflowError) -> Result<(), WorkflowError> {
+    if age <= 0 || age > MAX_EVIDENCE_AGE_MICROS {
+        return Err(error);
+    }
+    Ok(())
 }
 
 pub struct ClinicalPresentationCapability {
@@ -108,11 +129,12 @@ impl ClinicalPresentationCapability {
     }
 }
 
-/// Exact FHIR medication activation capability.
+/// Exact medication activation capability.
 ///
-/// It preserves two distinct proof lineages:
+/// It preserves three independent proof lineages:
 /// 1. requester -> authenticated principal resolution evidence;
-/// 2. professional authority evidence supporting the prescribing action.
+/// 2. professional authority evidence supporting the prescribing action;
+/// 3. patient-context/knowledge/evaluator evidence supporting medication safety.
 ///
 /// The capability is intentionally non-cloneable/non-serializable.
 pub struct MedicationActivationCapability {
@@ -121,6 +143,10 @@ pub struct MedicationActivationCapability {
     principal: PrincipalBinding,
     requester_resolution_evidence: [StoredDigest; 3],
     requester_resolved_at_micros: i64,
+    safety_context_digest: StoredDigest,
+    safety_policy_digest: StoredDigest,
+    safety_check_evaluation_digests: Vec<StoredDigest>,
+    safety_cleared_at_micros: i64,
     jurisdiction: JurisdictionCode,
     authority_policy_digest: StoredDigest,
     workflow_policy_digest: StoredDigest,
@@ -147,6 +173,22 @@ impl MedicationActivationCapability {
 
     pub fn requester_resolved_at_micros(&self) -> i64 {
         self.requester_resolved_at_micros
+    }
+
+    pub fn safety_context_digest(&self) -> StoredDigest {
+        self.safety_context_digest
+    }
+
+    pub fn safety_policy_digest(&self) -> StoredDigest {
+        self.safety_policy_digest
+    }
+
+    pub fn safety_check_evaluation_digests(&self) -> &[StoredDigest] {
+        &self.safety_check_evaluation_digests
+    }
+
+    pub fn safety_cleared_at_micros(&self) -> i64 {
+        self.safety_cleared_at_micros
     }
 
     pub fn jurisdiction(&self) -> &JurisdictionCode {
@@ -290,10 +332,13 @@ pub fn authorize_clinical_presentation(
 }
 
 /// Convert one strict FHIR MedicationRequest artifact into an exact activation
-/// capability. A bare `MedicationOrder` is intentionally insufficient because it
-/// does not prove who the external requester resolved to.
+/// capability. The safety clearance is consumed so the safe API cannot reuse one
+/// single-owner clearance across multiple activation calls.
+#[allow(clippy::too_many_arguments)]
 pub fn authorize_resolved_medication_activation(
     artifact: &MedicationRequestArtifact,
+    safety_clearance: MedicationSafetyClearance,
+    expected_safety_policy_digest: VerifiedDigest,
     authority: AuthorityPermit,
     authority_policy_digest: VerifiedDigest,
     workflow_policy: &WorkflowPolicyV1,
@@ -312,7 +357,8 @@ pub fn authorize_resolved_medication_activation(
     verify_freshness(
         artifact.requester_resolved_at_micros(),
         execution_at_micros,
-        workflow_policy,
+        workflow_policy.max_requester_resolution_age_micros,
+        workflow_policy.max_future_skew_micros,
         WorkflowError::RequesterResolutionFromFuture,
         WorkflowError::RequesterResolutionStale,
     )?;
@@ -321,6 +367,32 @@ pub fn authorize_resolved_medication_activation(
         .verified_digest()
         .map_err(|error| WorkflowError::MedicationArtifact(error.to_string()))?;
     artifact_digest.require_domain(DigestDomain::MedicationRequestArtifact)?;
+
+    expected_safety_policy_digest.require_domain(DigestDomain::MedicationSafetyPolicy)?;
+    if safety_clearance.medication_artifact_digest() != artifact_digest.stored() {
+        return Err(WorkflowError::SafetyClearanceMedicationMismatch);
+    }
+    if safety_clearance.policy_digest() != expected_safety_policy_digest.stored() {
+        return Err(WorkflowError::SafetyPolicyDigestMismatch);
+    }
+
+    let safety_context_digest = safety_clearance.context_digest();
+    validate_stored_domain(safety_context_digest, DigestDomain::MedicationSafetyContext)?;
+    let safety_check_evaluation_digests = safety_clearance.check_evaluation_digests().to_vec();
+    if safety_check_evaluation_digests.is_empty() {
+        return Err(WorkflowError::SafetyClearanceHasNoChecks);
+    }
+    for digest in &safety_check_evaluation_digests {
+        validate_stored_domain(*digest, DigestDomain::MedicationSafetyEvaluation)?;
+    }
+    verify_freshness(
+        safety_clearance.cleared_at_micros(),
+        execution_at_micros,
+        workflow_policy.max_safety_clearance_age_micros,
+        workflow_policy.max_future_skew_micros,
+        WorkflowError::SafetyClearanceFromFuture,
+        WorkflowError::SafetyClearanceStale,
+    )?;
 
     let workflow_policy_digest = workflow_policy.verified_digest()?;
     let evidence = verify_authority_binding(
@@ -344,6 +416,10 @@ pub fn authorize_resolved_medication_activation(
             artifact.requester_status_evidence_digest(),
         ],
         requester_resolved_at_micros: artifact.requester_resolved_at_micros(),
+        safety_context_digest,
+        safety_policy_digest: expected_safety_policy_digest.stored(),
+        safety_check_evaluation_digests,
+        safety_cleared_at_micros: safety_clearance.cleared_at_micros(),
         jurisdiction: jurisdiction.clone(),
         authority_policy_digest: authority_policy_digest.stored(),
         workflow_policy_digest: workflow_policy_digest.stored(),
@@ -422,6 +498,20 @@ fn hash_json<T: Serialize>(
     Ok(hash_canonical_bytes(domain, &framed)?)
 }
 
+fn validate_stored_domain(
+    digest: StoredDigest,
+    expected: DigestDomain,
+) -> Result<(), WorkflowError> {
+    digest.validate_shape()?;
+    if digest.domain != expected {
+        return Err(WorkflowError::StoredEvidenceDomainMismatch {
+            expected,
+            actual: digest.domain,
+        });
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn verify_authority_binding(
     authority: &AuthorityPermit,
@@ -458,7 +548,8 @@ fn verify_authority_binding(
     verify_freshness(
         authority.evaluated_at_micros(),
         execution_at_micros,
-        workflow_policy,
+        workflow_policy.max_authority_age_micros,
+        workflow_policy.max_future_skew_micros,
         WorkflowError::AuthorityEvaluationFromFuture,
         WorkflowError::AuthorityEvaluationStale,
     )?;
@@ -473,15 +564,16 @@ fn verify_authority_binding(
 fn verify_freshness(
     evidence_at_micros: i64,
     execution_at_micros: i64,
-    workflow_policy: &WorkflowPolicyV1,
+    max_age_micros: i64,
+    max_future_skew_micros: i64,
     future_error: WorkflowError,
     stale_error: WorkflowError,
 ) -> Result<(), WorkflowError> {
     let delta = execution_at_micros as i128 - evidence_at_micros as i128;
-    if delta < -(workflow_policy.max_future_skew_micros as i128) {
+    if delta < -(max_future_skew_micros as i128) {
         return Err(future_error);
     }
-    if delta > workflow_policy.max_authority_age_micros as i128 {
+    if delta > max_age_micros as i128 {
         return Err(stale_error);
     }
     Ok(())
@@ -493,12 +585,21 @@ pub enum WorkflowError {
     UnsupportedWorkflowPolicyVersion(u16),
     #[error("workflow authority age must be > 0 and <= 24 hours")]
     InvalidAuthorityAgePolicy,
+    #[error("workflow requester-resolution age must be > 0 and <= 24 hours")]
+    InvalidRequesterResolutionAgePolicy,
+    #[error("workflow safety-clearance age must be > 0 and <= 24 hours")]
+    InvalidSafetyClearanceAgePolicy,
     #[error("workflow future-skew allowance must be between 0 and 5 minutes")]
     InvalidFutureSkewPolicy,
     #[error("failed to serialize exact artifact under its v1 canonical JSON contract: {0}")]
     CanonicalSerialization(String),
     #[error(transparent)]
     Integrity(#[from] IntegrityError),
+    #[error("stored evidence digest domain mismatch: expected {expected:?}, got {actual:?}")]
+    StoredEvidenceDomainMismatch {
+        expected: DigestDomain,
+        actual: DigestDomain,
+    },
     #[error("authority target digest does not match exact workflow artifact")]
     TargetDigestMismatch,
     #[error("authority policy digest does not match the verified policy identity")]
@@ -522,6 +623,16 @@ pub enum WorkflowError {
     RequesterResolutionFromFuture,
     #[error("requester identity resolution is stale for workflow policy")]
     RequesterResolutionStale,
+    #[error("medication safety clearance targets a different medication artifact")]
+    SafetyClearanceMedicationMismatch,
+    #[error("medication safety clearance was produced under a different safety policy")]
+    SafetyPolicyDigestMismatch,
+    #[error("medication safety clearance contains no safety-check evidence")]
+    SafetyClearanceHasNoChecks,
+    #[error("medication safety clearance is too far in the future for workflow policy")]
+    SafetyClearanceFromFuture,
+    #[error("medication safety clearance is stale for workflow policy")]
+    SafetyClearanceStale,
     #[error("clinical qualification gate denied presentation: {0:?}")]
     ClinicalQualificationDenied(GateDecision),
     #[error("clinical qualification validation failed: {0}")]

--- a/crates/clinical-workflow/tests/workflow_capabilities.rs
+++ b/crates/clinical-workflow/tests/workflow_capabilities.rs
@@ -14,6 +14,12 @@ use mycelix_clinical_workflow::{
 use mycelix_fhir_medication_semantics::{
     project_active_medication_request_strict, MedicationRequestArtifact,
 };
+use mycelix_medication_safety::{
+    evaluate_medication_safety, hash_safety_knowledge_artifact, CheckRequirement,
+    ContextComponent, ContextEvidenceState, ContextRequirement, KnowledgeCoverage,
+    MedicationSafetyClearance, MedicationSafetyContextSnapshot, MedicationSafetyPolicyV1,
+    SafetyCheckKind, SafetyCheckOutcome, SafetyContextKind, VerifiedSafetyCheck,
+};
 use mycelix_provider_principal::{
     ExternalIdentifier, ExternalReferenceBinding, ExternalResourceKey,
     VerifiedProviderPrincipalBinding,
@@ -46,6 +52,8 @@ fn workflow_policy() -> WorkflowPolicyV1 {
     WorkflowPolicyV1 {
         schema_version: 1,
         max_authority_age_micros: 60_000_000,
+        max_requester_resolution_age_micros: 60_000_000,
+        max_safety_clearance_age_micros: 60_000_000,
         max_future_skew_micros: 1_000_000,
     }
 }
@@ -94,7 +102,7 @@ fn authority_for(
         .expect("authority should be granted")
 }
 
-fn provider_digest(seed: u8) -> VerifiedDigest {
+fn clinical_digest(seed: u8) -> VerifiedDigest {
     hash_canonical_bytes(DigestDomain::ClinicalArtifact, &[seed]).unwrap()
 }
 
@@ -115,9 +123,9 @@ fn provider_binding(p: PrincipalBinding) -> VerifiedProviderPrincipalBinding {
         0,
         Some(10_000_000_000),
         None,
-        provider_digest(21),
-        provider_digest(22),
-        provider_digest(23),
+        clinical_digest(21),
+        clinical_digest(22),
+        clinical_digest(23),
     )
     .unwrap()
 }
@@ -179,6 +187,72 @@ fn medication_artifact(
     .unwrap()
 }
 
+fn safety_policy() -> MedicationSafetyPolicyV1 {
+    MedicationSafetyPolicyV1 {
+        schema_version: 1,
+        policy_id: "workflow-test-medication-safety-v1".into(),
+        required_context: vec![ContextRequirement {
+            kind: SafetyContextKind::AllergiesIntolerances,
+            max_age_micros: Some(1_000_000),
+            allow_verified_absent: true,
+            allow_not_applicable: false,
+        }],
+        required_checks: vec![CheckRequirement {
+            kind: SafetyCheckKind::DrugAllergy,
+            max_evaluation_age_micros: 1_000_000,
+            max_knowledge_age_micros: 1_000_000,
+        }],
+        max_future_skew_micros: 0,
+    }
+}
+
+fn safety_clearance(
+    artifact: &MedicationRequestArtifact,
+    cleared_at: i64,
+) -> (MedicationSafetyClearance, VerifiedDigest) {
+    let context = MedicationSafetyContextSnapshot::from_verified_components(
+        artifact,
+        vec![ContextComponent::from_verified_evidence(
+            SafetyContextKind::AllergiesIntolerances,
+            ContextEvidenceState::VerifiedAbsent,
+            clinical_digest(31),
+            cleared_at,
+            None,
+        )
+        .unwrap()],
+        cleared_at,
+    )
+    .unwrap();
+    let policy = safety_policy();
+    let policy_digest = policy.verified_digest().unwrap();
+    let check = VerifiedSafetyCheck::from_verified_evaluation(
+        SafetyCheckKind::DrugAllergy,
+        artifact.verified_digest().unwrap(),
+        context.verified_digest().unwrap(),
+        policy_digest,
+        hash_safety_knowledge_artifact(b"qualified-test-allergy-knowledge-v1").unwrap(),
+        clinical_digest(32),
+        KnowledgeCoverage::CompleteForPolicy,
+        SafetyCheckOutcome::Clear,
+        0,
+        cleared_at,
+        cleared_at,
+    )
+    .unwrap();
+    let evaluation = evaluate_medication_safety(
+        artifact,
+        &context,
+        &policy,
+        &[check],
+        cleared_at,
+    )
+    .unwrap();
+    (
+        evaluation.into_clearance().expect("safety clearance expected"),
+        policy_digest,
+    )
+}
+
 fn expect_workflow_error<T>(result: Result<T, WorkflowError>) -> WorkflowError {
     match result {
         Ok(_) => panic!("expected workflow denial"),
@@ -189,22 +263,25 @@ fn expect_workflow_error<T>(result: Result<T, WorkflowError>) -> WorkflowError {
 #[test]
 fn medication_authority_cannot_cross_artifact_boundary() {
     let p = principal(1);
-    let policy = policy_digest(b"prescribing-policy-v1");
+    let authority_policy = policy_digest(b"prescribing-policy-v1");
     let artifact_a = medication_artifact("order-a", p, 100);
     let artifact_b = medication_artifact("order-b", p, 100);
     let authority = authority_for(
         artifact_a.verified_digest().unwrap(),
-        policy,
+        authority_policy,
         AuthorityPurpose::Prescribe,
         p,
         "prescribe",
         100,
     );
+    let (clearance_b, safety_policy_digest) = safety_clearance(&artifact_b, 150);
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact_b,
+        clearance_b,
+        safety_policy_digest,
         authority,
-        policy,
+        authority_policy,
         &workflow_policy(),
         p,
         &jurisdiction(),
@@ -214,23 +291,93 @@ fn medication_authority_cannot_cross_artifact_boundary() {
 }
 
 #[test]
-fn clinical_review_authority_cannot_be_replayed_as_prescribing() {
+fn safety_clearance_cannot_cross_medication_boundary() {
     let p = principal(2);
-    let policy = policy_digest(b"review-policy-v1");
+    let authority_policy = policy_digest(b"prescribing-policy-v1");
+    let artifact_a = medication_artifact("order-a", p, 100);
+    let artifact_b = medication_artifact("order-b", p, 100);
+    let authority = authority_for(
+        artifact_b.verified_digest().unwrap(),
+        authority_policy,
+        AuthorityPurpose::Prescribe,
+        p,
+        "prescribe",
+        100,
+    );
+    let (clearance_a, safety_policy_digest) = safety_clearance(&artifact_a, 150);
+
+    let error = expect_workflow_error(authorize_resolved_medication_activation(
+        &artifact_b,
+        clearance_a,
+        safety_policy_digest,
+        authority,
+        authority_policy,
+        &workflow_policy(),
+        p,
+        &jurisdiction(),
+        200,
+    ));
+    assert!(matches!(
+        error,
+        WorkflowError::SafetyClearanceMedicationMismatch
+    ));
+}
+
+#[test]
+fn safety_clearance_policy_substitution_is_rejected() {
+    let p = principal(3);
+    let authority_policy = policy_digest(b"prescribing-policy-v1");
     let artifact = medication_artifact("order-a", p, 100);
     let authority = authority_for(
         artifact.verified_digest().unwrap(),
-        policy,
+        authority_policy,
+        AuthorityPurpose::Prescribe,
+        p,
+        "prescribe",
+        100,
+    );
+    let (clearance, _) = safety_clearance(&artifact, 150);
+    let wrong_safety_policy = hash_canonical_bytes(
+        DigestDomain::MedicationSafetyPolicy,
+        b"different-qualified-safety-policy",
+    )
+    .unwrap();
+
+    let error = expect_workflow_error(authorize_resolved_medication_activation(
+        &artifact,
+        clearance,
+        wrong_safety_policy,
+        authority,
+        authority_policy,
+        &workflow_policy(),
+        p,
+        &jurisdiction(),
+        200,
+    ));
+    assert!(matches!(error, WorkflowError::SafetyPolicyDigestMismatch));
+}
+
+#[test]
+fn clinical_review_authority_cannot_be_replayed_as_prescribing() {
+    let p = principal(4);
+    let authority_policy = policy_digest(b"review-policy-v1");
+    let artifact = medication_artifact("order-a", p, 100);
+    let authority = authority_for(
+        artifact.verified_digest().unwrap(),
+        authority_policy,
         AuthorityPurpose::ClinicalReview,
         p,
         "prescribe",
         100,
     );
+    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 150);
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact,
+        clearance,
+        safety_policy_digest,
         authority,
-        policy,
+        authority_policy,
         &workflow_policy(),
         p,
         &jurisdiction(),
@@ -241,23 +388,26 @@ fn clinical_review_authority_cannot_be_replayed_as_prescribing() {
 
 #[test]
 fn requester_principal_substitution_is_rejected_before_action() {
-    let requester = principal(3);
-    let attacker = principal(4);
-    let policy = policy_digest(b"prescribing-policy-v1");
+    let requester = principal(5);
+    let attacker = principal(6);
+    let authority_policy = policy_digest(b"prescribing-policy-v1");
     let artifact = medication_artifact("order-a", requester, 100);
     let authority = authority_for(
         artifact.verified_digest().unwrap(),
-        policy,
+        authority_policy,
         AuthorityPurpose::Prescribe,
         requester,
         "prescribe",
         100,
     );
+    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 150);
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact,
+        clearance,
+        safety_policy_digest,
         authority,
-        policy,
+        authority_policy,
         &workflow_policy(),
         attacker,
         &jurisdiction(),
@@ -268,27 +418,32 @@ fn requester_principal_substitution_is_rejected_before_action() {
 
 #[test]
 fn stale_authority_cannot_be_converted_to_fresh_workflow_capability() {
-    let p = principal(5);
-    let policy = policy_digest(b"prescribing-policy-v1");
+    let p = principal(7);
+    let authority_policy = policy_digest(b"prescribing-policy-v1");
     let artifact = medication_artifact("order-a", p, 10);
     let authority = authority_for(
         artifact.verified_digest().unwrap(),
-        policy,
+        authority_policy,
         AuthorityPurpose::Prescribe,
         p,
         "prescribe",
         0,
     );
+    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 11);
     let strict = WorkflowPolicyV1 {
         schema_version: 1,
         max_authority_age_micros: 10,
+        max_requester_resolution_age_micros: 100,
+        max_safety_clearance_age_micros: 100,
         max_future_skew_micros: 0,
     };
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact,
+        clearance,
+        safety_policy_digest,
         authority,
-        policy,
+        authority_policy,
         &strict,
         p,
         &jurisdiction(),
@@ -299,27 +454,32 @@ fn stale_authority_cannot_be_converted_to_fresh_workflow_capability() {
 
 #[test]
 fn stale_requester_resolution_cannot_be_reused() {
-    let p = principal(6);
-    let policy = policy_digest(b"prescribing-policy-v1");
+    let p = principal(8);
+    let authority_policy = policy_digest(b"prescribing-policy-v1");
     let artifact = medication_artifact("order-a", p, 0);
     let authority = authority_for(
         artifact.verified_digest().unwrap(),
-        policy,
+        authority_policy,
         AuthorityPurpose::Prescribe,
         p,
         "prescribe",
         11,
     );
+    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 11);
     let strict = WorkflowPolicyV1 {
         schema_version: 1,
-        max_authority_age_micros: 10,
+        max_authority_age_micros: 100,
+        max_requester_resolution_age_micros: 10,
+        max_safety_clearance_age_micros: 100,
         max_future_skew_micros: 0,
     };
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact,
+        clearance,
+        safety_policy_digest,
         authority,
-        policy,
+        authority_policy,
         &strict,
         p,
         &jurisdiction(),
@@ -329,34 +489,88 @@ fn stale_requester_resolution_cannot_be_reused() {
 }
 
 #[test]
-fn successful_medication_capability_binds_requester_and_artifact_evidence() {
-    let p = principal(7);
-    let policy = policy_digest(b"prescribing-policy-v1");
-    let artifact = medication_artifact("order-a", p, 100);
-    let digest = artifact.verified_digest().unwrap();
+fn stale_safety_clearance_cannot_be_reused() {
+    let p = principal(9);
+    let authority_policy = policy_digest(b"prescribing-policy-v1");
+    let artifact = medication_artifact("order-a", p, 0);
     let authority = authority_for(
-        digest,
-        policy,
+        artifact.verified_digest().unwrap(),
+        authority_policy,
+        AuthorityPurpose::Prescribe,
+        p,
+        "prescribe",
+        11,
+    );
+    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 0);
+    let strict = WorkflowPolicyV1 {
+        schema_version: 1,
+        max_authority_age_micros: 100,
+        max_requester_resolution_age_micros: 100,
+        max_safety_clearance_age_micros: 10,
+        max_future_skew_micros: 0,
+    };
+
+    let error = expect_workflow_error(authorize_resolved_medication_activation(
+        &artifact,
+        clearance,
+        safety_policy_digest,
+        authority,
+        authority_policy,
+        &strict,
+        p,
+        &jurisdiction(),
+        11,
+    ));
+    assert!(matches!(error, WorkflowError::SafetyClearanceStale));
+}
+
+#[test]
+fn successful_medication_capability_binds_all_three_evidence_lineages() {
+    let p = principal(10);
+    let authority_policy = policy_digest(b"prescribing-policy-v1");
+    let artifact = medication_artifact("order-a", p, 100);
+    let artifact_digest = artifact.verified_digest().unwrap();
+    let authority = authority_for(
+        artifact_digest,
+        authority_policy,
         AuthorityPurpose::Prescribe,
         p,
         "prescribe",
         100,
     );
+    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 150);
 
     let capability = authorize_resolved_medication_activation(
         &artifact,
+        clearance,
+        safety_policy_digest,
         authority,
-        policy,
+        authority_policy,
         &workflow_policy(),
         p,
         &jurisdiction(),
         200,
     )
     .unwrap();
-    assert_eq!(capability.order_id(), "fhir:https://ehr.example/fhir:MedicationRequest:order-a");
-    assert_eq!(capability.medication_artifact_digest().value, digest.value());
+    assert_eq!(
+        capability.order_id(),
+        "fhir:https://ehr.example/fhir:MedicationRequest:order-a"
+    );
+    assert_eq!(
+        capability.medication_artifact_digest().value,
+        artifact_digest.value()
+    );
     assert_eq!(capability.principal(), p);
     assert_eq!(capability.requester_resolution_evidence().len(), 3);
+    assert_eq!(
+        capability.safety_policy_digest().value,
+        safety_policy_digest.value()
+    );
+    assert_eq!(capability.safety_check_evaluation_digests().len(), 1);
+    assert_eq!(
+        capability.safety_context_digest().domain,
+        DigestDomain::MedicationSafetyContext
+    );
 }
 
 #[test]
@@ -394,11 +608,11 @@ fn quarantine_capability_rejects_changed_event() {
     )
     .unwrap();
 
-    let p = principal(8);
-    let policy = policy_digest(b"clinical-review-policy-v1");
+    let p = principal(11);
+    let authority_policy = policy_digest(b"clinical-review-policy-v1");
     let authority = authority_for(
         hash_quarantine_event(&review).unwrap(),
-        policy,
+        authority_policy,
         AuthorityPurpose::ClinicalReview,
         p,
         "clinical-review",
@@ -408,7 +622,7 @@ fn quarantine_capability_rejects_changed_event() {
         &review,
         ResolutionDisposition::Discard,
         authority,
-        policy,
+        authority_policy,
         &workflow_policy(),
         p,
         &jurisdiction(),

--- a/crates/medication-safety/Cargo.toml
+++ b/crates/medication-safety/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mycelix-medication-safety"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Coverage-aware medication safety evidence and clearance semantics for Mycelix-Health"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
+mycelix-clinical-semantics = { path = "../clinical-semantics" }
+mycelix-fhir-medication-semantics = { path = "../fhir-medication-semantics" }

--- a/crates/medication-safety/src/lib.rs
+++ b/crates/medication-safety/src/lib.rs
@@ -1,0 +1,1205 @@
+#![deny(unsafe_code)]
+//! Coverage-aware medication safety evidence for Mycelix-Health.
+//!
+//! The central invariant is epistemic rather than pharmacological:
+//!
+//! **"No finding" is not the same as "safe".**
+//!
+//! A clearance is produced only when an explicit policy's required patient-context
+//! components and safety checks are present, fresh, bound to the exact medication
+//! artifact, evaluated against identified knowledge artifacts, and report complete
+//! coverage with a clear outcome. Missing/partial/stale evidence is indeterminate.
+//!
+//! This crate does not contain a drug database or calculate clinical interactions.
+//! Trusted adapters feed it verified evaluation evidence from qualified knowledge
+//! sources. The output clearance is deliberately non-serializable/non-cloneable.
+
+use mycelix_clinical_integrity::{
+    hash_canonical_bytes, DigestDomain, IntegrityError, StoredDigest, VerifiedDigest,
+};
+use mycelix_clinical_semantics::SubjectRef;
+use mycelix_fhir_medication_semantics::MedicationRequestArtifact;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashSet};
+use thiserror::Error;
+
+const MAX_FUTURE_SKEW_MICROS: i64 = 300_000_000; // five minutes
+const CONTEXT_SCHEMA_TAG: &[u8] = b"mycelix-health/medication-safety-context-v1";
+const POLICY_SCHEMA_TAG: &[u8] = b"mycelix-health/medication-safety-policy-v1";
+const CHECK_SCHEMA_TAG: &[u8] = b"mycelix-health/medication-safety-check-v1";
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum SafetyContextKind {
+    ActiveMedications,
+    AllergiesIntolerances,
+    ActiveConditions,
+    RenalFunction,
+    HepaticFunction,
+    PregnancyLactation,
+    Age,
+    Weight,
+    Pharmacogenomics,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub enum ContextEvidenceState {
+    /// Relevant clinical evidence is present in the bound evidence artifact.
+    Available,
+    /// An evidence-bearing process established absence, e.g. medication list reviewed
+    /// and no other active medication was reported. This is not the same as an empty list.
+    VerifiedAbsent,
+    /// An evidence-bearing applicability decision established that this context is not
+    /// applicable under the policy. Policies must opt in to accepting this state.
+    NotApplicable,
+}
+
+/// One patient-context component bound to a separately verified clinical artifact.
+///
+/// It is serializable as part of an exact context snapshot but not deserializable into
+/// trusted state. Construction requires an in-process `VerifiedDigest`.
+#[derive(Serialize)]
+pub struct ContextComponent {
+    kind: SafetyContextKind,
+    state: ContextEvidenceState,
+    evidence_digest: StoredDigest,
+    observed_at_micros: i64,
+    valid_until_micros: Option<i64>,
+}
+
+impl ContextComponent {
+    pub fn from_verified_evidence(
+        kind: SafetyContextKind,
+        state: ContextEvidenceState,
+        evidence_digest: VerifiedDigest,
+        observed_at_micros: i64,
+        valid_until_micros: Option<i64>,
+    ) -> Result<Self, MedicationSafetyError> {
+        evidence_digest.require_domain(DigestDomain::ClinicalArtifact)?;
+        if let Some(valid_until) = valid_until_micros {
+            if valid_until <= observed_at_micros {
+                return Err(MedicationSafetyError::InvalidContextValidityWindow(kind));
+            }
+        }
+        Ok(Self {
+            kind,
+            state,
+            evidence_digest: evidence_digest.stored(),
+            observed_at_micros,
+            valid_until_micros,
+        })
+    }
+
+    pub fn kind(&self) -> SafetyContextKind {
+        self.kind
+    }
+
+    pub fn state(&self) -> ContextEvidenceState {
+        self.state
+    }
+
+    pub fn evidence_digest(&self) -> StoredDigest {
+        self.evidence_digest
+    }
+
+    pub fn observed_at_micros(&self) -> i64 {
+        self.observed_at_micros
+    }
+
+    pub fn valid_until_micros(&self) -> Option<i64> {
+        self.valid_until_micros
+    }
+}
+
+/// Exact patient context against which medication safety was evaluated.
+///
+/// No `Deserialize` implementation is provided: callers cannot turn arbitrary wire
+/// JSON into a trusted context snapshot without re-establishing verified components.
+#[derive(Serialize)]
+pub struct MedicationSafetyContextSnapshot {
+    subject: SubjectRef,
+    medication_artifact_digest: StoredDigest,
+    components: Vec<ContextComponent>,
+    assembled_at_micros: i64,
+}
+
+impl MedicationSafetyContextSnapshot {
+    pub fn from_verified_components(
+        medication: &MedicationRequestArtifact,
+        components: Vec<ContextComponent>,
+        assembled_at_micros: i64,
+    ) -> Result<Self, MedicationSafetyError> {
+        if components.is_empty() {
+            return Err(MedicationSafetyError::EmptyContextSnapshot);
+        }
+        let mut kinds = HashSet::new();
+        for component in &components {
+            if !kinds.insert(component.kind) {
+                return Err(MedicationSafetyError::DuplicateContextComponent(
+                    component.kind,
+                ));
+            }
+        }
+
+        let medication_artifact_digest = medication.verified_digest()?;
+        medication_artifact_digest.require_domain(DigestDomain::MedicationRequestArtifact)?;
+
+        Ok(Self {
+            subject: medication.order().subject.clone(),
+            medication_artifact_digest: medication_artifact_digest.stored(),
+            components,
+            assembled_at_micros,
+        })
+    }
+
+    pub fn subject(&self) -> &SubjectRef {
+        &self.subject
+    }
+
+    pub fn medication_artifact_digest(&self) -> StoredDigest {
+        self.medication_artifact_digest
+    }
+
+    pub fn components(&self) -> &[ContextComponent] {
+        &self.components
+    }
+
+    pub fn assembled_at_micros(&self) -> i64 {
+        self.assembled_at_micros
+    }
+
+    pub fn verified_digest(&self) -> Result<VerifiedDigest, MedicationSafetyError> {
+        hash_json(DigestDomain::MedicationSafetyContext, CONTEXT_SCHEMA_TAG, self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum SafetyCheckKind {
+    DrugDrugInteraction,
+    DrugAllergy,
+    DuplicateTherapy,
+    DrugDiseaseContraindication,
+    DoseRange,
+    RenalAdjustment,
+    HepaticAdjustment,
+    PregnancyLactation,
+    AgeWeight,
+    Pharmacogenomics,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ContextRequirement {
+    pub kind: SafetyContextKind,
+    /// Maximum evidence age at the point of clearance. `None` means the policy relies
+    /// only on the component's explicit `valid_until_micros` for that domain.
+    pub max_age_micros: Option<i64>,
+    pub allow_verified_absent: bool,
+    pub allow_not_applicable: bool,
+}
+
+impl ContextRequirement {
+    fn validate(&self) -> Result<(), MedicationSafetyError> {
+        if self.max_age_micros.is_some_and(|age| age <= 0) {
+            return Err(MedicationSafetyError::InvalidContextMaximumAge(self.kind));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CheckRequirement {
+    pub kind: SafetyCheckKind,
+    pub max_evaluation_age_micros: i64,
+    pub max_knowledge_age_micros: i64,
+}
+
+impl CheckRequirement {
+    fn validate(&self) -> Result<(), MedicationSafetyError> {
+        if self.max_evaluation_age_micros <= 0 {
+            return Err(MedicationSafetyError::InvalidCheckMaximumAge(self.kind));
+        }
+        if self.max_knowledge_age_micros <= 0 {
+            return Err(MedicationSafetyError::InvalidKnowledgeMaximumAge(self.kind));
+        }
+        Ok(())
+    }
+}
+
+/// Versioned safety-coverage policy. This says which evidence is required; it does
+/// not establish that a specific medical rule or knowledge provider is clinically valid.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MedicationSafetyPolicyV1 {
+    pub schema_version: u16,
+    pub policy_id: String,
+    pub required_context: Vec<ContextRequirement>,
+    pub required_checks: Vec<CheckRequirement>,
+    pub max_future_skew_micros: i64,
+}
+
+impl MedicationSafetyPolicyV1 {
+    pub fn validate(&self) -> Result<(), MedicationSafetyError> {
+        if self.schema_version != 1 {
+            return Err(MedicationSafetyError::UnsupportedPolicyVersion(
+                self.schema_version,
+            ));
+        }
+        if self.policy_id.trim().is_empty() {
+            return Err(MedicationSafetyError::MissingPolicyId);
+        }
+        if self.required_context.is_empty() {
+            return Err(MedicationSafetyError::PolicyHasNoContextRequirements);
+        }
+        if self.required_checks.is_empty() {
+            return Err(MedicationSafetyError::PolicyHasNoCheckRequirements);
+        }
+        if self.max_future_skew_micros < 0
+            || self.max_future_skew_micros > MAX_FUTURE_SKEW_MICROS
+        {
+            return Err(MedicationSafetyError::InvalidFutureSkew);
+        }
+
+        let mut context_kinds = HashSet::new();
+        for requirement in &self.required_context {
+            requirement.validate()?;
+            if !context_kinds.insert(requirement.kind) {
+                return Err(MedicationSafetyError::DuplicateContextRequirement(
+                    requirement.kind,
+                ));
+            }
+        }
+
+        let mut check_kinds = HashSet::new();
+        for requirement in &self.required_checks {
+            requirement.validate()?;
+            if !check_kinds.insert(requirement.kind) {
+                return Err(MedicationSafetyError::DuplicateCheckRequirement(
+                    requirement.kind,
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn verified_digest(&self) -> Result<VerifiedDigest, MedicationSafetyError> {
+        self.validate()?;
+        hash_json(DigestDomain::MedicationSafetyPolicy, POLICY_SCHEMA_TAG, self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum KnowledgeCoverage {
+    /// The evaluator attests that its named/versioned knowledge artifact covers the
+    /// exact scope required by this safety policy/check for the evaluated artifact.
+    CompleteForPolicy,
+    Partial,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum SafetyCheckOutcome {
+    Clear,
+    Warning,
+    Blocked,
+    Indeterminate,
+}
+
+#[derive(Serialize)]
+struct SafetyCheckDigestMaterial {
+    kind: SafetyCheckKind,
+    medication_artifact_digest: StoredDigest,
+    context_digest: StoredDigest,
+    policy_digest: StoredDigest,
+    knowledge_digest: StoredDigest,
+    evaluator_digest: StoredDigest,
+    coverage: KnowledgeCoverage,
+    outcome: SafetyCheckOutcome,
+    finding_count: u32,
+    evaluated_at_micros: i64,
+    knowledge_as_of_micros: i64,
+}
+
+/// Safety check evidence that crossed a trusted evaluator adapter boundary.
+///
+/// It intentionally has no serde implementation. A caller must supply already
+/// verified artifact/context/policy/knowledge/evaluator digests, and the exact check
+/// envelope receives its own domain-separated evaluation digest.
+pub struct VerifiedSafetyCheck {
+    kind: SafetyCheckKind,
+    medication_artifact_digest: StoredDigest,
+    context_digest: StoredDigest,
+    policy_digest: StoredDigest,
+    knowledge_digest: StoredDigest,
+    evaluator_digest: StoredDigest,
+    coverage: KnowledgeCoverage,
+    outcome: SafetyCheckOutcome,
+    finding_count: u32,
+    evaluated_at_micros: i64,
+    knowledge_as_of_micros: i64,
+    evaluation_digest: VerifiedDigest,
+}
+
+impl VerifiedSafetyCheck {
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_verified_evaluation(
+        kind: SafetyCheckKind,
+        medication_artifact_digest: VerifiedDigest,
+        context_digest: VerifiedDigest,
+        policy_digest: VerifiedDigest,
+        knowledge_digest: VerifiedDigest,
+        evaluator_digest: VerifiedDigest,
+        coverage: KnowledgeCoverage,
+        outcome: SafetyCheckOutcome,
+        finding_count: u32,
+        evaluated_at_micros: i64,
+        knowledge_as_of_micros: i64,
+    ) -> Result<Self, MedicationSafetyError> {
+        medication_artifact_digest.require_domain(DigestDomain::MedicationRequestArtifact)?;
+        context_digest.require_domain(DigestDomain::MedicationSafetyContext)?;
+        policy_digest.require_domain(DigestDomain::MedicationSafetyPolicy)?;
+        knowledge_digest.require_domain(DigestDomain::MedicationSafetyKnowledge)?;
+        evaluator_digest.require_domain(DigestDomain::ClinicalArtifact)?;
+
+        let material = SafetyCheckDigestMaterial {
+            kind,
+            medication_artifact_digest: medication_artifact_digest.stored(),
+            context_digest: context_digest.stored(),
+            policy_digest: policy_digest.stored(),
+            knowledge_digest: knowledge_digest.stored(),
+            evaluator_digest: evaluator_digest.stored(),
+            coverage,
+            outcome,
+            finding_count,
+            evaluated_at_micros,
+            knowledge_as_of_micros,
+        };
+        let evaluation_digest = hash_json(
+            DigestDomain::MedicationSafetyEvaluation,
+            CHECK_SCHEMA_TAG,
+            &material,
+        )?;
+
+        Ok(Self {
+            kind,
+            medication_artifact_digest: material.medication_artifact_digest,
+            context_digest: material.context_digest,
+            policy_digest: material.policy_digest,
+            knowledge_digest: material.knowledge_digest,
+            evaluator_digest: material.evaluator_digest,
+            coverage,
+            outcome,
+            finding_count,
+            evaluated_at_micros,
+            knowledge_as_of_micros,
+            evaluation_digest,
+        })
+    }
+
+    pub fn kind(&self) -> SafetyCheckKind {
+        self.kind
+    }
+
+    pub fn coverage(&self) -> KnowledgeCoverage {
+        self.coverage
+    }
+
+    pub fn outcome(&self) -> SafetyCheckOutcome {
+        self.outcome
+    }
+
+    pub fn finding_count(&self) -> u32 {
+        self.finding_count
+    }
+
+    pub fn knowledge_digest(&self) -> StoredDigest {
+        self.knowledge_digest
+    }
+
+    pub fn evaluator_digest(&self) -> StoredDigest {
+        self.evaluator_digest
+    }
+
+    pub fn evaluation_digest(&self) -> StoredDigest {
+        self.evaluation_digest.stored()
+    }
+}
+
+/// Produce a domain-separated identity for the exact knowledge snapshot used by a
+/// medication safety adapter. Version/license/source metadata should be included in
+/// the caller's canonical bytes rather than conveyed only in display text.
+pub fn hash_safety_knowledge_artifact(
+    canonical_bytes: &[u8],
+) -> Result<VerifiedDigest, MedicationSafetyError> {
+    Ok(hash_canonical_bytes(
+        DigestDomain::MedicationSafetyKnowledge,
+        canonical_bytes,
+    )?)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MedicationSafetyDecision {
+    Cleared,
+    RequiresReview,
+    Blocked,
+    Indeterminate,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SafetyDecisionReason {
+    MissingContext(SafetyContextKind),
+    ContextFromFuture(SafetyContextKind),
+    ContextStale(SafetyContextKind),
+    ContextExpired(SafetyContextKind),
+    ContextStateNotAllowed(SafetyContextKind),
+    MissingCheck(SafetyCheckKind),
+    CheckFromFuture(SafetyCheckKind),
+    CheckStale(SafetyCheckKind),
+    KnowledgeFromFuture(SafetyCheckKind),
+    KnowledgeStale(SafetyCheckKind),
+    IncompleteKnowledgeCoverage(SafetyCheckKind),
+    CheckWarning(SafetyCheckKind),
+    CheckBlocked(SafetyCheckKind),
+    CheckIndeterminate(SafetyCheckKind),
+}
+
+pub struct MedicationSafetyEvaluation {
+    pub decision: MedicationSafetyDecision,
+    pub reasons: Vec<SafetyDecisionReason>,
+    clearance: Option<MedicationSafetyClearance>,
+}
+
+impl MedicationSafetyEvaluation {
+    pub fn clearance(&self) -> Option<&MedicationSafetyClearance> {
+        self.clearance.as_ref()
+    }
+
+    pub fn into_clearance(self) -> Option<MedicationSafetyClearance> {
+        self.clearance
+    }
+}
+
+/// Single-owner proof that one exact medication artifact satisfied one exact safety
+/// policy against one exact patient-context snapshot and complete/fresh required
+/// check evidence. It intentionally implements no Clone/Copy/Serialize/Deserialize/Debug.
+pub struct MedicationSafetyClearance {
+    medication_artifact_digest: StoredDigest,
+    context_digest: StoredDigest,
+    policy_digest: StoredDigest,
+    check_evaluation_digests: Vec<StoredDigest>,
+    cleared_at_micros: i64,
+}
+
+impl MedicationSafetyClearance {
+    pub fn medication_artifact_digest(&self) -> StoredDigest {
+        self.medication_artifact_digest
+    }
+
+    pub fn context_digest(&self) -> StoredDigest {
+        self.context_digest
+    }
+
+    pub fn policy_digest(&self) -> StoredDigest {
+        self.policy_digest
+    }
+
+    pub fn check_evaluation_digests(&self) -> &[StoredDigest] {
+        &self.check_evaluation_digests
+    }
+
+    pub fn cleared_at_micros(&self) -> i64 {
+        self.cleared_at_micros
+    }
+}
+
+pub fn evaluate_medication_safety(
+    medication: &MedicationRequestArtifact,
+    context: &MedicationSafetyContextSnapshot,
+    policy: &MedicationSafetyPolicyV1,
+    checks: &[VerifiedSafetyCheck],
+    at_micros: i64,
+) -> Result<MedicationSafetyEvaluation, MedicationSafetyError> {
+    policy.validate()?;
+    medication
+        .validate_for_activation(at_micros)
+        .map_err(|error| MedicationSafetyError::MedicationArtifact(error.to_string()))?;
+
+    let medication_digest = medication.verified_digest()?;
+    medication_digest.require_domain(DigestDomain::MedicationRequestArtifact)?;
+    if context.medication_artifact_digest != medication_digest.stored() {
+        return Err(MedicationSafetyError::ContextMedicationMismatch);
+    }
+    if context.subject != medication.order().subject {
+        return Err(MedicationSafetyError::ContextSubjectMismatch);
+    }
+    let context_digest = context.verified_digest()?;
+    let policy_digest = policy.verified_digest()?;
+
+    let mut reasons = Vec::new();
+    let mut indeterminate = false;
+
+    for requirement in &policy.required_context {
+        let Some(component) = context
+            .components
+            .iter()
+            .find(|component| component.kind == requirement.kind)
+        else {
+            indeterminate = true;
+            reasons.push(SafetyDecisionReason::MissingContext(requirement.kind));
+            continue;
+        };
+
+        match evidence_age(
+            component.observed_at_micros,
+            at_micros,
+            policy.max_future_skew_micros,
+        ) {
+            EvidenceAge::Future => {
+                indeterminate = true;
+                reasons.push(SafetyDecisionReason::ContextFromFuture(requirement.kind));
+            }
+            EvidenceAge::Age(age) => {
+                if requirement.max_age_micros.is_some_and(|max| age > max as i128) {
+                    indeterminate = true;
+                    reasons.push(SafetyDecisionReason::ContextStale(requirement.kind));
+                }
+            }
+        }
+
+        if component
+            .valid_until_micros
+            .is_some_and(|valid_until| at_micros >= valid_until)
+        {
+            indeterminate = true;
+            reasons.push(SafetyDecisionReason::ContextExpired(requirement.kind));
+        }
+
+        let state_allowed = match component.state {
+            ContextEvidenceState::Available => true,
+            ContextEvidenceState::VerifiedAbsent => requirement.allow_verified_absent,
+            ContextEvidenceState::NotApplicable => requirement.allow_not_applicable,
+        };
+        if !state_allowed {
+            indeterminate = true;
+            reasons.push(SafetyDecisionReason::ContextStateNotAllowed(
+                requirement.kind,
+            ));
+        }
+    }
+
+    let required: BTreeSet<SafetyCheckKind> =
+        policy.required_checks.iter().map(|check| check.kind).collect();
+    let mut supplied = HashSet::new();
+    for check in checks {
+        if !supplied.insert(check.kind) {
+            return Err(MedicationSafetyError::DuplicateCheckEvidence(check.kind));
+        }
+        if !required.contains(&check.kind) {
+            return Err(MedicationSafetyError::UnexpectedCheckEvidence(check.kind));
+        }
+        if check.medication_artifact_digest != medication_digest.stored() {
+            return Err(MedicationSafetyError::CheckMedicationMismatch(check.kind));
+        }
+        if check.context_digest != context_digest.stored() {
+            return Err(MedicationSafetyError::CheckContextMismatch(check.kind));
+        }
+        if check.policy_digest != policy_digest.stored() {
+            return Err(MedicationSafetyError::CheckPolicyMismatch(check.kind));
+        }
+    }
+
+    let mut blocked = false;
+    let mut warning = false;
+    let mut clearance_digests = Vec::with_capacity(policy.required_checks.len());
+
+    for requirement in &policy.required_checks {
+        let Some(check) = checks.iter().find(|check| check.kind == requirement.kind) else {
+            indeterminate = true;
+            reasons.push(SafetyDecisionReason::MissingCheck(requirement.kind));
+            continue;
+        };
+
+        match evidence_age(
+            check.evaluated_at_micros,
+            at_micros,
+            policy.max_future_skew_micros,
+        ) {
+            EvidenceAge::Future => {
+                indeterminate = true;
+                reasons.push(SafetyDecisionReason::CheckFromFuture(requirement.kind));
+            }
+            EvidenceAge::Age(age) if age > requirement.max_evaluation_age_micros as i128 => {
+                indeterminate = true;
+                reasons.push(SafetyDecisionReason::CheckStale(requirement.kind));
+            }
+            EvidenceAge::Age(_) => {}
+        }
+
+        match evidence_age(
+            check.knowledge_as_of_micros,
+            at_micros,
+            policy.max_future_skew_micros,
+        ) {
+            EvidenceAge::Future => {
+                indeterminate = true;
+                reasons.push(SafetyDecisionReason::KnowledgeFromFuture(requirement.kind));
+            }
+            EvidenceAge::Age(age) if age > requirement.max_knowledge_age_micros as i128 => {
+                indeterminate = true;
+                reasons.push(SafetyDecisionReason::KnowledgeStale(requirement.kind));
+            }
+            EvidenceAge::Age(_) => {}
+        }
+
+        if check.coverage != KnowledgeCoverage::CompleteForPolicy {
+            indeterminate = true;
+            reasons.push(SafetyDecisionReason::IncompleteKnowledgeCoverage(
+                requirement.kind,
+            ));
+        }
+
+        match check.outcome {
+            SafetyCheckOutcome::Clear => {}
+            SafetyCheckOutcome::Warning => {
+                warning = true;
+                reasons.push(SafetyDecisionReason::CheckWarning(requirement.kind));
+            }
+            SafetyCheckOutcome::Blocked => {
+                blocked = true;
+                reasons.push(SafetyDecisionReason::CheckBlocked(requirement.kind));
+            }
+            SafetyCheckOutcome::Indeterminate => {
+                indeterminate = true;
+                reasons.push(SafetyDecisionReason::CheckIndeterminate(requirement.kind));
+            }
+        }
+        clearance_digests.push(check.evaluation_digest.stored());
+    }
+
+    let decision = if blocked {
+        MedicationSafetyDecision::Blocked
+    } else if indeterminate {
+        MedicationSafetyDecision::Indeterminate
+    } else if warning {
+        MedicationSafetyDecision::RequiresReview
+    } else {
+        MedicationSafetyDecision::Cleared
+    };
+
+    let clearance = if decision == MedicationSafetyDecision::Cleared {
+        Some(MedicationSafetyClearance {
+            medication_artifact_digest: medication_digest.stored(),
+            context_digest: context_digest.stored(),
+            policy_digest: policy_digest.stored(),
+            check_evaluation_digests: clearance_digests,
+            cleared_at_micros: at_micros,
+        })
+    } else {
+        None
+    };
+
+    Ok(MedicationSafetyEvaluation {
+        decision,
+        reasons,
+        clearance,
+    })
+}
+
+enum EvidenceAge {
+    Future,
+    Age(i128),
+}
+
+fn evidence_age(evidence_at: i64, now: i64, allowed_future_skew: i64) -> EvidenceAge {
+    let delta = now as i128 - evidence_at as i128;
+    if delta < -(allowed_future_skew as i128) {
+        EvidenceAge::Future
+    } else {
+        EvidenceAge::Age(delta.max(0))
+    }
+}
+
+fn hash_json<T: Serialize>(
+    domain: DigestDomain,
+    schema_tag: &[u8],
+    value: &T,
+) -> Result<VerifiedDigest, MedicationSafetyError> {
+    let encoded = serde_json::to_vec(value)
+        .map_err(|error| MedicationSafetyError::Serialization(error.to_string()))?;
+    let mut framed = Vec::with_capacity(schema_tag.len() + 1 + encoded.len());
+    framed.extend_from_slice(schema_tag);
+    framed.push(0);
+    framed.extend_from_slice(&encoded);
+    Ok(hash_canonical_bytes(domain, &framed)?)
+}
+
+#[derive(Debug, Error)]
+pub enum MedicationSafetyError {
+    #[error("unsupported medication safety policy version {0}")]
+    UnsupportedPolicyVersion(u16),
+    #[error("medication safety policy id is required")]
+    MissingPolicyId,
+    #[error("medication safety policy requires patient-context requirements")]
+    PolicyHasNoContextRequirements,
+    #[error("medication safety policy requires safety checks")]
+    PolicyHasNoCheckRequirements,
+    #[error("medication safety policy future-skew allowance must be between 0 and five minutes")]
+    InvalidFutureSkew,
+    #[error("duplicate patient-context requirement: {0:?}")]
+    DuplicateContextRequirement(SafetyContextKind),
+    #[error("invalid maximum age for patient-context requirement: {0:?}")]
+    InvalidContextMaximumAge(SafetyContextKind),
+    #[error("duplicate safety-check requirement: {0:?}")]
+    DuplicateCheckRequirement(SafetyCheckKind),
+    #[error("invalid safety-check maximum evaluation age: {0:?}")]
+    InvalidCheckMaximumAge(SafetyCheckKind),
+    #[error("invalid safety-check maximum knowledge age: {0:?}")]
+    InvalidKnowledgeMaximumAge(SafetyCheckKind),
+    #[error("medication safety context snapshot cannot be empty")]
+    EmptyContextSnapshot,
+    #[error("duplicate patient-context component: {0:?}")]
+    DuplicateContextComponent(SafetyContextKind),
+    #[error("invalid validity window for patient-context component: {0:?}")]
+    InvalidContextValidityWindow(SafetyContextKind),
+    #[error("patient-context snapshot targets a different medication artifact")]
+    ContextMedicationMismatch,
+    #[error("patient-context snapshot subject differs from medication subject")]
+    ContextSubjectMismatch,
+    #[error("duplicate safety-check evidence supplied: {0:?}")]
+    DuplicateCheckEvidence(SafetyCheckKind),
+    #[error("unexpected safety-check evidence not required by policy: {0:?}")]
+    UnexpectedCheckEvidence(SafetyCheckKind),
+    #[error("safety-check evidence targets a different medication artifact: {0:?}")]
+    CheckMedicationMismatch(SafetyCheckKind),
+    #[error("safety-check evidence targets a different patient-context snapshot: {0:?}")]
+    CheckContextMismatch(SafetyCheckKind),
+    #[error("safety-check evidence was evaluated under a different policy: {0:?}")]
+    CheckPolicyMismatch(SafetyCheckKind),
+    #[error("resolved medication artifact failed activation preconditions: {0}")]
+    MedicationArtifact(String),
+    #[error("failed to serialize exact medication safety artifact: {0}")]
+    Serialization(String),
+    #[error(transparent)]
+    Integrity(#[from] IntegrityError),
+    #[error("FHIR medication artifact error: {0}")]
+    FhirMedication(String),
+}
+
+impl From<mycelix_fhir_medication_semantics::FhirMedicationError> for MedicationSafetyError {
+    fn from(error: mycelix_fhir_medication_semantics::FhirMedicationError) -> Self {
+        Self::FhirMedication(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_authority::PrincipalBinding;
+    use mycelix_provider_principal::{
+        ExternalIdentifier, ExternalReferenceBinding, ExternalResourceKey,
+        VerifiedProviderPrincipalBinding,
+    };
+    use serde_json::json;
+
+    fn clinical_digest(seed: u8) -> VerifiedDigest {
+        hash_canonical_bytes(DigestDomain::ClinicalArtifact, &[seed]).unwrap()
+    }
+
+    fn provider_binding() -> VerifiedProviderPrincipalBinding {
+        VerifiedProviderPrincipalBinding::from_verified_provider_record(
+            PrincipalBinding([7; 32]),
+            vec![ExternalReferenceBinding {
+                source_system: "https://ehr.example/fhir".into(),
+                resource: ExternalResourceKey {
+                    resource_type: "Practitioner".into(),
+                    id: "prac-1".into(),
+                },
+            }],
+            vec![ExternalIdentifier {
+                system: "http://hl7.org/fhir/sid/us-npi".into(),
+                value: "1234567893".into(),
+            }],
+            0,
+            Some(10_000_000),
+            None,
+            clinical_digest(1),
+            clinical_digest(2),
+            clinical_digest(3),
+        )
+        .unwrap()
+    }
+
+    fn medication(id: &str, resolved_at: i64) -> MedicationRequestArtifact {
+        let resource = json!({
+            "resourceType": "MedicationRequest",
+            "id": id,
+            "status": "active",
+            "intent": "order",
+            "medicationCodeableConcept": {
+                "coding": [{
+                    "system": "http://www.nlm.nih.gov/research/umls/rxnorm",
+                    "code": "860975"
+                }]
+            },
+            "subject": { "reference": "Patient/patient-a" },
+            "requester": {
+                "reference": "Practitioner/prac-1",
+                "type": "Practitioner",
+                "identifier": {
+                    "system": "http://hl7.org/fhir/sid/us-npi",
+                    "value": "1234567893"
+                }
+            },
+            "dosageInstruction": [{
+                "timing": { "repeat": { "frequency": 2, "period": 1, "periodUnit": "d" } },
+                "route": {
+                    "coding": [{"system": "http://snomed.info/sct", "code": "26643006"}]
+                },
+                "doseAndRate": [{
+                    "doseQuantity": {
+                        "value": 1,
+                        "system": "http://unitsofmeasure.org",
+                        "code": "{tablet}"
+                    }
+                }]
+            }]
+        });
+        mycelix_fhir_medication_semantics::project_active_medication_request_strict(
+            &resource,
+            "patient-a",
+            "https://ehr.example/fhir",
+            resolved_at,
+            &[provider_binding()],
+        )
+        .unwrap()
+    }
+
+    fn policy() -> MedicationSafetyPolicyV1 {
+        MedicationSafetyPolicyV1 {
+            schema_version: 1,
+            policy_id: "outpatient-medication-safety-test-v1".into(),
+            required_context: vec![
+                ContextRequirement {
+                    kind: SafetyContextKind::ActiveMedications,
+                    max_age_micros: Some(100),
+                    allow_verified_absent: true,
+                    allow_not_applicable: false,
+                },
+                ContextRequirement {
+                    kind: SafetyContextKind::AllergiesIntolerances,
+                    max_age_micros: Some(100),
+                    allow_verified_absent: true,
+                    allow_not_applicable: false,
+                },
+            ],
+            required_checks: vec![
+                CheckRequirement {
+                    kind: SafetyCheckKind::DrugDrugInteraction,
+                    max_evaluation_age_micros: 100,
+                    max_knowledge_age_micros: 1_000,
+                },
+                CheckRequirement {
+                    kind: SafetyCheckKind::DrugAllergy,
+                    max_evaluation_age_micros: 100,
+                    max_knowledge_age_micros: 1_000,
+                },
+            ],
+            max_future_skew_micros: 0,
+        }
+    }
+
+    fn context(
+        medication: &MedicationRequestArtifact,
+        observed_at: i64,
+    ) -> MedicationSafetyContextSnapshot {
+        MedicationSafetyContextSnapshot::from_verified_components(
+            medication,
+            vec![
+                ContextComponent::from_verified_evidence(
+                    SafetyContextKind::ActiveMedications,
+                    ContextEvidenceState::Available,
+                    clinical_digest(11),
+                    observed_at,
+                    None,
+                )
+                .unwrap(),
+                ContextComponent::from_verified_evidence(
+                    SafetyContextKind::AllergiesIntolerances,
+                    ContextEvidenceState::VerifiedAbsent,
+                    clinical_digest(12),
+                    observed_at,
+                    None,
+                )
+                .unwrap(),
+            ],
+            observed_at,
+        )
+        .unwrap()
+    }
+
+    fn check(
+        medication: &MedicationRequestArtifact,
+        context: &MedicationSafetyContextSnapshot,
+        policy: &MedicationSafetyPolicyV1,
+        kind: SafetyCheckKind,
+        coverage: KnowledgeCoverage,
+        outcome: SafetyCheckOutcome,
+        at: i64,
+        seed: u8,
+    ) -> VerifiedSafetyCheck {
+        VerifiedSafetyCheck::from_verified_evaluation(
+            kind,
+            medication.verified_digest().unwrap(),
+            context.verified_digest().unwrap(),
+            policy.verified_digest().unwrap(),
+            hash_safety_knowledge_artifact(&[seed, 1]).unwrap(),
+            clinical_digest(seed),
+            coverage,
+            outcome,
+            0,
+            at,
+            at,
+        )
+        .unwrap()
+    }
+
+    fn complete_clear_checks(
+        medication: &MedicationRequestArtifact,
+        context: &MedicationSafetyContextSnapshot,
+        policy: &MedicationSafetyPolicyV1,
+        at: i64,
+    ) -> Vec<VerifiedSafetyCheck> {
+        vec![
+            check(
+                medication,
+                context,
+                policy,
+                SafetyCheckKind::DrugDrugInteraction,
+                KnowledgeCoverage::CompleteForPolicy,
+                SafetyCheckOutcome::Clear,
+                at,
+                21,
+            ),
+            check(
+                medication,
+                context,
+                policy,
+                SafetyCheckKind::DrugAllergy,
+                KnowledgeCoverage::CompleteForPolicy,
+                SafetyCheckOutcome::Clear,
+                at,
+                22,
+            ),
+        ]
+    }
+
+    #[test]
+    fn complete_fresh_evidence_can_produce_clearance() {
+        let medication = medication("rx-a", 100);
+        let context = context(&medication, 100);
+        let policy = policy();
+        let checks = complete_clear_checks(&medication, &context, &policy, 100);
+
+        let result = evaluate_medication_safety(&medication, &context, &policy, &checks, 150)
+            .unwrap();
+        assert_eq!(result.decision, MedicationSafetyDecision::Cleared);
+        let clearance = result.into_clearance().expect("clearance expected");
+        assert_eq!(clearance.check_evaluation_digests().len(), 2);
+        assert_eq!(
+            clearance.medication_artifact_digest(),
+            medication.verified_digest().unwrap().stored()
+        );
+    }
+
+    #[test]
+    fn zero_findings_with_unknown_coverage_is_indeterminate_not_safe() {
+        let medication = medication("rx-a", 100);
+        let context = context(&medication, 100);
+        let policy = policy();
+        let mut checks = complete_clear_checks(&medication, &context, &policy, 100);
+        checks[0] = check(
+            &medication,
+            &context,
+            &policy,
+            SafetyCheckKind::DrugDrugInteraction,
+            KnowledgeCoverage::Unknown,
+            SafetyCheckOutcome::Clear,
+            100,
+            31,
+        );
+
+        let result = evaluate_medication_safety(&medication, &context, &policy, &checks, 150)
+            .unwrap();
+        assert_eq!(result.decision, MedicationSafetyDecision::Indeterminate);
+        assert!(result.clearance().is_none());
+        assert!(result.reasons.contains(
+            &SafetyDecisionReason::IncompleteKnowledgeCoverage(
+                SafetyCheckKind::DrugDrugInteraction
+            )
+        ));
+    }
+
+    #[test]
+    fn skipped_required_check_is_indeterminate() {
+        let medication = medication("rx-a", 100);
+        let context = context(&medication, 100);
+        let policy = policy();
+        let checks = vec![check(
+            &medication,
+            &context,
+            &policy,
+            SafetyCheckKind::DrugDrugInteraction,
+            KnowledgeCoverage::CompleteForPolicy,
+            SafetyCheckOutcome::Clear,
+            100,
+            21,
+        )];
+
+        let result = evaluate_medication_safety(&medication, &context, &policy, &checks, 150)
+            .unwrap();
+        assert_eq!(result.decision, MedicationSafetyDecision::Indeterminate);
+        assert!(result
+            .reasons
+            .contains(&SafetyDecisionReason::MissingCheck(SafetyCheckKind::DrugAllergy)));
+    }
+
+    #[test]
+    fn stale_patient_context_is_indeterminate() {
+        let medication = medication("rx-a", 10);
+        let context = context(&medication, 10);
+        let policy = policy();
+        let checks = complete_clear_checks(&medication, &context, &policy, 150);
+
+        let result = evaluate_medication_safety(&medication, &context, &policy, &checks, 150)
+            .unwrap();
+        assert_eq!(result.decision, MedicationSafetyDecision::Indeterminate);
+        assert!(result.reasons.iter().any(|reason| matches!(
+            reason,
+            SafetyDecisionReason::ContextStale(SafetyContextKind::ActiveMedications)
+        )));
+    }
+
+    #[test]
+    fn warning_requires_review_and_does_not_issue_clearance() {
+        let medication = medication("rx-a", 100);
+        let context = context(&medication, 100);
+        let policy = policy();
+        let mut checks = complete_clear_checks(&medication, &context, &policy, 100);
+        checks[0] = check(
+            &medication,
+            &context,
+            &policy,
+            SafetyCheckKind::DrugDrugInteraction,
+            KnowledgeCoverage::CompleteForPolicy,
+            SafetyCheckOutcome::Warning,
+            100,
+            31,
+        );
+
+        let result = evaluate_medication_safety(&medication, &context, &policy, &checks, 150)
+            .unwrap();
+        assert_eq!(result.decision, MedicationSafetyDecision::RequiresReview);
+        assert!(result.clearance().is_none());
+    }
+
+    #[test]
+    fn known_blocker_dominates_missing_evidence() {
+        let medication = medication("rx-a", 100);
+        let context = context(&medication, 100);
+        let policy = policy();
+        let checks = vec![check(
+            &medication,
+            &context,
+            &policy,
+            SafetyCheckKind::DrugDrugInteraction,
+            KnowledgeCoverage::CompleteForPolicy,
+            SafetyCheckOutcome::Blocked,
+            100,
+            21,
+        )];
+
+        let result = evaluate_medication_safety(&medication, &context, &policy, &checks, 150)
+            .unwrap();
+        assert_eq!(result.decision, MedicationSafetyDecision::Blocked);
+        assert!(result.clearance().is_none());
+    }
+
+    #[test]
+    fn stale_knowledge_is_indeterminate_even_when_check_says_clear() {
+        let medication = medication("rx-a", 100);
+        let context = context(&medication, 100);
+        let mut policy = policy();
+        policy.required_checks[0].max_knowledge_age_micros = 10;
+        let mut checks = complete_clear_checks(&medication, &context, &policy, 100);
+        checks[0] = VerifiedSafetyCheck::from_verified_evaluation(
+            SafetyCheckKind::DrugDrugInteraction,
+            medication.verified_digest().unwrap(),
+            context.verified_digest().unwrap(),
+            policy.verified_digest().unwrap(),
+            hash_safety_knowledge_artifact(b"old-kb").unwrap(),
+            clinical_digest(41),
+            KnowledgeCoverage::CompleteForPolicy,
+            SafetyCheckOutcome::Clear,
+            0,
+            150,
+            100,
+        )
+        .unwrap();
+
+        let result = evaluate_medication_safety(&medication, &context, &policy, &checks, 150)
+            .unwrap();
+        assert_eq!(result.decision, MedicationSafetyDecision::Indeterminate);
+        assert!(result.reasons.contains(
+            &SafetyDecisionReason::KnowledgeStale(SafetyCheckKind::DrugDrugInteraction)
+        ));
+    }
+
+    #[test]
+    fn check_for_another_medication_is_rejected_not_reused() {
+        let medication_a = medication("rx-a", 100);
+        let medication_b = medication("rx-b", 100);
+        let context = context(&medication_a, 100);
+        let policy = policy();
+        let wrong = VerifiedSafetyCheck::from_verified_evaluation(
+            SafetyCheckKind::DrugDrugInteraction,
+            medication_b.verified_digest().unwrap(),
+            context.verified_digest().unwrap(),
+            policy.verified_digest().unwrap(),
+            hash_safety_knowledge_artifact(b"kb").unwrap(),
+            clinical_digest(51),
+            KnowledgeCoverage::CompleteForPolicy,
+            SafetyCheckOutcome::Clear,
+            0,
+            100,
+            100,
+        )
+        .unwrap();
+        let allergy = check(
+            &medication_a,
+            &context,
+            &policy,
+            SafetyCheckKind::DrugAllergy,
+            KnowledgeCoverage::CompleteForPolicy,
+            SafetyCheckOutcome::Clear,
+            100,
+            52,
+        );
+
+        let error = match evaluate_medication_safety(
+            &medication_a,
+            &context,
+            &policy,
+            &[wrong, allergy],
+            150,
+        ) {
+            Ok(_) => panic!("expected target mismatch"),
+            Err(error) => error,
+        };
+        assert!(matches!(
+            error,
+            MedicationSafetyError::CheckMedicationMismatch(
+                SafetyCheckKind::DrugDrugInteraction
+            )
+        ));
+    }
+}

--- a/docs/MEDICATION_SAFETY_EVIDENCE_V1.md
+++ b/docs/MEDICATION_SAFETY_EVIDENCE_V1.md
@@ -1,0 +1,119 @@
+# Medication Safety Evidence v1
+
+Status: **experimental / qualification subject**. This contract does not establish clinical efficacy, regulatory clearance, or production suitability.
+
+## Central invariant
+
+> No finding is not the same as sufficient evidence of safety.
+
+A medication may cross the high-assurance activation boundary only when all of the following independently hold:
+
+1. the exact FHIR `MedicationRequest` has been projected into a strict typed `MedicationRequestArtifact`;
+2. the external requester has resolved unambiguously to the authenticated Mycelix principal;
+3. the principal has current professional authority for `Prescribe`, in the required jurisdiction, against the exact medication artifact;
+4. a versioned medication-safety policy has been satisfied against an exact patient-context snapshot;
+5. every policy-required safety check has fresh evidence with `CompleteForPolicy` knowledge coverage and a `Clear` outcome;
+6. the resulting `MedicationSafetyClearance` is still fresh at activation time and is consumed when the final capability is issued.
+
+## Decision lattice
+
+`MedicationSafetyDecision` is intentionally not a boolean:
+
+- `Cleared` — every required context component and safety check is present, current, correctly bound, completely covered for the policy, and clear.
+- `RequiresReview` — evidence is complete enough to interpret but one or more required checks returned a warning.
+- `Blocked` — at least one required check reports a blocking/contraindicating condition. This dominates missing evidence.
+- `Indeterminate` — required evidence is missing, stale, future-dated, expired, partially covered, skipped, or itself indeterminate.
+
+Only `Cleared` creates the opaque, non-cloneable, non-serializable `MedicationSafetyClearance`.
+
+## Exact evidence bindings
+
+A clearance binds:
+
+- `MedicationRequestArtifact` digest (`MedicationRequestArtifact` domain);
+- patient-context snapshot digest (`MedicationSafetyContext` domain);
+- safety-policy digest (`MedicationSafetyPolicy` domain);
+- all required safety-check evaluation digests (`MedicationSafetyEvaluation` domain);
+- clearance time.
+
+Each safety-check evaluation separately binds:
+
+- medication artifact;
+- patient-context snapshot;
+- safety policy;
+- exact knowledge artifact/version digest;
+- evaluator identity/artifact digest;
+- knowledge coverage classification;
+- outcome and finding count;
+- evaluation time;
+- knowledge-as-of time.
+
+The exact knowledge snapshot is identified under the separate `MedicationSafetyKnowledge` digest domain. The repository's development CDS seed tables are not treated as comprehensive production coverage.
+
+## Context is evidence, not an empty vector
+
+A context component must distinguish:
+
+- `Available` — relevant evidence is present;
+- `VerifiedAbsent` — an evidence-bearing process established absence;
+- `NotApplicable` — an evidence-bearing applicability decision established that the domain does not apply.
+
+An empty allergy list or medication list is therefore not automatically proof that there are no allergies or concomitant medications.
+
+The v1 vocabulary can represent active medications, allergies/intolerances, active conditions, renal function, hepatic function, pregnancy/lactation, age, weight, and pharmacogenomics. A policy chooses which are required for a particular workflow; v1 does not claim every medication always requires every domain.
+
+## Safety checks
+
+The v1 vocabulary includes drug-drug interaction, drug-allergy, duplicate therapy, drug-disease contraindication, dose range, renal adjustment, hepatic adjustment, pregnancy/lactation, age/weight, and pharmacogenomic checks.
+
+The kernel does **not** implement a proprietary drug database. Qualified adapters may evaluate these checks against external or local knowledge systems, but the exact knowledge artifact/version and coverage claim must be carried as evidence.
+
+## Workflow composition
+
+The high-assurance medication capability path is:
+
+`MedicationRequestArtifact`
++ `MedicationSafetyClearance`
++ expected `MedicationSafetyPolicy` digest
++ `AuthorityPermit(Prescribe)`
++ workflow policy
++ authenticated principal
++ jurisdiction
+-> `MedicationActivationCapability`
+
+The safe API rejects:
+
+- clearance for another medication artifact;
+- clearance produced under another safety policy;
+- stale/future clearance;
+- stale/future requester resolution;
+- wrong authenticated principal;
+- wrong authority purpose;
+- stale/future professional authority;
+- authority for another artifact or policy.
+
+The final capability preserves requester-resolution evidence, professional-authority evidence, safety context, safety policy, and check-evaluation digests as separate lineages.
+
+## Known limitation: evaluator/knowledge admission
+
+`VerifiedSafetyCheck` v1 establishes exact digest binding and coverage semantics, but it does not yet itself prove that a particular evaluator or knowledge provider is trusted by deployment policy. Before production promotion, add a verifier-owned evaluator/knowledge admission capability or an equivalent signed trust-policy adapter. The final deployment must not allow arbitrary callers to self-designate an evaluator or knowledge artifact as qualified.
+
+This limitation is intentionally explicit: cryptographic identity of evidence is not the same thing as institutional or clinical trust in that evidence.
+
+## Legacy CDS migration
+
+The current CDS `SafetyAssessment::Safe` path must not be accepted as a `MedicationSafetyClearance`. Existing CDS responses can remain useful as legacy/user-facing information, but the strict boundary requires coverage-aware evidence. Issue #46 tracks migration/hardening of the legacy assessment semantics.
+
+## Qualification requirements
+
+Before promotion beyond experimental status, require at minimum:
+
+- exact-head CI for all workspace crates;
+- adversarial tests for skipped checks and partial/unknown knowledge coverage;
+- stale/future context and evaluation tests;
+- cross-medication, cross-context, and cross-policy replay tests;
+- provider/requester identity substitution tests;
+- evaluator/knowledge trust admission tests;
+- negative tests against the development seed corpus being labeled comprehensive;
+- integration tests proving legacy prescription/CDS paths cannot bypass the final capability boundary;
+- clinical and regulatory review of intended use and policy profiles.


### PR DESCRIPTION
## Stack

Depends on #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

## Why

The existing CDS path can return `SafetyAssessment::Safe` when collected finding lists are empty even if optional checks were skipped. The repository's bundled CDS seed corpus is explicitly development/reference data rather than comprehensive production coverage. Therefore `no finding` must not be allowed to mean `sufficient evidence of safety` at the high-assurance medication boundary.

Issue #46 tracks migration/hardening of the legacy CDS semantics.

## What this adds

### `mycelix-medication-safety`

A pure coverage-aware evidence kernel with:

- explicit patient-context kinds: active medications, allergies/intolerances, active conditions, renal/hepatic function, pregnancy/lactation, age, weight, pharmacogenomics;
- explicit context states: `Available`, `VerifiedAbsent`, `NotApplicable`;
- versioned `MedicationSafetyPolicyV1` selecting required context/checks and freshness requirements;
- safety-check kinds for interactions, allergy, duplicate therapy, disease contraindication, dose, renal/hepatic adjustment, pregnancy/lactation, age/weight, and PGx;
- exact medication/context/policy/knowledge/evaluator/time binding for each `VerifiedSafetyCheck`;
- `KnowledgeCoverage::{CompleteForPolicy, Partial, Unknown}`;
- `SafetyCheckOutcome::{Clear, Warning, Blocked, Indeterminate}`;
- decision lattice `Cleared / RequiresReview / Blocked / Indeterminate`;
- missing/skipped/stale/future/partial/unknown evidence -> `Indeterminate`, never `Cleared`;
- known blockers dominate missing evidence;
- only complete, fresh, policy-covered clear evidence can create opaque `MedicationSafetyClearance`.

### Integrity domains

Adds separate BLAKE3/domain-separated identities for:

- medication safety context;
- medication safety policy;
- medication safety knowledge;
- medication safety evaluation.

### Final medication workflow composition

`MedicationActivationCapability` now requires and binds three independent evidence lineages:

1. FHIR requester -> authenticated-principal resolution;
2. professional `Prescribe` authority;
3. medication safety clearance.

`authorize_resolved_medication_activation(...)` now consumes a `MedicationSafetyClearance` and requires the deployment's expected medication-safety policy digest. It rejects:

- safety clearance for another medication artifact;
- safety-policy substitution;
- stale/future safety clearance;
- stale/future requester identity resolution;
- stale/future professional authority;
- requester/authenticated-principal substitution;
- wrong authority purpose;
- authority target/policy mismatch.

Workflow freshness policy now separates maximum age for professional authority, requester resolution, and safety clearance rather than coupling all three.

The final capability preserves safety context, safety policy, required check-evaluation digests, requester-resolution evidence, and professional-authority evidence as separate audit lineages.

## Tests

Adds/extends adversarial coverage for:

- zero findings with unknown knowledge coverage;
- skipped required checks;
- stale patient context;
- warnings not producing clearance;
- blockers dominating missing evidence;
- stale knowledge;
- cross-medication safety-check replay;
- cross-medication authority replay;
- cross-medication safety-clearance replay;
- safety-policy substitution;
- requester principal substitution;
- stale authority;
- stale requester resolution;
- stale safety clearance;
- successful three-lineage activation.

## Important non-claim / follow-up

This PR proves exact evidence binding and coverage semantics, but it does **not yet establish deployment trust in a particular safety evaluator or drug-knowledge artifact**. Issue #47 tracks verifier-owned evaluator/knowledge admission. Until that is implemented and qualified, this tranche remains experimental and must not be represented as production clinical clearance.

## Central invariant

> Absence of a detected problem may become `Cleared` only when the system can also establish that the required problem space was actually checked with complete, current, policy-approved evidence.