### PR TITLE
security(health): require trusted medication safety evaluators and knowledge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "crates/provider-principal",
     "crates/fhir-medication-semantics",
     "crates/medication-safety",
+    "crates/medication-safety-trust",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -27,6 +27,8 @@ pub enum DigestDomain {
     MedicationSafetyKnowledge,
     MedicationSafetyPolicy,
     MedicationSafetyEvaluation,
+    MedicationSafetyTrustPolicy,
+    MedicationSafetyTrustReceipt,
     QuarantineEvent,
     QuarantineDecision,
     AuthorityPolicy,
@@ -48,6 +50,8 @@ impl DigestDomain {
             Self::MedicationSafetyKnowledge => b"medication-safety-knowledge",
             Self::MedicationSafetyPolicy => b"medication-safety-policy",
             Self::MedicationSafetyEvaluation => b"medication-safety-evaluation",
+            Self::MedicationSafetyTrustPolicy => b"medication-safety-trust-policy",
+            Self::MedicationSafetyTrustReceipt => b"medication-safety-trust-receipt",
             Self::QuarantineEvent => b"quarantine-event",
             Self::QuarantineDecision => b"quarantine-decision",
             Self::AuthorityPolicy => b"authority-policy",
@@ -109,10 +113,6 @@ impl VerifiedDigest {
 }
 
 /// Hash bytes that are already in the owning artifact's canonical serialization.
-///
-/// This crate intentionally does not invent canonical JSON. Each artifact owner
-/// must define its canonical byte representation separately; this function freezes
-/// how those bytes are framed and hashed once canonicalization has occurred.
 pub fn hash_canonical_bytes(
     domain: DigestDomain,
     canonical_bytes: &[u8],
@@ -143,7 +143,6 @@ pub fn hash_canonical_bytes(
     })
 }
 
-/// Re-verify a stored/wire digest claim against the exact canonical bytes.
 pub fn verify_stored_digest(
     claimed: StoredDigest,
     canonical_bytes: &[u8],
@@ -159,8 +158,6 @@ pub fn verify_stored_digest(
     Ok(computed)
 }
 
-/// Verify that two already-verified identities are equal and belong to the exact
-/// expected semantic domain.
 pub fn require_same_digest(
     left: VerifiedDigest,
     right: VerifiedDigest,
@@ -205,15 +202,26 @@ mod tests {
     #[test]
     fn identical_bytes_in_different_domains_do_not_collide_by_construction() {
         let payload = b"same-canonical-bytes";
-        let order = hash_canonical_bytes(DigestDomain::MedicationOrder, payload).unwrap();
-        let request =
-            hash_canonical_bytes(DigestDomain::MedicationRequestArtifact, payload).unwrap();
-        let safety =
-            hash_canonical_bytes(DigestDomain::MedicationSafetyEvaluation, payload).unwrap();
-        let policy = hash_canonical_bytes(DigestDomain::AuthorityPolicy, payload).unwrap();
-        assert_ne!(order.value(), request.value());
-        assert_ne!(request.value(), safety.value());
-        assert_ne!(safety.value(), policy.value());
+        let domains = [
+            DigestDomain::MedicationOrder,
+            DigestDomain::MedicationRequestArtifact,
+            DigestDomain::MedicationSafetyContext,
+            DigestDomain::MedicationSafetyPolicy,
+            DigestDomain::MedicationSafetyKnowledge,
+            DigestDomain::MedicationSafetyEvaluation,
+            DigestDomain::MedicationSafetyTrustPolicy,
+            DigestDomain::MedicationSafetyTrustReceipt,
+            DigestDomain::AuthorityPolicy,
+        ];
+        let values: Vec<[u8; 32]> = domains
+            .iter()
+            .map(|domain| hash_canonical_bytes(*domain, payload).unwrap().value())
+            .collect();
+        for (index, left) in values.iter().enumerate() {
+            for right in values.iter().skip(index + 1) {
+                assert_ne!(left, right);
+            }
+        }
     }
 
     #[test]

--- a/crates/clinical-workflow/Cargo.toml
+++ b/crates/clinical-workflow/Cargo.toml
@@ -16,4 +16,5 @@ mycelix-clinical-promotion = { path = "../clinical-promotion" }
 mycelix-medication-semantics = { path = "../medication-semantics" }
 mycelix-fhir-medication-semantics = { path = "../fhir-medication-semantics" }
 mycelix-medication-safety = { path = "../medication-safety" }
+mycelix-medication-safety-trust = { path = "../medication-safety-trust" }
 mycelix-clinical-quarantine = { path = "../clinical-quarantine" }

--- a/crates/clinical-workflow/src/lib.rs
+++ b/crates/clinical-workflow/src/lib.rs
@@ -1,9 +1,9 @@
 #![deny(unsafe_code)]
 //! Exact-target capability composition for Mycelix-Health.
 //!
-//! A valid credential, requester identity, qualification result, or medication-safety
-//! result is not sufficient on its own. This crate composes verifier-owned evidence
-//! into exact-purpose, exact-target workflow capabilities.
+//! A valid credential, requester identity, qualification result, medication-safety
+//! result, or source-trust result is not sufficient on its own. This crate composes
+//! verifier-owned evidence into exact-purpose, exact-target workflow capabilities.
 //!
 //! Resulting workflow capabilities intentionally implement no Clone/Copy/serde/Debug.
 
@@ -21,7 +21,9 @@ use mycelix_clinical_quarantine::{
 };
 use mycelix_fhir_medication_semantics::MedicationRequestArtifact;
 use mycelix_medication_safety::MedicationSafetyClearance;
+use mycelix_medication_safety_trust::SafetySourceTrustReceipt;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use thiserror::Error;
 
 const MAX_EVIDENCE_AGE_MICROS: i64 = 86_400_000_000;
@@ -37,6 +39,8 @@ pub struct WorkflowPolicyV1 {
     pub max_requester_resolution_age_micros: i64,
     /// Maximum time between medication safety clearance and activation.
     pub max_safety_clearance_age_micros: i64,
+    /// Maximum time between safety-source trust admission and activation.
+    pub max_safety_source_trust_age_micros: i64,
     pub max_future_skew_micros: i64,
 }
 
@@ -58,6 +62,10 @@ impl WorkflowPolicyV1 {
         validate_age_policy(
             self.max_safety_clearance_age_micros,
             WorkflowError::InvalidSafetyClearanceAgePolicy,
+        )?;
+        validate_age_policy(
+            self.max_safety_source_trust_age_micros,
+            WorkflowError::InvalidSafetySourceTrustAgePolicy,
         )?;
         if self.max_future_skew_micros < 0
             || self.max_future_skew_micros > MAX_FUTURE_SKEW_MICROS
@@ -131,10 +139,11 @@ impl ClinicalPresentationCapability {
 
 /// Exact medication activation capability.
 ///
-/// It preserves three independent proof lineages:
+/// It preserves four independent proof lineages:
 /// 1. requester -> authenticated principal resolution evidence;
 /// 2. professional authority evidence supporting the prescribing action;
-/// 3. patient-context/knowledge/evaluator evidence supporting medication safety.
+/// 3. patient-context/check evidence supporting medication safety;
+/// 4. deployment trust evidence admitting the exact evaluator/knowledge sources.
 ///
 /// The capability is intentionally non-cloneable/non-serializable.
 pub struct MedicationActivationCapability {
@@ -147,6 +156,11 @@ pub struct MedicationActivationCapability {
     safety_policy_digest: StoredDigest,
     safety_check_evaluation_digests: Vec<StoredDigest>,
     safety_cleared_at_micros: i64,
+    safety_trust_policy_digest: StoredDigest,
+    safety_trust_receipt_digest: StoredDigest,
+    safety_evaluator_admission_evidence: Vec<StoredDigest>,
+    safety_knowledge_admission_evidence: Vec<StoredDigest>,
+    safety_trust_evaluated_at_micros: i64,
     jurisdiction: JurisdictionCode,
     authority_policy_digest: StoredDigest,
     workflow_policy_digest: StoredDigest,
@@ -189,6 +203,26 @@ impl MedicationActivationCapability {
 
     pub fn safety_cleared_at_micros(&self) -> i64 {
         self.safety_cleared_at_micros
+    }
+
+    pub fn safety_trust_policy_digest(&self) -> StoredDigest {
+        self.safety_trust_policy_digest
+    }
+
+    pub fn safety_trust_receipt_digest(&self) -> StoredDigest {
+        self.safety_trust_receipt_digest
+    }
+
+    pub fn safety_evaluator_admission_evidence(&self) -> &[StoredDigest] {
+        &self.safety_evaluator_admission_evidence
+    }
+
+    pub fn safety_knowledge_admission_evidence(&self) -> &[StoredDigest] {
+        &self.safety_knowledge_admission_evidence
+    }
+
+    pub fn safety_trust_evaluated_at_micros(&self) -> i64 {
+        self.safety_trust_evaluated_at_micros
     }
 
     pub fn jurisdiction(&self) -> &JurisdictionCode {
@@ -332,13 +366,14 @@ pub fn authorize_clinical_presentation(
 }
 
 /// Convert one strict FHIR MedicationRequest artifact into an exact activation
-/// capability. The safety clearance is consumed so the safe API cannot reuse one
-/// single-owner clearance across multiple activation calls.
+/// capability. Both the safety clearance and source-trust receipt are consumed.
 #[allow(clippy::too_many_arguments)]
 pub fn authorize_resolved_medication_activation(
     artifact: &MedicationRequestArtifact,
     safety_clearance: MedicationSafetyClearance,
+    safety_source_trust: SafetySourceTrustReceipt,
     expected_safety_policy_digest: VerifiedDigest,
+    expected_safety_trust_policy_digest: VerifiedDigest,
     authority: AuthorityPermit,
     authority_policy_digest: VerifiedDigest,
     workflow_policy: &WorkflowPolicyV1,
@@ -394,6 +429,52 @@ pub fn authorize_resolved_medication_activation(
         WorkflowError::SafetyClearanceStale,
     )?;
 
+    expected_safety_trust_policy_digest
+        .require_domain(DigestDomain::MedicationSafetyTrustPolicy)?;
+    if safety_source_trust.safety_policy_digest() != expected_safety_policy_digest.stored() {
+        return Err(WorkflowError::SafetyTrustSafetyPolicyMismatch);
+    }
+    if safety_source_trust.trust_policy_digest()
+        != expected_safety_trust_policy_digest.stored()
+    {
+        return Err(WorkflowError::SafetyTrustPolicyDigestMismatch);
+    }
+    if !same_digest_set(
+        &safety_check_evaluation_digests,
+        safety_source_trust.check_evaluation_digests(),
+    ) {
+        return Err(WorkflowError::SafetyTrustEvaluationSetMismatch);
+    }
+
+    let safety_trust_receipt_digest = safety_source_trust.receipt_digest();
+    validate_stored_domain(
+        safety_trust_receipt_digest,
+        DigestDomain::MedicationSafetyTrustReceipt,
+    )?;
+    let safety_evaluator_admission_evidence =
+        safety_source_trust.evaluator_admission_evidence_digests().to_vec();
+    let safety_knowledge_admission_evidence =
+        safety_source_trust.knowledge_admission_evidence_digests().to_vec();
+    if safety_evaluator_admission_evidence.is_empty()
+        || safety_knowledge_admission_evidence.is_empty()
+    {
+        return Err(WorkflowError::SafetyTrustHasNoAdmissionEvidence);
+    }
+    for digest in safety_evaluator_admission_evidence
+        .iter()
+        .chain(safety_knowledge_admission_evidence.iter())
+    {
+        validate_stored_domain(*digest, DigestDomain::ClinicalArtifact)?;
+    }
+    verify_freshness(
+        safety_source_trust.evaluated_at_micros(),
+        execution_at_micros,
+        workflow_policy.max_safety_source_trust_age_micros,
+        workflow_policy.max_future_skew_micros,
+        WorkflowError::SafetySourceTrustFromFuture,
+        WorkflowError::SafetySourceTrustStale,
+    )?;
+
     let workflow_policy_digest = workflow_policy.verified_digest()?;
     let evidence = verify_authority_binding(
         &authority,
@@ -420,6 +501,11 @@ pub fn authorize_resolved_medication_activation(
         safety_policy_digest: expected_safety_policy_digest.stored(),
         safety_check_evaluation_digests,
         safety_cleared_at_micros: safety_clearance.cleared_at_micros(),
+        safety_trust_policy_digest: expected_safety_trust_policy_digest.stored(),
+        safety_trust_receipt_digest,
+        safety_evaluator_admission_evidence,
+        safety_knowledge_admission_evidence,
+        safety_trust_evaluated_at_micros: safety_source_trust.evaluated_at_micros(),
         jurisdiction: jurisdiction.clone(),
         authority_policy_digest: authority_policy_digest.stored(),
         workflow_policy_digest: workflow_policy_digest.stored(),
@@ -512,6 +598,15 @@ fn validate_stored_domain(
     Ok(())
 }
 
+fn same_digest_set(left: &[StoredDigest], right: &[StoredDigest]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let left: HashSet<StoredDigest> = left.iter().copied().collect();
+    let right: HashSet<StoredDigest> = right.iter().copied().collect();
+    left.len() == right.len() && left == right
+}
+
 #[allow(clippy::too_many_arguments)]
 fn verify_authority_binding(
     authority: &AuthorityPermit,
@@ -589,6 +684,8 @@ pub enum WorkflowError {
     InvalidRequesterResolutionAgePolicy,
     #[error("workflow safety-clearance age must be > 0 and <= 24 hours")]
     InvalidSafetyClearanceAgePolicy,
+    #[error("workflow safety-source-trust age must be > 0 and <= 24 hours")]
+    InvalidSafetySourceTrustAgePolicy,
     #[error("workflow future-skew allowance must be between 0 and 5 minutes")]
     InvalidFutureSkewPolicy,
     #[error("failed to serialize exact artifact under its v1 canonical JSON contract: {0}")]
@@ -633,6 +730,18 @@ pub enum WorkflowError {
     SafetyClearanceFromFuture,
     #[error("medication safety clearance is stale for workflow policy")]
     SafetyClearanceStale,
+    #[error("safety-source trust receipt qualifies a different medication safety policy")]
+    SafetyTrustSafetyPolicyMismatch,
+    #[error("safety-source trust receipt was produced under a different trust policy")]
+    SafetyTrustPolicyDigestMismatch,
+    #[error("safety-source trust receipt does not cover the exact safety evaluation set")]
+    SafetyTrustEvaluationSetMismatch,
+    #[error("safety-source trust receipt contains no evaluator/knowledge admission evidence")]
+    SafetyTrustHasNoAdmissionEvidence,
+    #[error("safety-source trust receipt is too far in the future for workflow policy")]
+    SafetySourceTrustFromFuture,
+    #[error("safety-source trust receipt is stale for workflow policy")]
+    SafetySourceTrustStale,
     #[error("clinical qualification gate denied presentation: {0:?}")]
     ClinicalQualificationDenied(GateDecision),
     #[error("clinical qualification validation failed: {0}")]

--- a/crates/clinical-workflow/tests/workflow_capabilities.rs
+++ b/crates/clinical-workflow/tests/workflow_capabilities.rs
@@ -20,6 +20,10 @@ use mycelix_medication_safety::{
     MedicationSafetyClearance, MedicationSafetyContextSnapshot, MedicationSafetyPolicyV1,
     SafetyCheckKind, SafetyCheckOutcome, SafetyContextKind, VerifiedSafetyCheck,
 };
+use mycelix_medication_safety_trust::{
+    evaluate_safety_source_trust, SafetySourceTrustPolicyV1, SafetySourceTrustReceipt,
+    VerifiedEvaluatorAdmission, VerifiedKnowledgeAdmission,
+};
 use mycelix_provider_principal::{
     ExternalIdentifier, ExternalReferenceBinding, ExternalResourceKey,
     VerifiedProviderPrincipalBinding,
@@ -44,7 +48,7 @@ fn scope(code: &str) -> ScopeCode {
     }
 }
 
-fn policy_digest(bytes: &[u8]) -> VerifiedDigest {
+fn authority_policy_digest(bytes: &[u8]) -> VerifiedDigest {
     hash_canonical_bytes(DigestDomain::AuthorityPolicy, bytes).unwrap()
 }
 
@@ -54,6 +58,7 @@ fn workflow_policy() -> WorkflowPolicyV1 {
         max_authority_age_micros: 60_000_000,
         max_requester_resolution_age_micros: 60_000_000,
         max_safety_clearance_age_micros: 60_000_000,
+        max_safety_source_trust_age_micros: 60_000_000,
         max_future_skew_micros: 1_000_000,
     }
 }
@@ -206,10 +211,18 @@ fn safety_policy() -> MedicationSafetyPolicyV1 {
     }
 }
 
-fn safety_clearance(
+struct SafetyBundle {
+    clearance: MedicationSafetyClearance,
+    source_trust: SafetySourceTrustReceipt,
+    safety_policy_digest: VerifiedDigest,
+    trust_policy_digest: VerifiedDigest,
+}
+
+fn safety_bundle(
     artifact: &MedicationRequestArtifact,
     cleared_at: i64,
-) -> (MedicationSafetyClearance, VerifiedDigest) {
+    trust_evaluated_at: i64,
+) -> SafetyBundle {
     let context = MedicationSafetyContextSnapshot::from_verified_components(
         artifact,
         vec![ContextComponent::from_verified_evidence(
@@ -223,15 +236,18 @@ fn safety_clearance(
         cleared_at,
     )
     .unwrap();
-    let policy = safety_policy();
-    let policy_digest = policy.verified_digest().unwrap();
+    let safety_policy = safety_policy();
+    let safety_policy_digest = safety_policy.verified_digest().unwrap();
+    let evaluator_digest = clinical_digest(32);
+    let knowledge_digest =
+        hash_safety_knowledge_artifact(b"qualified-test-allergy-knowledge-v1").unwrap();
     let check = VerifiedSafetyCheck::from_verified_evaluation(
         SafetyCheckKind::DrugAllergy,
         artifact.verified_digest().unwrap(),
         context.verified_digest().unwrap(),
-        policy_digest,
-        hash_safety_knowledge_artifact(b"qualified-test-allergy-knowledge-v1").unwrap(),
-        clinical_digest(32),
+        safety_policy_digest,
+        knowledge_digest,
+        evaluator_digest,
         KnowledgeCoverage::CompleteForPolicy,
         SafetyCheckOutcome::Clear,
         0,
@@ -239,18 +255,61 @@ fn safety_clearance(
         cleared_at,
     )
     .unwrap();
-    let evaluation = evaluate_medication_safety(
+    let checks = vec![check];
+    let clearance = evaluate_medication_safety(
         artifact,
         &context,
-        &policy,
-        &[check],
+        &safety_policy,
+        &checks,
         cleared_at,
     )
-    .unwrap();
-    (
-        evaluation.into_clearance().expect("safety clearance expected"),
-        policy_digest,
+    .unwrap()
+    .into_clearance()
+    .expect("safety clearance expected");
+
+    let trust_policy = SafetySourceTrustPolicyV1 {
+        schema_version: 1,
+        policy_id: "workflow-test-safety-source-trust-v1".into(),
+        safety_policy_digest: safety_policy_digest.stored(),
+        max_future_skew_micros: 0,
+    };
+    let trust_policy_digest = trust_policy.verified_digest().unwrap();
+    let evaluators = vec![VerifiedEvaluatorAdmission::from_verified_record(
+        evaluator_digest,
+        vec![SafetyCheckKind::DrugAllergy],
+        0,
+        Some(10_000_000_000),
+        None,
+        trust_policy_digest,
+        clinical_digest(33),
     )
+    .unwrap()];
+    let knowledge = vec![VerifiedKnowledgeAdmission::from_verified_record(
+        knowledge_digest,
+        vec![SafetyCheckKind::DrugAllergy],
+        0,
+        Some(10_000_000_000),
+        None,
+        trust_policy_digest,
+        clinical_digest(34),
+    )
+    .unwrap()];
+    let source_trust = evaluate_safety_source_trust(
+        safety_policy_digest,
+        &trust_policy,
+        &checks,
+        &evaluators,
+        &knowledge,
+        trust_evaluated_at,
+    )
+    .unwrap();
+
+    SafetyBundle {
+        clearance,
+        source_trust,
+        safety_policy_digest,
+        trust_policy_digest,
+    }
 }
 
 fn expect_workflow_error<T>(result: Result<T, WorkflowError>) -> WorkflowError {
@@ -263,7 +322,7 @@ fn expect_workflow_error<T>(result: Result<T, WorkflowError>) -> WorkflowError {
 #[test]
 fn medication_authority_cannot_cross_artifact_boundary() {
     let p = principal(1);
-    let authority_policy = policy_digest(b"prescribing-policy-v1");
+    let authority_policy = authority_policy_digest(b"prescribing-policy-v1");
     let artifact_a = medication_artifact("order-a", p, 100);
     let artifact_b = medication_artifact("order-b", p, 100);
     let authority = authority_for(
@@ -274,12 +333,14 @@ fn medication_authority_cannot_cross_artifact_boundary() {
         "prescribe",
         100,
     );
-    let (clearance_b, safety_policy_digest) = safety_clearance(&artifact_b, 150);
+    let safety = safety_bundle(&artifact_b, 150, 150);
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact_b,
-        clearance_b,
-        safety_policy_digest,
+        safety.clearance,
+        safety.source_trust,
+        safety.safety_policy_digest,
+        safety.trust_policy_digest,
         authority,
         authority_policy,
         &workflow_policy(),
@@ -293,7 +354,7 @@ fn medication_authority_cannot_cross_artifact_boundary() {
 #[test]
 fn safety_clearance_cannot_cross_medication_boundary() {
     let p = principal(2);
-    let authority_policy = policy_digest(b"prescribing-policy-v1");
+    let authority_policy = authority_policy_digest(b"prescribing-policy-v1");
     let artifact_a = medication_artifact("order-a", p, 100);
     let artifact_b = medication_artifact("order-b", p, 100);
     let authority = authority_for(
@@ -304,12 +365,14 @@ fn safety_clearance_cannot_cross_medication_boundary() {
         "prescribe",
         100,
     );
-    let (clearance_a, safety_policy_digest) = safety_clearance(&artifact_a, 150);
+    let safety = safety_bundle(&artifact_a, 150, 150);
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact_b,
-        clearance_a,
-        safety_policy_digest,
+        safety.clearance,
+        safety.source_trust,
+        safety.safety_policy_digest,
+        safety.trust_policy_digest,
         authority,
         authority_policy,
         &workflow_policy(),
@@ -324,9 +387,9 @@ fn safety_clearance_cannot_cross_medication_boundary() {
 }
 
 #[test]
-fn safety_clearance_policy_substitution_is_rejected() {
+fn source_trust_policy_substitution_is_rejected() {
     let p = principal(3);
-    let authority_policy = policy_digest(b"prescribing-policy-v1");
+    let authority_policy = authority_policy_digest(b"prescribing-policy-v1");
     let artifact = medication_artifact("order-a", p, 100);
     let authority = authority_for(
         artifact.verified_digest().unwrap(),
@@ -336,17 +399,19 @@ fn safety_clearance_policy_substitution_is_rejected() {
         "prescribe",
         100,
     );
-    let (clearance, _) = safety_clearance(&artifact, 150);
-    let wrong_safety_policy = hash_canonical_bytes(
-        DigestDomain::MedicationSafetyPolicy,
-        b"different-qualified-safety-policy",
+    let safety = safety_bundle(&artifact, 150, 150);
+    let wrong_trust_policy = hash_canonical_bytes(
+        DigestDomain::MedicationSafetyTrustPolicy,
+        b"different-source-trust-policy",
     )
     .unwrap();
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact,
-        clearance,
-        wrong_safety_policy,
+        safety.clearance,
+        safety.source_trust,
+        safety.safety_policy_digest,
+        wrong_trust_policy,
         authority,
         authority_policy,
         &workflow_policy(),
@@ -354,43 +419,17 @@ fn safety_clearance_policy_substitution_is_rejected() {
         &jurisdiction(),
         200,
     ));
-    assert!(matches!(error, WorkflowError::SafetyPolicyDigestMismatch));
-}
-
-#[test]
-fn clinical_review_authority_cannot_be_replayed_as_prescribing() {
-    let p = principal(4);
-    let authority_policy = policy_digest(b"review-policy-v1");
-    let artifact = medication_artifact("order-a", p, 100);
-    let authority = authority_for(
-        artifact.verified_digest().unwrap(),
-        authority_policy,
-        AuthorityPurpose::ClinicalReview,
-        p,
-        "prescribe",
-        100,
-    );
-    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 150);
-
-    let error = expect_workflow_error(authorize_resolved_medication_activation(
-        &artifact,
-        clearance,
-        safety_policy_digest,
-        authority,
-        authority_policy,
-        &workflow_policy(),
-        p,
-        &jurisdiction(),
-        200,
+    assert!(matches!(
+        error,
+        WorkflowError::SafetyTrustPolicyDigestMismatch
     ));
-    assert!(matches!(error, WorkflowError::WrongAuthorityPurpose { .. }));
 }
 
 #[test]
 fn requester_principal_substitution_is_rejected_before_action() {
-    let requester = principal(5);
-    let attacker = principal(6);
-    let authority_policy = policy_digest(b"prescribing-policy-v1");
+    let requester = principal(4);
+    let attacker = principal(5);
+    let authority_policy = authority_policy_digest(b"prescribing-policy-v1");
     let artifact = medication_artifact("order-a", requester, 100);
     let authority = authority_for(
         artifact.verified_digest().unwrap(),
@@ -400,12 +439,14 @@ fn requester_principal_substitution_is_rejected_before_action() {
         "prescribe",
         100,
     );
-    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 150);
+    let safety = safety_bundle(&artifact, 150, 150);
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact,
-        clearance,
-        safety_policy_digest,
+        safety.clearance,
+        safety.source_trust,
+        safety.safety_policy_digest,
+        safety.trust_policy_digest,
         authority,
         authority_policy,
         &workflow_policy(),
@@ -417,117 +458,79 @@ fn requester_principal_substitution_is_rejected_before_action() {
 }
 
 #[test]
-fn stale_authority_cannot_be_converted_to_fresh_workflow_capability() {
+fn stale_source_trust_cannot_be_reused() {
+    let p = principal(6);
+    let authority_policy = authority_policy_digest(b"prescribing-policy-v1");
+    let artifact = medication_artifact("order-a", p, 0);
+    let authority = authority_for(
+        artifact.verified_digest().unwrap(),
+        authority_policy,
+        AuthorityPurpose::Prescribe,
+        p,
+        "prescribe",
+        11,
+    );
+    let safety = safety_bundle(&artifact, 11, 0);
+    let strict = WorkflowPolicyV1 {
+        schema_version: 1,
+        max_authority_age_micros: 100,
+        max_requester_resolution_age_micros: 100,
+        max_safety_clearance_age_micros: 100,
+        max_safety_source_trust_age_micros: 10,
+        max_future_skew_micros: 0,
+    };
+
+    let error = expect_workflow_error(authorize_resolved_medication_activation(
+        &artifact,
+        safety.clearance,
+        safety.source_trust,
+        safety.safety_policy_digest,
+        safety.trust_policy_digest,
+        authority,
+        authority_policy,
+        &strict,
+        p,
+        &jurisdiction(),
+        11,
+    ));
+    assert!(matches!(error, WorkflowError::SafetySourceTrustStale));
+}
+
+#[test]
+fn clinical_review_authority_cannot_be_replayed_as_prescribing() {
     let p = principal(7);
-    let authority_policy = policy_digest(b"prescribing-policy-v1");
-    let artifact = medication_artifact("order-a", p, 10);
+    let authority_policy = authority_policy_digest(b"review-policy-v1");
+    let artifact = medication_artifact("order-a", p, 100);
     let authority = authority_for(
         artifact.verified_digest().unwrap(),
         authority_policy,
-        AuthorityPurpose::Prescribe,
+        AuthorityPurpose::ClinicalReview,
         p,
         "prescribe",
-        0,
+        100,
     );
-    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 11);
-    let strict = WorkflowPolicyV1 {
-        schema_version: 1,
-        max_authority_age_micros: 10,
-        max_requester_resolution_age_micros: 100,
-        max_safety_clearance_age_micros: 100,
-        max_future_skew_micros: 0,
-    };
+    let safety = safety_bundle(&artifact, 150, 150);
 
     let error = expect_workflow_error(authorize_resolved_medication_activation(
         &artifact,
-        clearance,
-        safety_policy_digest,
+        safety.clearance,
+        safety.source_trust,
+        safety.safety_policy_digest,
+        safety.trust_policy_digest,
         authority,
         authority_policy,
-        &strict,
+        &workflow_policy(),
         p,
         &jurisdiction(),
-        11,
+        200,
     ));
-    assert!(matches!(error, WorkflowError::AuthorityEvaluationStale));
+    assert!(matches!(error, WorkflowError::WrongAuthorityPurpose { .. }));
 }
 
 #[test]
-fn stale_requester_resolution_cannot_be_reused() {
+fn successful_medication_capability_binds_four_evidence_lineages() {
     let p = principal(8);
-    let authority_policy = policy_digest(b"prescribing-policy-v1");
-    let artifact = medication_artifact("order-a", p, 0);
-    let authority = authority_for(
-        artifact.verified_digest().unwrap(),
-        authority_policy,
-        AuthorityPurpose::Prescribe,
-        p,
-        "prescribe",
-        11,
-    );
-    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 11);
-    let strict = WorkflowPolicyV1 {
-        schema_version: 1,
-        max_authority_age_micros: 100,
-        max_requester_resolution_age_micros: 10,
-        max_safety_clearance_age_micros: 100,
-        max_future_skew_micros: 0,
-    };
-
-    let error = expect_workflow_error(authorize_resolved_medication_activation(
-        &artifact,
-        clearance,
-        safety_policy_digest,
-        authority,
-        authority_policy,
-        &strict,
-        p,
-        &jurisdiction(),
-        11,
-    ));
-    assert!(matches!(error, WorkflowError::RequesterResolutionStale));
-}
-
-#[test]
-fn stale_safety_clearance_cannot_be_reused() {
-    let p = principal(9);
-    let authority_policy = policy_digest(b"prescribing-policy-v1");
-    let artifact = medication_artifact("order-a", p, 0);
-    let authority = authority_for(
-        artifact.verified_digest().unwrap(),
-        authority_policy,
-        AuthorityPurpose::Prescribe,
-        p,
-        "prescribe",
-        11,
-    );
-    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 0);
-    let strict = WorkflowPolicyV1 {
-        schema_version: 1,
-        max_authority_age_micros: 100,
-        max_requester_resolution_age_micros: 100,
-        max_safety_clearance_age_micros: 10,
-        max_future_skew_micros: 0,
-    };
-
-    let error = expect_workflow_error(authorize_resolved_medication_activation(
-        &artifact,
-        clearance,
-        safety_policy_digest,
-        authority,
-        authority_policy,
-        &strict,
-        p,
-        &jurisdiction(),
-        11,
-    ));
-    assert!(matches!(error, WorkflowError::SafetyClearanceStale));
-}
-
-#[test]
-fn successful_medication_capability_binds_all_three_evidence_lineages() {
-    let p = principal(10);
-    let authority_policy = policy_digest(b"prescribing-policy-v1");
+    let authority_policy = authority_policy_digest(b"prescribing-policy-v1");
     let artifact = medication_artifact("order-a", p, 100);
     let artifact_digest = artifact.verified_digest().unwrap();
     let authority = authority_for(
@@ -538,12 +541,16 @@ fn successful_medication_capability_binds_all_three_evidence_lineages() {
         "prescribe",
         100,
     );
-    let (clearance, safety_policy_digest) = safety_clearance(&artifact, 150);
+    let safety = safety_bundle(&artifact, 150, 150);
+    let safety_policy_digest = safety.safety_policy_digest;
+    let trust_policy_digest = safety.trust_policy_digest;
 
     let capability = authorize_resolved_medication_activation(
         &artifact,
-        clearance,
+        safety.clearance,
+        safety.source_trust,
         safety_policy_digest,
+        trust_policy_digest,
         authority,
         authority_policy,
         &workflow_policy(),
@@ -552,25 +559,19 @@ fn successful_medication_capability_binds_all_three_evidence_lineages() {
         200,
     )
     .unwrap();
-    assert_eq!(
-        capability.order_id(),
-        "fhir:https://ehr.example/fhir:MedicationRequest:order-a"
-    );
-    assert_eq!(
-        capability.medication_artifact_digest().value,
-        artifact_digest.value()
-    );
+
+    assert_eq!(capability.medication_artifact_digest().value, artifact_digest.value());
     assert_eq!(capability.principal(), p);
     assert_eq!(capability.requester_resolution_evidence().len(), 3);
-    assert_eq!(
-        capability.safety_policy_digest().value,
-        safety_policy_digest.value()
-    );
+    assert_eq!(capability.safety_policy_digest().value, safety_policy_digest.value());
     assert_eq!(capability.safety_check_evaluation_digests().len(), 1);
+    assert_eq!(capability.safety_trust_policy_digest().value, trust_policy_digest.value());
     assert_eq!(
-        capability.safety_context_digest().domain,
-        DigestDomain::MedicationSafetyContext
+        capability.safety_trust_receipt_digest().domain,
+        DigestDomain::MedicationSafetyTrustReceipt
     );
+    assert_eq!(capability.safety_evaluator_admission_evidence().len(), 1);
+    assert_eq!(capability.safety_knowledge_admission_evidence().len(), 1);
 }
 
 #[test]
@@ -608,8 +609,8 @@ fn quarantine_capability_rejects_changed_event() {
     )
     .unwrap();
 
-    let p = principal(11);
-    let authority_policy = policy_digest(b"clinical-review-policy-v1");
+    let p = principal(9);
+    let authority_policy = authority_policy_digest(b"clinical-review-policy-v1");
     let authority = authority_for(
         hash_quarantine_event(&review).unwrap(),
         authority_policy,

--- a/crates/medication-safety-trust/Cargo.toml
+++ b/crates/medication-safety-trust/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mycelix-medication-safety-trust"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Evaluator and knowledge admission for Mycelix-Health medication safety evidence"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
+mycelix-medication-safety = { path = "../medication-safety" }

--- a/crates/medication-safety-trust/src/lib.rs
+++ b/crates/medication-safety-trust/src/lib.rs
@@ -1,0 +1,651 @@
+#![deny(unsafe_code)]
+//! Deployment-scoped trust admission for medication safety evidence.
+//!
+//! `mycelix-medication-safety` answers whether required evidence is complete and
+//! clear under a safety policy. This crate answers the separate trust question:
+//! were the evaluator and knowledge artifact for every required check actually
+//! admitted by deployment policy at the time of use?
+
+use mycelix_clinical_integrity::{
+    hash_canonical_bytes, DigestDomain, IntegrityError, StoredDigest, VerifiedDigest,
+};
+use mycelix_medication_safety::{SafetyCheckKind, VerifiedSafetyCheck};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use thiserror::Error;
+
+const MAX_FUTURE_SKEW_MICROS: i64 = 300_000_000;
+const TRUST_POLICY_SCHEMA_TAG: &[u8] = b"mycelix-health/medication-safety-trust-policy-v1";
+const TRUST_RECEIPT_SCHEMA_TAG: &[u8] = b"mycelix-health/medication-safety-trust-receipt-v1";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SafetySourceTrustPolicyV1 {
+    pub schema_version: u16,
+    pub policy_id: String,
+    /// Exact medication-safety policy this trust policy is allowed to qualify.
+    pub safety_policy_digest: StoredDigest,
+    pub max_future_skew_micros: i64,
+}
+
+impl SafetySourceTrustPolicyV1 {
+    pub fn validate(&self) -> Result<(), SafetySourceTrustError> {
+        if self.schema_version != 1 {
+            return Err(SafetySourceTrustError::UnsupportedPolicyVersion(
+                self.schema_version,
+            ));
+        }
+        if self.policy_id.trim().is_empty() {
+            return Err(SafetySourceTrustError::MissingPolicyId);
+        }
+        self.safety_policy_digest.validate_shape()?;
+        if self.safety_policy_digest.domain != DigestDomain::MedicationSafetyPolicy {
+            return Err(SafetySourceTrustError::SafetyPolicyDomainMismatch);
+        }
+        if self.max_future_skew_micros < 0
+            || self.max_future_skew_micros > MAX_FUTURE_SKEW_MICROS
+        {
+            return Err(SafetySourceTrustError::InvalidFutureSkew);
+        }
+        Ok(())
+    }
+
+    pub fn verified_digest(&self) -> Result<VerifiedDigest, SafetySourceTrustError> {
+        self.validate()?;
+        hash_json(
+            DigestDomain::MedicationSafetyTrustPolicy,
+            TRUST_POLICY_SCHEMA_TAG,
+            self,
+        )
+    }
+}
+
+/// Evidence that deployment configuration admitted a particular evaluator artifact.
+///
+/// This object intentionally has no serde implementation. The adapter constructing it
+/// is responsible for verifying the configuration/signature/registry record represented
+/// by `admission_evidence_digest`. This crate then enforces scope, policy and time.
+pub struct VerifiedEvaluatorAdmission {
+    evaluator_digest: StoredDigest,
+    allowed_checks: Vec<SafetyCheckKind>,
+    valid_from_micros: i64,
+    valid_until_micros: Option<i64>,
+    revoked_at_micros: Option<i64>,
+    trust_policy_digest: StoredDigest,
+    admission_evidence_digest: StoredDigest,
+}
+
+impl VerifiedEvaluatorAdmission {
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_verified_record(
+        evaluator_digest: VerifiedDigest,
+        allowed_checks: Vec<SafetyCheckKind>,
+        valid_from_micros: i64,
+        valid_until_micros: Option<i64>,
+        revoked_at_micros: Option<i64>,
+        trust_policy_digest: VerifiedDigest,
+        admission_evidence_digest: VerifiedDigest,
+    ) -> Result<Self, SafetySourceTrustError> {
+        evaluator_digest.require_domain(DigestDomain::ClinicalArtifact)?;
+        trust_policy_digest.require_domain(DigestDomain::MedicationSafetyTrustPolicy)?;
+        admission_evidence_digest.require_domain(DigestDomain::ClinicalArtifact)?;
+        validate_check_set(&allowed_checks)?;
+        validate_window(valid_from_micros, valid_until_micros, revoked_at_micros)?;
+        Ok(Self {
+            evaluator_digest: evaluator_digest.stored(),
+            allowed_checks,
+            valid_from_micros,
+            valid_until_micros,
+            revoked_at_micros,
+            trust_policy_digest: trust_policy_digest.stored(),
+            admission_evidence_digest: admission_evidence_digest.stored(),
+        })
+    }
+
+    fn active_at(&self, at_micros: i64) -> bool {
+        at_micros >= self.valid_from_micros
+            && self
+                .valid_until_micros
+                .map(|until| at_micros < until)
+                .unwrap_or(true)
+            && self
+                .revoked_at_micros
+                .map(|revoked| at_micros < revoked)
+                .unwrap_or(true)
+    }
+
+    fn admits(&self, check: &VerifiedSafetyCheck, trust_policy: StoredDigest) -> bool {
+        self.trust_policy_digest == trust_policy
+            && self.evaluator_digest == check.evaluator_digest()
+            && self.allowed_checks.contains(&check.kind())
+    }
+}
+
+/// Evidence that deployment policy admitted one exact knowledge snapshot/version.
+pub struct VerifiedKnowledgeAdmission {
+    knowledge_digest: StoredDigest,
+    allowed_checks: Vec<SafetyCheckKind>,
+    valid_from_micros: i64,
+    valid_until_micros: Option<i64>,
+    revoked_at_micros: Option<i64>,
+    trust_policy_digest: StoredDigest,
+    admission_evidence_digest: StoredDigest,
+}
+
+impl VerifiedKnowledgeAdmission {
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_verified_record(
+        knowledge_digest: VerifiedDigest,
+        allowed_checks: Vec<SafetyCheckKind>,
+        valid_from_micros: i64,
+        valid_until_micros: Option<i64>,
+        revoked_at_micros: Option<i64>,
+        trust_policy_digest: VerifiedDigest,
+        admission_evidence_digest: VerifiedDigest,
+    ) -> Result<Self, SafetySourceTrustError> {
+        knowledge_digest.require_domain(DigestDomain::MedicationSafetyKnowledge)?;
+        trust_policy_digest.require_domain(DigestDomain::MedicationSafetyTrustPolicy)?;
+        admission_evidence_digest.require_domain(DigestDomain::ClinicalArtifact)?;
+        validate_check_set(&allowed_checks)?;
+        validate_window(valid_from_micros, valid_until_micros, revoked_at_micros)?;
+        Ok(Self {
+            knowledge_digest: knowledge_digest.stored(),
+            allowed_checks,
+            valid_from_micros,
+            valid_until_micros,
+            revoked_at_micros,
+            trust_policy_digest: trust_policy_digest.stored(),
+            admission_evidence_digest: admission_evidence_digest.stored(),
+        })
+    }
+
+    fn active_at(&self, at_micros: i64) -> bool {
+        at_micros >= self.valid_from_micros
+            && self
+                .valid_until_micros
+                .map(|until| at_micros < until)
+                .unwrap_or(true)
+            && self
+                .revoked_at_micros
+                .map(|revoked| at_micros < revoked)
+                .unwrap_or(true)
+    }
+
+    fn admits(&self, check: &VerifiedSafetyCheck, trust_policy: StoredDigest) -> bool {
+        self.trust_policy_digest == trust_policy
+            && self.knowledge_digest == check.knowledge_digest()
+            && self.allowed_checks.contains(&check.kind())
+    }
+}
+
+#[derive(Serialize)]
+struct ReceiptDigestMaterial {
+    safety_policy_digest: StoredDigest,
+    trust_policy_digest: StoredDigest,
+    check_evaluation_digests: Vec<StoredDigest>,
+    evaluator_admission_evidence_digests: Vec<StoredDigest>,
+    knowledge_admission_evidence_digests: Vec<StoredDigest>,
+    evaluated_at_micros: i64,
+}
+
+/// Single-owner proof that every supplied safety check was admitted through an active
+/// evaluator record and an active exact-knowledge record under one deployment policy.
+/// Intentionally non-cloneable and non-serializable.
+pub struct SafetySourceTrustReceipt {
+    safety_policy_digest: StoredDigest,
+    trust_policy_digest: StoredDigest,
+    check_evaluation_digests: Vec<StoredDigest>,
+    evaluator_admission_evidence_digests: Vec<StoredDigest>,
+    knowledge_admission_evidence_digests: Vec<StoredDigest>,
+    evaluated_at_micros: i64,
+    receipt_digest: StoredDigest,
+}
+
+impl SafetySourceTrustReceipt {
+    pub fn safety_policy_digest(&self) -> StoredDigest {
+        self.safety_policy_digest
+    }
+
+    pub fn trust_policy_digest(&self) -> StoredDigest {
+        self.trust_policy_digest
+    }
+
+    pub fn check_evaluation_digests(&self) -> &[StoredDigest] {
+        &self.check_evaluation_digests
+    }
+
+    pub fn evaluator_admission_evidence_digests(&self) -> &[StoredDigest] {
+        &self.evaluator_admission_evidence_digests
+    }
+
+    pub fn knowledge_admission_evidence_digests(&self) -> &[StoredDigest] {
+        &self.knowledge_admission_evidence_digests
+    }
+
+    pub fn evaluated_at_micros(&self) -> i64 {
+        self.evaluated_at_micros
+    }
+
+    pub fn receipt_digest(&self) -> StoredDigest {
+        self.receipt_digest
+    }
+}
+
+pub fn evaluate_safety_source_trust(
+    safety_policy_digest: VerifiedDigest,
+    trust_policy: &SafetySourceTrustPolicyV1,
+    checks: &[VerifiedSafetyCheck],
+    evaluator_admissions: &[VerifiedEvaluatorAdmission],
+    knowledge_admissions: &[VerifiedKnowledgeAdmission],
+    at_micros: i64,
+) -> Result<SafetySourceTrustReceipt, SafetySourceTrustError> {
+    safety_policy_digest.require_domain(DigestDomain::MedicationSafetyPolicy)?;
+    trust_policy.validate()?;
+    if trust_policy.safety_policy_digest != safety_policy_digest.stored() {
+        return Err(SafetySourceTrustError::SafetyPolicyMismatch);
+    }
+    if checks.is_empty() {
+        return Err(SafetySourceTrustError::NoSafetyChecks);
+    }
+
+    let trust_policy_digest = trust_policy.verified_digest()?;
+    let stored_trust_policy = trust_policy_digest.stored();
+    let mut seen_checks = HashSet::new();
+    let mut check_evaluation_digests = Vec::with_capacity(checks.len());
+    let mut evaluator_evidence = Vec::with_capacity(checks.len());
+    let mut knowledge_evidence = Vec::with_capacity(checks.len());
+
+    for check in checks {
+        if !seen_checks.insert(check.kind()) {
+            return Err(SafetySourceTrustError::DuplicateCheckKind(check.kind()));
+        }
+
+        let evaluation_digest = check.evaluation_digest();
+        validate_stored_domain(evaluation_digest, DigestDomain::MedicationSafetyEvaluation)?;
+        validate_stored_domain(check.evaluator_digest(), DigestDomain::ClinicalArtifact)?;
+        validate_stored_domain(
+            check.knowledge_digest(),
+            DigestDomain::MedicationSafetyKnowledge,
+        )?;
+
+        let evaluator = evaluator_admissions
+            .iter()
+            .filter(|admission| admission.active_at(at_micros))
+            .filter(|admission| admission.admits(check, stored_trust_policy))
+            .min_by_key(|admission| admission.admission_evidence_digest.value)
+            .ok_or(SafetySourceTrustError::EvaluatorNotAdmitted(check.kind()))?;
+
+        let knowledge = knowledge_admissions
+            .iter()
+            .filter(|admission| admission.active_at(at_micros))
+            .filter(|admission| admission.admits(check, stored_trust_policy))
+            .min_by_key(|admission| admission.admission_evidence_digest.value)
+            .ok_or(SafetySourceTrustError::KnowledgeNotAdmitted(check.kind()))?;
+
+        check_evaluation_digests.push(evaluation_digest);
+        evaluator_evidence.push(evaluator.admission_evidence_digest);
+        knowledge_evidence.push(knowledge.admission_evidence_digest);
+    }
+
+    let material = ReceiptDigestMaterial {
+        safety_policy_digest: safety_policy_digest.stored(),
+        trust_policy_digest: stored_trust_policy,
+        check_evaluation_digests: check_evaluation_digests.clone(),
+        evaluator_admission_evidence_digests: evaluator_evidence.clone(),
+        knowledge_admission_evidence_digests: knowledge_evidence.clone(),
+        evaluated_at_micros: at_micros,
+    };
+    let receipt_digest = hash_json(
+        DigestDomain::MedicationSafetyTrustReceipt,
+        TRUST_RECEIPT_SCHEMA_TAG,
+        &material,
+    )?;
+
+    Ok(SafetySourceTrustReceipt {
+        safety_policy_digest: material.safety_policy_digest,
+        trust_policy_digest: material.trust_policy_digest,
+        check_evaluation_digests,
+        evaluator_admission_evidence_digests: evaluator_evidence,
+        knowledge_admission_evidence_digests: knowledge_evidence,
+        evaluated_at_micros: at_micros,
+        receipt_digest: receipt_digest.stored(),
+    })
+}
+
+fn validate_check_set(checks: &[SafetyCheckKind]) -> Result<(), SafetySourceTrustError> {
+    if checks.is_empty() {
+        return Err(SafetySourceTrustError::AdmissionHasNoChecks);
+    }
+    let mut seen = HashSet::new();
+    for check in checks {
+        if !seen.insert(*check) {
+            return Err(SafetySourceTrustError::DuplicateAdmissionCheck(*check));
+        }
+    }
+    Ok(())
+}
+
+fn validate_window(
+    valid_from_micros: i64,
+    valid_until_micros: Option<i64>,
+    revoked_at_micros: Option<i64>,
+) -> Result<(), SafetySourceTrustError> {
+    if valid_until_micros.is_some_and(|until| until <= valid_from_micros) {
+        return Err(SafetySourceTrustError::InvalidValidityWindow);
+    }
+    if revoked_at_micros.is_some_and(|revoked| revoked < valid_from_micros) {
+        return Err(SafetySourceTrustError::RevocationPredatesValidity);
+    }
+    Ok(())
+}
+
+fn validate_stored_domain(
+    digest: StoredDigest,
+    expected: DigestDomain,
+) -> Result<(), SafetySourceTrustError> {
+    digest.validate_shape()?;
+    if digest.domain != expected {
+        return Err(SafetySourceTrustError::StoredDigestDomainMismatch {
+            expected,
+            actual: digest.domain,
+        });
+    }
+    Ok(())
+}
+
+fn hash_json<T: Serialize>(
+    domain: DigestDomain,
+    schema_tag: &[u8],
+    value: &T,
+) -> Result<VerifiedDigest, SafetySourceTrustError> {
+    let encoded = serde_json::to_vec(value)
+        .map_err(|error| SafetySourceTrustError::Serialization(error.to_string()))?;
+    let mut framed = Vec::with_capacity(schema_tag.len() + 1 + encoded.len());
+    framed.extend_from_slice(schema_tag);
+    framed.push(0);
+    framed.extend_from_slice(&encoded);
+    Ok(hash_canonical_bytes(domain, &framed)?)
+}
+
+#[derive(Debug, Error)]
+pub enum SafetySourceTrustError {
+    #[error("unsupported medication safety trust policy version {0}")]
+    UnsupportedPolicyVersion(u16),
+    #[error("medication safety trust policy id is required")]
+    MissingPolicyId,
+    #[error("trust policy safety-policy digest must use MedicationSafetyPolicy domain")]
+    SafetyPolicyDomainMismatch,
+    #[error("trust policy does not qualify the supplied medication safety policy")]
+    SafetyPolicyMismatch,
+    #[error("trust policy future-skew allowance must be between 0 and five minutes")]
+    InvalidFutureSkew,
+    #[error("safety-source admission must authorize at least one check kind")]
+    AdmissionHasNoChecks,
+    #[error("duplicate check kind in safety-source admission: {0:?}")]
+    DuplicateAdmissionCheck(SafetyCheckKind),
+    #[error("safety-source admission validity window is invalid")]
+    InvalidValidityWindow,
+    #[error("safety-source admission revocation predates validity")]
+    RevocationPredatesValidity,
+    #[error("at least one safety check is required for source-trust evaluation")]
+    NoSafetyChecks,
+    #[error("duplicate safety check kind in trust evaluation: {0:?}")]
+    DuplicateCheckKind(SafetyCheckKind),
+    #[error("no active trusted evaluator admission covers safety check {0:?}")]
+    EvaluatorNotAdmitted(SafetyCheckKind),
+    #[error("no active trusted knowledge admission covers safety check {0:?}")]
+    KnowledgeNotAdmitted(SafetyCheckKind),
+    #[error("stored digest domain mismatch: expected {expected:?}, got {actual:?}")]
+    StoredDigestDomainMismatch {
+        expected: DigestDomain,
+        actual: DigestDomain,
+    },
+    #[error("failed to serialize medication safety trust artifact: {0}")]
+    Serialization(String),
+    #[error(transparent)]
+    Integrity(#[from] IntegrityError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_medication_safety::{KnowledgeCoverage, SafetyCheckOutcome};
+
+    fn clinical(seed: u8) -> VerifiedDigest {
+        hash_canonical_bytes(DigestDomain::ClinicalArtifact, &[seed]).unwrap()
+    }
+
+    fn safety_policy() -> VerifiedDigest {
+        hash_canonical_bytes(DigestDomain::MedicationSafetyPolicy, b"safety-policy").unwrap()
+    }
+
+    fn knowledge(seed: u8) -> VerifiedDigest {
+        hash_canonical_bytes(DigestDomain::MedicationSafetyKnowledge, &[seed]).unwrap()
+    }
+
+    fn trust_policy(safety: VerifiedDigest) -> SafetySourceTrustPolicyV1 {
+        SafetySourceTrustPolicyV1 {
+            schema_version: 1,
+            policy_id: "deployment-medication-safety-trust-v1".into(),
+            safety_policy_digest: safety.stored(),
+            max_future_skew_micros: 0,
+        }
+    }
+
+    fn check(
+        kind: SafetyCheckKind,
+        safety: VerifiedDigest,
+        evaluator: VerifiedDigest,
+        kb: VerifiedDigest,
+        seed: u8,
+    ) -> VerifiedSafetyCheck {
+        VerifiedSafetyCheck::from_verified_evaluation(
+            kind,
+            hash_canonical_bytes(DigestDomain::MedicationRequestArtifact, b"medication").unwrap(),
+            hash_canonical_bytes(DigestDomain::MedicationSafetyContext, b"context").unwrap(),
+            safety,
+            kb,
+            evaluator,
+            KnowledgeCoverage::CompleteForPolicy,
+            SafetyCheckOutcome::Clear,
+            0,
+            100,
+            100,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn admitted_evaluator_and_knowledge_produce_receipt() {
+        let safety = safety_policy();
+        let policy = trust_policy(safety);
+        let trust_digest = policy.verified_digest().unwrap();
+        let evaluator = clinical(1);
+        let kb = knowledge(2);
+        let check = check(SafetyCheckKind::DrugAllergy, safety, evaluator, kb, 9);
+        let evaluators = vec![VerifiedEvaluatorAdmission::from_verified_record(
+            evaluator,
+            vec![SafetyCheckKind::DrugAllergy],
+            0,
+            Some(1_000),
+            None,
+            trust_digest,
+            clinical(3),
+        )
+        .unwrap()];
+        let knowledge = vec![VerifiedKnowledgeAdmission::from_verified_record(
+            kb,
+            vec![SafetyCheckKind::DrugAllergy],
+            0,
+            Some(1_000),
+            None,
+            trust_digest,
+            clinical(4),
+        )
+        .unwrap()];
+
+        let receipt = evaluate_safety_source_trust(
+            safety,
+            &policy,
+            &[check],
+            &evaluators,
+            &knowledge,
+            150,
+        )
+        .unwrap();
+        assert_eq!(receipt.safety_policy_digest(), safety.stored());
+        assert_eq!(receipt.trust_policy_digest(), trust_digest.stored());
+        assert_eq!(receipt.check_evaluation_digests().len(), 1);
+        assert_eq!(receipt.receipt_digest().domain, DigestDomain::MedicationSafetyTrustReceipt);
+    }
+
+    #[test]
+    fn unknown_evaluator_is_rejected() {
+        let safety = safety_policy();
+        let policy = trust_policy(safety);
+        let trust_digest = policy.verified_digest().unwrap();
+        let check = check(
+            SafetyCheckKind::DrugAllergy,
+            safety,
+            clinical(9),
+            knowledge(2),
+            9,
+        );
+        let evaluators = vec![VerifiedEvaluatorAdmission::from_verified_record(
+            clinical(1),
+            vec![SafetyCheckKind::DrugAllergy],
+            0,
+            Some(1_000),
+            None,
+            trust_digest,
+            clinical(3),
+        )
+        .unwrap()];
+        let knowledge = vec![VerifiedKnowledgeAdmission::from_verified_record(
+            knowledge(2),
+            vec![SafetyCheckKind::DrugAllergy],
+            0,
+            Some(1_000),
+            None,
+            trust_digest,
+            clinical(4),
+        )
+        .unwrap()];
+
+        let error = evaluate_safety_source_trust(
+            safety,
+            &policy,
+            &[check],
+            &evaluators,
+            &knowledge,
+            150,
+        )
+        .err()
+        .expect("unknown evaluator must fail");
+        assert!(matches!(
+            error,
+            SafetySourceTrustError::EvaluatorNotAdmitted(SafetyCheckKind::DrugAllergy)
+        ));
+    }
+
+    #[test]
+    fn revoked_evaluator_is_rejected() {
+        let safety = safety_policy();
+        let policy = trust_policy(safety);
+        let trust_digest = policy.verified_digest().unwrap();
+        let evaluator = clinical(1);
+        let kb = knowledge(2);
+        let check = check(SafetyCheckKind::DrugAllergy, safety, evaluator, kb, 9);
+        let evaluators = vec![VerifiedEvaluatorAdmission::from_verified_record(
+            evaluator,
+            vec![SafetyCheckKind::DrugAllergy],
+            0,
+            Some(1_000),
+            Some(100),
+            trust_digest,
+            clinical(3),
+        )
+        .unwrap()];
+        let knowledge = vec![VerifiedKnowledgeAdmission::from_verified_record(
+            kb,
+            vec![SafetyCheckKind::DrugAllergy],
+            0,
+            Some(1_000),
+            None,
+            trust_digest,
+            clinical(4),
+        )
+        .unwrap()];
+
+        let error = evaluate_safety_source_trust(
+            safety,
+            &policy,
+            &[check],
+            &evaluators,
+            &knowledge,
+            150,
+        )
+        .err()
+        .expect("revoked evaluator must fail");
+        assert!(matches!(
+            error,
+            SafetySourceTrustError::EvaluatorNotAdmitted(SafetyCheckKind::DrugAllergy)
+        ));
+    }
+
+    #[test]
+    fn check_kind_cannot_escape_admission_scope() {
+        let safety = safety_policy();
+        let policy = trust_policy(safety);
+        let trust_digest = policy.verified_digest().unwrap();
+        let evaluator = clinical(1);
+        let kb = knowledge(2);
+        let check = check(SafetyCheckKind::DrugAllergy, safety, evaluator, kb, 9);
+        let evaluators = vec![VerifiedEvaluatorAdmission::from_verified_record(
+            evaluator,
+            vec![SafetyCheckKind::DrugDrugInteraction],
+            0,
+            Some(1_000),
+            None,
+            trust_digest,
+            clinical(3),
+        )
+        .unwrap()];
+        let knowledge = vec![VerifiedKnowledgeAdmission::from_verified_record(
+            kb,
+            vec![SafetyCheckKind::DrugAllergy],
+            0,
+            Some(1_000),
+            None,
+            trust_digest,
+            clinical(4),
+        )
+        .unwrap()];
+
+        assert!(matches!(
+            evaluate_safety_source_trust(
+                safety,
+                &policy,
+                &[check],
+                &evaluators,
+                &knowledge,
+                150,
+            ),
+            Err(SafetySourceTrustError::EvaluatorNotAdmitted(
+                SafetyCheckKind::DrugAllergy
+            ))
+        ));
+    }
+
+    #[test]
+    fn trust_policy_cannot_be_replayed_across_safety_policy() {
+        let safety = safety_policy();
+        let policy = trust_policy(safety);
+        let other_safety =
+            hash_canonical_bytes(DigestDomain::MedicationSafetyPolicy, b"other-policy").unwrap();
+        assert!(matches!(
+            evaluate_safety_source_trust(other_safety, &policy, &[], &[], &[], 100),
+            Err(SafetySourceTrustError::SafetyPolicyMismatch)
+        ));
+    }
+}

--- a/crates/medication-safety-trust/tests/adversarial_admission.rs
+++ b/crates/medication-safety-trust/tests/adversarial_admission.rs
@@ -1,0 +1,185 @@
+use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, VerifiedDigest};
+use mycelix_medication_safety::{
+    KnowledgeCoverage, SafetyCheckKind, SafetyCheckOutcome, VerifiedSafetyCheck,
+};
+use mycelix_medication_safety_trust::{
+    evaluate_safety_source_trust, SafetySourceTrustError, SafetySourceTrustPolicyV1,
+    VerifiedEvaluatorAdmission, VerifiedKnowledgeAdmission,
+};
+
+fn clinical(seed: u8) -> VerifiedDigest {
+    hash_canonical_bytes(DigestDomain::ClinicalArtifact, &[seed]).unwrap()
+}
+
+fn safety_policy(label: &[u8]) -> VerifiedDigest {
+    hash_canonical_bytes(DigestDomain::MedicationSafetyPolicy, label).unwrap()
+}
+
+fn knowledge(seed: u8) -> VerifiedDigest {
+    hash_canonical_bytes(DigestDomain::MedicationSafetyKnowledge, &[seed]).unwrap()
+}
+
+fn trust_policy(safety: VerifiedDigest, id: &str) -> SafetySourceTrustPolicyV1 {
+    SafetySourceTrustPolicyV1 {
+        schema_version: 1,
+        policy_id: id.into(),
+        safety_policy_digest: safety.stored(),
+        max_future_skew_micros: 0,
+    }
+}
+
+fn check(
+    safety: VerifiedDigest,
+    evaluator: VerifiedDigest,
+    kb: VerifiedDigest,
+) -> VerifiedSafetyCheck {
+    VerifiedSafetyCheck::from_verified_evaluation(
+        SafetyCheckKind::DrugAllergy,
+        hash_canonical_bytes(DigestDomain::MedicationRequestArtifact, b"rx-a").unwrap(),
+        hash_canonical_bytes(DigestDomain::MedicationSafetyContext, b"ctx-a").unwrap(),
+        safety,
+        kb,
+        evaluator,
+        KnowledgeCoverage::CompleteForPolicy,
+        SafetyCheckOutcome::Clear,
+        0,
+        100,
+        100,
+    )
+    .unwrap()
+}
+
+#[test]
+fn unknown_knowledge_artifact_is_not_admitted() {
+    let safety = safety_policy(b"safety-a");
+    let policy = trust_policy(safety, "trust-a");
+    let trust_digest = policy.verified_digest().unwrap();
+    let evaluator = clinical(1);
+    let checked_knowledge = knowledge(2);
+    let admitted_knowledge = knowledge(3);
+    let check = check(safety, evaluator, checked_knowledge);
+    let evaluators = vec![VerifiedEvaluatorAdmission::from_verified_record(
+        evaluator,
+        vec![SafetyCheckKind::DrugAllergy],
+        0,
+        Some(1_000),
+        None,
+        trust_digest,
+        clinical(4),
+    )
+    .unwrap()];
+    let knowledge = vec![VerifiedKnowledgeAdmission::from_verified_record(
+        admitted_knowledge,
+        vec![SafetyCheckKind::DrugAllergy],
+        0,
+        Some(1_000),
+        None,
+        trust_digest,
+        clinical(5),
+    )
+    .unwrap()];
+
+    assert!(matches!(
+        evaluate_safety_source_trust(
+            safety,
+            &policy,
+            &[check],
+            &evaluators,
+            &knowledge,
+            150,
+        ),
+        Err(SafetySourceTrustError::KnowledgeNotAdmitted(
+            SafetyCheckKind::DrugAllergy
+        ))
+    ));
+}
+
+#[test]
+fn revoked_knowledge_artifact_is_not_admitted() {
+    let safety = safety_policy(b"safety-a");
+    let policy = trust_policy(safety, "trust-a");
+    let trust_digest = policy.verified_digest().unwrap();
+    let evaluator = clinical(1);
+    let kb = knowledge(2);
+    let check = check(safety, evaluator, kb);
+    let evaluators = vec![VerifiedEvaluatorAdmission::from_verified_record(
+        evaluator,
+        vec![SafetyCheckKind::DrugAllergy],
+        0,
+        Some(1_000),
+        None,
+        trust_digest,
+        clinical(4),
+    )
+    .unwrap()];
+    let knowledge = vec![VerifiedKnowledgeAdmission::from_verified_record(
+        kb,
+        vec![SafetyCheckKind::DrugAllergy],
+        0,
+        Some(1_000),
+        Some(120),
+        trust_digest,
+        clinical(5),
+    )
+    .unwrap()];
+
+    assert!(matches!(
+        evaluate_safety_source_trust(
+            safety,
+            &policy,
+            &[check],
+            &evaluators,
+            &knowledge,
+            150,
+        ),
+        Err(SafetySourceTrustError::KnowledgeNotAdmitted(
+            SafetyCheckKind::DrugAllergy
+        ))
+    ));
+}
+
+#[test]
+fn evaluator_admission_from_another_trust_policy_cannot_be_replayed() {
+    let safety = safety_policy(b"safety-a");
+    let policy = trust_policy(safety, "trust-a");
+    let other_policy = trust_policy(safety, "trust-b");
+    let trust_digest = policy.verified_digest().unwrap();
+    let other_trust_digest = other_policy.verified_digest().unwrap();
+    let evaluator = clinical(1);
+    let kb = knowledge(2);
+    let check = check(safety, evaluator, kb);
+    let evaluators = vec![VerifiedEvaluatorAdmission::from_verified_record(
+        evaluator,
+        vec![SafetyCheckKind::DrugAllergy],
+        0,
+        Some(1_000),
+        None,
+        other_trust_digest,
+        clinical(4),
+    )
+    .unwrap()];
+    let knowledge = vec![VerifiedKnowledgeAdmission::from_verified_record(
+        kb,
+        vec![SafetyCheckKind::DrugAllergy],
+        0,
+        Some(1_000),
+        None,
+        trust_digest,
+        clinical(5),
+    )
+    .unwrap()];
+
+    assert!(matches!(
+        evaluate_safety_source_trust(
+            safety,
+            &policy,
+            &[check],
+            &evaluators,
+            &knowledge,
+            150,
+        ),
+        Err(SafetySourceTrustError::EvaluatorNotAdmitted(
+            SafetyCheckKind::DrugAllergy
+        ))
+    ));
+}

--- a/docs/MEDICATION_SAFETY_SOURCE_TRUST_V1.md
+++ b/docs/MEDICATION_SAFETY_SOURCE_TRUST_V1.md
@@ -1,0 +1,113 @@
+# Medication Safety Source Trust v1
+
+Status: **experimental / qualification subject**.
+
+## Why this layer exists
+
+`mycelix-medication-safety` can prove that an exact set of medication-safety checks is complete, fresh, bound to an exact patient-context snapshot, and clear under an exact safety policy. That still does not answer a different question:
+
+> Does this deployment trust the evaluator and the exact knowledge snapshot that produced each check?
+
+This layer keeps those questions separate.
+
+## Central invariant
+
+A safety check is admitted only when both of these independently match the check itself:
+
+- an active evaluator admission for the exact evaluator digest and check kind;
+- an active knowledge admission for the exact knowledge-artifact digest and check kind.
+
+Both admissions must belong to the same exact `MedicationSafetyTrustPolicy` digest, and that trust policy is itself bound to one exact `MedicationSafetyPolicy` digest.
+
+## Trust policy
+
+`SafetySourceTrustPolicyV1` identifies the deployment policy used to qualify medication-safety sources and binds the exact safety policy it is permitted to support.
+
+The policy digest uses the `MedicationSafetyTrustPolicy` domain. The resulting source-trust receipt uses the separate `MedicationSafetyTrustReceipt` domain.
+
+## Evaluator admission
+
+A `VerifiedEvaluatorAdmission` binds:
+
+- exact evaluator artifact/identity digest;
+- allowed `SafetyCheckKind` values;
+- validity interval;
+- optional revocation time;
+- exact trust-policy digest;
+- evidence digest for the admission decision.
+
+An evaluator admitted for one check kind is not implicitly trusted for another.
+
+## Knowledge admission
+
+A `VerifiedKnowledgeAdmission` binds:
+
+- exact medication-safety knowledge artifact/version digest;
+- allowed `SafetyCheckKind` values;
+- validity interval;
+- optional revocation time;
+- exact trust-policy digest;
+- evidence digest for the admission decision.
+
+A newer, older, modified, unknown, expired, or revoked knowledge snapshot is therefore a different object and must be admitted separately.
+
+## Source-trust receipt
+
+`evaluate_safety_source_trust(...)` requires an exact safety-policy digest and the exact `VerifiedSafetyCheck` set. For each check it requires both an active evaluator admission and an active knowledge admission under the same trust policy.
+
+Success produces an opaque, non-cloneable, non-serializable `SafetySourceTrustReceipt` containing:
+
+- exact safety-policy digest;
+- exact safety-source trust-policy digest;
+- exact safety-check evaluation digests;
+- evaluator-admission evidence digests;
+- knowledge-admission evidence digests;
+- trust evaluation time;
+- domain-separated receipt digest.
+
+The final medication workflow consumes this receipt together with `MedicationSafetyClearance`. The two must cover the same exact safety-evaluation digest set.
+
+## Four independent medication activation lineages
+
+The high-assurance activation path now preserves four different proofs:
+
+1. **Requester identity** — the external FHIR requester resolves to the authenticated Mycelix principal.
+2. **Professional authority** — that principal may prescribe this exact artifact in this jurisdiction under the expected authority policy.
+3. **Clinical safety evidence** — required patient context and safety checks are complete, fresh, policy-covered, and clear.
+4. **Source trust** — the exact evaluators and knowledge snapshots behind those checks are admitted under the expected deployment trust policy.
+
+No one proof substitutes for another.
+
+## Trust-root boundary and non-claim
+
+This pure crate does not create institutional legitimacy from nothing. `VerifiedEvaluatorAdmission` and `VerifiedKnowledgeAdmission` are intended to be created only after a trusted adapter verifies deployment configuration, signatures, registry/DHT state, revocation, and provenance.
+
+A process that lets an untrusted caller choose both the trust policy and the admission records can still manufacture a self-consistent local story. Production integration must therefore pin the expected trust policy at a boundary the untrusted clinical request cannot choose, such as validated DHT/configuration state or another verifier-owned authority root.
+
+Accordingly, this PR improves composition safety and auditability but is **not yet a production trust root** by itself.
+
+## Required follow-on integration
+
+Before production promotion:
+
+- define the canonical signed/DHT representation of evaluator and knowledge admissions;
+- bind admission creation/revocation to authorized trust administrators at integrity validation;
+- pin the active safety-source trust policy independently of request input;
+- prove admission status/revocation at the same execution lineage used to authorize activation;
+- add conductor-level adversarial tests against a modified coordinator;
+- ensure the development CDS seed corpus cannot be admitted as `CompleteForPolicy` in production profiles;
+- wire the real prescription persistence/activation path so it cannot bypass `MedicationActivationCapability`.
+
+## Adversarial properties covered at the pure layer
+
+The current tests reject:
+
+- unknown evaluator;
+- revoked evaluator;
+- evaluator used for an unapproved check kind;
+- unknown knowledge artifact;
+- revoked knowledge artifact;
+- evaluator admission from another trust policy;
+- trust policy replay across another medication-safety policy;
+- source-trust receipt replay against a different safety-evaluation set;
+- stale source-trust receipts at final workflow activation.


### PR DESCRIPTION
## Stack

Depends on #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

Addresses the core pure-layer portion of #47.

## Why

Coverage-aware medication safety answers whether the required evidence is complete and clear. It does not, by itself, establish that the evaluator and exact drug-knowledge snapshot behind each check are trusted by the deployment.

This PR makes source admission a fourth independent proof lineage.

## What this adds

### `mycelix-medication-safety-trust`

- `SafetySourceTrustPolicyV1`, bound to one exact medication-safety policy digest;
- opaque `VerifiedEvaluatorAdmission` with exact evaluator digest, allowed safety-check kinds, validity/revocation, trust-policy digest, and admission evidence;
- opaque `VerifiedKnowledgeAdmission` with exact knowledge-artifact digest, allowed check kinds, validity/revocation, trust-policy digest, and admission evidence;
- exact-match source admission: evaluator and knowledge must independently match each `VerifiedSafetyCheck`;
- unknown, expired, revoked, wrong-policy, wrong-check-kind sources fail closed;
- opaque `SafetySourceTrustReceipt` binding the exact safety-evaluation set and all evaluator/knowledge admission evidence;
- dedicated `MedicationSafetyTrustPolicy` and `MedicationSafetyTrustReceipt` integrity domains.

### Final medication workflow composition

`MedicationActivationCapability` now requires four independent proof lineages:

1. external requester -> authenticated-principal resolution;
2. professional `Prescribe` authority;
3. coverage-aware medication safety clearance;
4. deployment source-trust receipt for the exact evaluator/knowledge evidence.

Both `MedicationSafetyClearance` and `SafetySourceTrustReceipt` are consumed by the activation call.

The workflow requires:

- exact expected medication-safety policy digest;
- exact expected safety-source trust-policy digest;
- exact equality of the safety evaluation digest set in the clearance and trust receipt;
- non-empty evaluator/knowledge admission evidence;
- source-trust receipt freshness independent from requester, safety-clearance, and professional-authority freshness.

## Adversarial coverage

The stack now tests rejection of:

- unknown evaluator;
- revoked evaluator;
- evaluator used outside admitted check scope;
- unknown knowledge artifact;
- revoked knowledge artifact;
- evaluator admission from another trust policy;
- trust-policy replay across another safety policy;
- source-trust-policy substitution at final activation;
- stale source-trust receipt;
- cross-medication safety-clearance replay;
- requester principal substitution;
- ClinicalReview -> Prescribe authority substitution.

## Important trust-root non-claim

This pure crate does **not** manufacture institutional legitimacy. Its admission types assume a trusted adapter has verified signed/configured/DHT admission evidence. If an untrusted caller can choose both the expected trust policy and the admission records, type-level consistency is not a production trust root.

Production promotion therefore still requires a pinned trust policy and admission/revocation authority at a validated runtime/DHT/configuration boundary, plus conductor-level adversarial tests. The PR remains draft/experimental until those boundaries are qualified.

## Central invariant

> Complete clinical evidence is not sufficient unless the deployment can also prove that the exact evaluator and exact knowledge version behind that evidence were admitted for that exact purpose.