### PR TITLE
security(medication): add DNA-rooted qualified activation attestations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ members = [
     "zomes/records/coordinator",
     "zomes/prescriptions/integrity",
     "zomes/prescriptions/coordinator",
+    "zomes/medication_activation/integrity",
+    "zomes/medication_activation/coordinator",
     "zomes/consent/integrity",
     "zomes/consent/coordinator",
     "zomes/bridge/integrity",
@@ -51,6 +53,7 @@ members = [
     "crates/fhir-medication-semantics",
     "crates/medication-safety",
     "crates/medication-safety-trust",
+    "crates/medication-activation-receipt",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -30,6 +30,7 @@ pub enum DigestDomain {
     MedicationSafetyTrustPolicy,
     MedicationSafetyTrustReceipt,
     MedicationActivationReceipt,
+    MedicationActivationAttestation,
     QuarantineEvent,
     QuarantineDecision,
     AuthorityPolicy,
@@ -54,6 +55,7 @@ impl DigestDomain {
             Self::MedicationSafetyTrustPolicy => b"medication-safety-trust-policy",
             Self::MedicationSafetyTrustReceipt => b"medication-safety-trust-receipt",
             Self::MedicationActivationReceipt => b"medication-activation-receipt",
+            Self::MedicationActivationAttestation => b"medication-activation-attestation",
             Self::QuarantineEvent => b"quarantine-event",
             Self::QuarantineDecision => b"quarantine-decision",
             Self::AuthorityPolicy => b"authority-policy",
@@ -214,6 +216,7 @@ mod tests {
             DigestDomain::MedicationSafetyTrustPolicy,
             DigestDomain::MedicationSafetyTrustReceipt,
             DigestDomain::MedicationActivationReceipt,
+            DigestDomain::MedicationActivationAttestation,
             DigestDomain::AuthorityPolicy,
         ];
         let values: Vec<[u8; 32]> = domains

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -29,6 +29,7 @@ pub enum DigestDomain {
     MedicationSafetyEvaluation,
     MedicationSafetyTrustPolicy,
     MedicationSafetyTrustReceipt,
+    MedicationActivationReceipt,
     QuarantineEvent,
     QuarantineDecision,
     AuthorityPolicy,
@@ -52,6 +53,7 @@ impl DigestDomain {
             Self::MedicationSafetyEvaluation => b"medication-safety-evaluation",
             Self::MedicationSafetyTrustPolicy => b"medication-safety-trust-policy",
             Self::MedicationSafetyTrustReceipt => b"medication-safety-trust-receipt",
+            Self::MedicationActivationReceipt => b"medication-activation-receipt",
             Self::QuarantineEvent => b"quarantine-event",
             Self::QuarantineDecision => b"quarantine-decision",
             Self::AuthorityPolicy => b"authority-policy",
@@ -211,6 +213,7 @@ mod tests {
             DigestDomain::MedicationSafetyEvaluation,
             DigestDomain::MedicationSafetyTrustPolicy,
             DigestDomain::MedicationSafetyTrustReceipt,
+            DigestDomain::MedicationActivationReceipt,
             DigestDomain::AuthorityPolicy,
         ];
         let values: Vec<[u8; 32]> = domains

--- a/crates/medication-activation-receipt/Cargo.toml
+++ b/crates/medication-activation-receipt/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mycelix-medication-activation-receipt"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Serializable audit receipt produced by consuming a qualified Mycelix medication activation capability"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
+mycelix-clinical-authority = { path = "../clinical-authority" }
+mycelix-clinical-workflow = { path = "../clinical-workflow" }

--- a/crates/medication-activation-receipt/src/lib.rs
+++ b/crates/medication-activation-receipt/src/lib.rs
@@ -1,0 +1,293 @@
+#![deny(unsafe_code)]
+//! Serializable audit receipt for a qualified medication activation.
+//!
+//! A `MedicationActivationCapability` is intentionally non-cloneable and
+//! non-serializable. This crate consumes that single-owner capability into an audit
+//! receipt that may be persisted or attested. The receipt is evidence, not authority:
+//! deserializing it does not recreate the capability and does not authorize another
+//! activation.
+
+use mycelix_clinical_authority::JurisdictionCode;
+use mycelix_clinical_integrity::{
+    hash_canonical_bytes, DigestDomain, IntegrityError, StoredDigest, VerifiedDigest,
+};
+use mycelix_clinical_workflow::MedicationActivationCapability;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const RECEIPT_SCHEMA_TAG: &[u8] = b"mycelix-health/medication-activation-audit-receipt-v1";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MedicationActivationAuditReceiptV1 {
+    pub schema_version: u16,
+    pub order_id: String,
+    pub medication_artifact_digest: StoredDigest,
+    pub principal: [u8; 32],
+    pub requester_resolution_evidence: [StoredDigest; 3],
+    pub requester_resolved_at_micros: i64,
+    pub safety_context_digest: StoredDigest,
+    pub safety_policy_digest: StoredDigest,
+    pub safety_check_evaluation_digests: Vec<StoredDigest>,
+    pub safety_cleared_at_micros: i64,
+    pub safety_trust_policy_digest: StoredDigest,
+    pub safety_trust_receipt_digest: StoredDigest,
+    pub safety_evaluator_admission_evidence: Vec<StoredDigest>,
+    pub safety_knowledge_admission_evidence: Vec<StoredDigest>,
+    pub safety_trust_evaluated_at_micros: i64,
+    pub jurisdiction: JurisdictionCode,
+    pub authority_policy_digest: StoredDigest,
+    pub workflow_policy_digest: StoredDigest,
+    pub authorized_at_micros: i64,
+    pub supporting_authority_evidence: Vec<[u8; 32]>,
+}
+
+impl MedicationActivationAuditReceiptV1 {
+    /// Validate the serialized receipt as a well-formed audit artifact. This does
+    /// not recreate workflow authority; it only establishes internal shape/domain
+    /// consistency before hashing or persistence.
+    pub fn validate(&self) -> Result<(), ActivationReceiptError> {
+        if self.schema_version != 1 {
+            return Err(ActivationReceiptError::UnsupportedVersion(self.schema_version));
+        }
+        if self.order_id.trim().is_empty() {
+            return Err(ActivationReceiptError::MissingOrderId);
+        }
+        if self.principal == [0u8; 32] {
+            return Err(ActivationReceiptError::ZeroPrincipal);
+        }
+        if self.jurisdiction.system.trim().is_empty() || self.jurisdiction.code.trim().is_empty() {
+            return Err(ActivationReceiptError::InvalidJurisdiction);
+        }
+
+        require_domain(
+            self.medication_artifact_digest,
+            DigestDomain::MedicationRequestArtifact,
+        )?;
+        for digest in self.requester_resolution_evidence {
+            require_domain(digest, DigestDomain::ClinicalArtifact)?;
+        }
+        require_domain(
+            self.safety_context_digest,
+            DigestDomain::MedicationSafetyContext,
+        )?;
+        require_domain(
+            self.safety_policy_digest,
+            DigestDomain::MedicationSafetyPolicy,
+        )?;
+        require_nonempty_domains(
+            &self.safety_check_evaluation_digests,
+            DigestDomain::MedicationSafetyEvaluation,
+            ActivationReceiptError::MissingSafetyEvaluations,
+        )?;
+        require_domain(
+            self.safety_trust_policy_digest,
+            DigestDomain::MedicationSafetyTrustPolicy,
+        )?;
+        require_domain(
+            self.safety_trust_receipt_digest,
+            DigestDomain::MedicationSafetyTrustReceipt,
+        )?;
+        require_nonempty_domains(
+            &self.safety_evaluator_admission_evidence,
+            DigestDomain::ClinicalArtifact,
+            ActivationReceiptError::MissingEvaluatorAdmissionEvidence,
+        )?;
+        require_nonempty_domains(
+            &self.safety_knowledge_admission_evidence,
+            DigestDomain::ClinicalArtifact,
+            ActivationReceiptError::MissingKnowledgeAdmissionEvidence,
+        )?;
+        require_domain(self.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+        require_domain(self.workflow_policy_digest, DigestDomain::WorkflowPolicy)?;
+
+        if self.supporting_authority_evidence.is_empty()
+            || self
+                .supporting_authority_evidence
+                .iter()
+                .any(|digest| *digest == [0u8; 32])
+        {
+            return Err(ActivationReceiptError::MissingAuthorityEvidence);
+        }
+        Ok(())
+    }
+
+    pub fn verified_digest(&self) -> Result<VerifiedDigest, ActivationReceiptError> {
+        self.validate()?;
+        let encoded = serde_json::to_vec(self)
+            .map_err(|error| ActivationReceiptError::Serialization(error.to_string()))?;
+        let mut framed = Vec::with_capacity(RECEIPT_SCHEMA_TAG.len() + 1 + encoded.len());
+        framed.extend_from_slice(RECEIPT_SCHEMA_TAG);
+        framed.push(0);
+        framed.extend_from_slice(&encoded);
+        Ok(hash_canonical_bytes(
+            DigestDomain::MedicationActivationReceipt,
+            &framed,
+        )?)
+    }
+}
+
+/// Consume the single-owner workflow capability into a replay-safe audit artifact.
+/// The resulting receipt may be copied for audit, but it cannot be converted back
+/// into `MedicationActivationCapability` through this API.
+pub fn consume_activation_capability(
+    capability: MedicationActivationCapability,
+) -> Result<MedicationActivationAuditReceiptV1, ActivationReceiptError> {
+    let receipt = MedicationActivationAuditReceiptV1 {
+        schema_version: 1,
+        order_id: capability.order_id().to_string(),
+        medication_artifact_digest: capability.medication_artifact_digest(),
+        principal: capability.principal().0,
+        requester_resolution_evidence: *capability.requester_resolution_evidence(),
+        requester_resolved_at_micros: capability.requester_resolved_at_micros(),
+        safety_context_digest: capability.safety_context_digest(),
+        safety_policy_digest: capability.safety_policy_digest(),
+        safety_check_evaluation_digests: capability.safety_check_evaluation_digests().to_vec(),
+        safety_cleared_at_micros: capability.safety_cleared_at_micros(),
+        safety_trust_policy_digest: capability.safety_trust_policy_digest(),
+        safety_trust_receipt_digest: capability.safety_trust_receipt_digest(),
+        safety_evaluator_admission_evidence: capability
+            .safety_evaluator_admission_evidence()
+            .to_vec(),
+        safety_knowledge_admission_evidence: capability
+            .safety_knowledge_admission_evidence()
+            .to_vec(),
+        safety_trust_evaluated_at_micros: capability.safety_trust_evaluated_at_micros(),
+        jurisdiction: capability.jurisdiction().clone(),
+        authority_policy_digest: capability.authority_policy_digest(),
+        workflow_policy_digest: capability.workflow_policy_digest(),
+        authorized_at_micros: capability.authorized_at_micros(),
+        supporting_authority_evidence: capability.supporting_authority_evidence().to_vec(),
+    };
+    receipt.validate()?;
+    Ok(receipt)
+}
+
+fn require_domain(
+    digest: StoredDigest,
+    expected: DigestDomain,
+) -> Result<(), ActivationReceiptError> {
+    digest.validate_shape()?;
+    if digest.domain != expected {
+        return Err(ActivationReceiptError::DigestDomainMismatch {
+            expected,
+            actual: digest.domain,
+        });
+    }
+    Ok(())
+}
+
+fn require_nonempty_domains(
+    digests: &[StoredDigest],
+    expected: DigestDomain,
+    empty_error: ActivationReceiptError,
+) -> Result<(), ActivationReceiptError> {
+    if digests.is_empty() {
+        return Err(empty_error);
+    }
+    for digest in digests {
+        require_domain(*digest, expected)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+pub enum ActivationReceiptError {
+    #[error("unsupported medication activation receipt version {0}")]
+    UnsupportedVersion(u16),
+    #[error("medication activation receipt requires an order id")]
+    MissingOrderId,
+    #[error("medication activation receipt principal cannot be zero")]
+    ZeroPrincipal,
+    #[error("medication activation receipt jurisdiction is invalid")]
+    InvalidJurisdiction,
+    #[error("medication activation receipt has no safety evaluations")]
+    MissingSafetyEvaluations,
+    #[error("medication activation receipt has no evaluator admission evidence")]
+    MissingEvaluatorAdmissionEvidence,
+    #[error("medication activation receipt has no knowledge admission evidence")]
+    MissingKnowledgeAdmissionEvidence,
+    #[error("medication activation receipt has no professional authority evidence")]
+    MissingAuthorityEvidence,
+    #[error("digest domain mismatch: expected {expected:?}, got {actual:?}")]
+    DigestDomainMismatch {
+        expected: DigestDomain,
+        actual: DigestDomain,
+    },
+    #[error("failed to serialize medication activation receipt: {0}")]
+    Serialization(String),
+    #[error(transparent)]
+    Integrity(#[from] IntegrityError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain};
+
+    fn stored(domain: DigestDomain, seed: u8) -> StoredDigest {
+        hash_canonical_bytes(domain, &[seed]).unwrap().stored()
+    }
+
+    fn receipt() -> MedicationActivationAuditReceiptV1 {
+        MedicationActivationAuditReceiptV1 {
+            schema_version: 1,
+            order_id: "order-a".into(),
+            medication_artifact_digest: stored(DigestDomain::MedicationRequestArtifact, 1),
+            principal: [2; 32],
+            requester_resolution_evidence: [
+                stored(DigestDomain::ClinicalArtifact, 3),
+                stored(DigestDomain::ClinicalArtifact, 4),
+                stored(DigestDomain::ClinicalArtifact, 5),
+            ],
+            requester_resolved_at_micros: 100,
+            safety_context_digest: stored(DigestDomain::MedicationSafetyContext, 6),
+            safety_policy_digest: stored(DigestDomain::MedicationSafetyPolicy, 7),
+            safety_check_evaluation_digests: vec![stored(
+                DigestDomain::MedicationSafetyEvaluation,
+                8,
+            )],
+            safety_cleared_at_micros: 120,
+            safety_trust_policy_digest: stored(DigestDomain::MedicationSafetyTrustPolicy, 9),
+            safety_trust_receipt_digest: stored(DigestDomain::MedicationSafetyTrustReceipt, 10),
+            safety_evaluator_admission_evidence: vec![stored(DigestDomain::ClinicalArtifact, 11)],
+            safety_knowledge_admission_evidence: vec![stored(DigestDomain::ClinicalArtifact, 12)],
+            safety_trust_evaluated_at_micros: 125,
+            jurisdiction: JurisdictionCode {
+                system: "urn:iso:std:iso:3166-2".into(),
+                code: "US-TX".into(),
+            },
+            authority_policy_digest: stored(DigestDomain::AuthorityPolicy, 13),
+            workflow_policy_digest: stored(DigestDomain::WorkflowPolicy, 14),
+            authorized_at_micros: 130,
+            supporting_authority_evidence: vec![[15; 32]],
+        }
+    }
+
+    #[test]
+    fn well_formed_receipt_has_activation_specific_identity() {
+        let receipt = receipt();
+        let digest = receipt.verified_digest().unwrap();
+        assert_eq!(digest.domain(), DigestDomain::MedicationActivationReceipt);
+    }
+
+    #[test]
+    fn wrong_safety_policy_domain_fails_closed() {
+        let mut receipt = receipt();
+        receipt.safety_policy_digest = stored(DigestDomain::AuthorityPolicy, 7);
+        assert!(matches!(
+            receipt.validate(),
+            Err(ActivationReceiptError::DigestDomainMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn missing_source_admission_evidence_is_invalid() {
+        let mut receipt = receipt();
+        receipt.safety_knowledge_admission_evidence.clear();
+        assert!(matches!(
+            receipt.validate(),
+            Err(ActivationReceiptError::MissingKnowledgeAdmissionEvidence)
+        ));
+    }
+}

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -3,7 +3,14 @@ manifest_version: "0"
 name: health
 integrity:
   network_seed: ~
-  properties: ~
+  properties:
+    medication_activation:
+      schema_version: 1
+      # Fail closed by default. Production/test deployments must repack the DNA
+      # with explicit trusted AgentPubKeys before verifier grants can validate.
+      root_authorities: []
+      # Verifier grants are intentionally short-lived even after roots are pinned.
+      max_verifier_grant_duration_micros: 86400000000
   zomes:
     # Tier 1: MVP Core
     - name: patient_integrity
@@ -14,6 +21,8 @@ integrity:
       path: ../target/wasm32-unknown-unknown/release/records_integrity.wasm
     - name: prescriptions_integrity
       path: ../target/wasm32-unknown-unknown/release/prescriptions_integrity.wasm
+    - name: medication_activation_integrity
+      path: ../target/wasm32-unknown-unknown/release/medication_activation_integrity.wasm
     - name: consent_integrity
       path: ../target/wasm32-unknown-unknown/release/consent_integrity.wasm
     - name: bridge_integrity
@@ -40,6 +49,10 @@ coordinator:
         - name: prescriptions_integrity
         - name: patient_integrity
         - name: provider_integrity
+    - name: medication_activation
+      path: ../target/wasm32-unknown-unknown/release/medication_activation.wasm
+      dependencies:
+        - name: medication_activation_integrity
     - name: consent
       path: ../target/wasm32-unknown-unknown/release/consent.wasm
       dependencies:

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -7,10 +7,12 @@ integrity:
     medication_activation:
       schema_version: 1
       # Fail closed by default. Production/test deployments must repack the DNA
-      # with explicit trusted AgentPubKeys before verifier grants can validate.
+      # with explicit trusted AgentPubKeys before exact verifier authorizations validate.
       root_authorities: []
-      # Verifier grants are intentionally short-lived even after roots are pinned.
-      max_verifier_grant_duration_micros: 86400000000
+      # v1 exact-receipt verifier authorizations may live for at most 15 minutes.
+      # The integrity zome also hard-caps this value, so accidental packaging with a
+      # longer window fails validation rather than silently weakening the contract.
+      max_verifier_authorization_duration_micros: 900000000
   zomes:
     # Tier 1: MVP Core
     - name: patient_integrity

--- a/docs/security/MEDICATION_ACTIVATION_DHT_TRUST_V1.md
+++ b/docs/security/MEDICATION_ACTIVATION_DHT_TRUST_V1.md
@@ -1,0 +1,165 @@
+# Medication Activation DHT Trust v1
+
+Status: **experimental / qualification required**
+
+## Goal
+
+Bridge the in-process high-assurance medication workflow into Holochain without allowing an ordinary or modified coordinator to manufacture a `qualified` active-medication claim.
+
+The design intentionally separates three things:
+
+1. **clinical evidence computation** — performed by the pure typed/evidence/authority/safety stack;
+2. **audit receipt** — a serializable record of what that stack concluded, which is evidence but not authority merely because it deserializes;
+3. **DHT activation attestation** — a privacy-minimized public claim that is accepted only when an explicitly DNA-rooted authority authorized one exact receipt and one exact attestation payload.
+
+## Why native CapGrant is not the trust root
+
+Holochain capability grants govern who may call a zome function. They do not prevent a modified coordinator owned by the same agent from writing another entry path to its own source chain.
+
+The activation authorization must therefore be enforced by the **integrity zome**, using dependencies that remote validators can verify.
+
+## DNA-pinned root
+
+The health DNA carries:
+
+```yaml
+properties:
+  medication_activation:
+    schema_version: 1
+    root_authorities: []
+    max_verifier_authorization_duration_micros: 900000000
+```
+
+`root_authorities` is intentionally empty in the repository manifest. The default DNA therefore cannot issue qualified medication activation authorizations.
+
+A real test/production deployment must deliberately repack the DNA with the approved root AgentPubKeys. That changes the DNA hash and makes the trust decision explicit at deployment time.
+
+The integrity zome reads this configuration via `dna_info()?.modifiers.properties`.
+
+## Exact-target authorization
+
+A `MedicationActivationVerifierAuthorization` is created only by a DNA-pinned root and binds:
+
+- one verifier/grantee AgentPubKey;
+- one exact `MedicationActivationReceipt` digest;
+- one exact `MedicationActivationAttestation` digest;
+- one exact authority-policy digest;
+- one exact medication-safety-policy digest;
+- one exact medication-safety-source-trust-policy digest;
+- one exact workflow-policy digest;
+- a bounded validity window.
+
+It is not a reusable role grant.
+
+The code has an absolute v1 maximum authorization lifetime of **15 minutes**, even if DNA properties are accidentally configured with a larger value.
+
+## Why authorization deletion is not revocation
+
+Holochain `must_get_*` retrieves addressable content while intentionally ignoring mutable metadata such as later updates/deletes. Therefore a validator must not assume that deleting an authorization causes `must_get_valid_record(authorization_hash)` to stop resolving the original valid record.
+
+v1 consequently does **not** model verifier-authorization revocation as deletion. Authorization entries are append-only, exact-target, and short-lived.
+
+If a root no longer trusts a verifier, it stops issuing future exact authorizations. An already-issued authorization has only its short remaining validity window and can authorize only its pre-approved receipt/attestation.
+
+A future design may add stronger online/epoch/status machinery, but must prove the semantics under conductor tests before claiming instant revocation.
+
+## Action time, not request time
+
+`QualifiedMedicationActivation` carries no caller-selected `activated_at` field. The integrity validator checks the Holochain **action timestamp** against the root authorization window.
+
+This avoids allowing request data to choose the time used for authority validity.
+
+## Privacy-minimized attestation
+
+The public `MedicationActivationAttestationV1` carries only:
+
+- an opaque activation id;
+- exact medication-artifact digest;
+- exact activation-receipt digest;
+- exact safety-context digest;
+- exact source-trust receipt digest;
+- exact authority/safety/source-trust/workflow policy digests.
+
+It does not require patient name, medication name, dosage text, diagnosis, allergy data, lab values, or raw safety evidence on the distributed attestation surface.
+
+Sensitive receipt/evidence material may remain in an encrypted/local institutional store subject to clinical retention and audit policy.
+
+## Activation publication
+
+A `QualifiedMedicationActivation` contains:
+
+- the exact `MedicationActivationAttestationV1`;
+- the root authorization action hash.
+
+Integrity validation:
+
+1. retrieves the authorization with `must_get_valid_record`;
+2. requires activation author == authorization grantee;
+3. uses the activation action timestamp and requires it inside the authorization window;
+4. recomputes the exact attestation digest;
+5. requires exact receipt digest equality;
+6. requires exact authority/safety/source-trust/workflow policy equality.
+
+Changing any safety-significant field changes the attestation digest and invalidates the authorization.
+
+## Duplicate publication
+
+Holochain can contain more than one create action for identical content. v1 therefore does not use action-count uniqueness as a safety property.
+
+High-assurance read models should treat the activation receipt/attestation digest as the semantic identity and de-duplicate equivalent publications. A duplicate does not create a second clinical authorization.
+
+## Activation revocation
+
+`MedicationActivationRevocation` is an append-only corrective event referencing:
+
+- an exact activation action;
+- the activation's exact receipt digest;
+- a typed revocation reason;
+- an optional commitment to sensitive rationale.
+
+It may be authored by the activation verifier or a DNA-pinned root. It cannot modify or erase the original evidence history.
+
+Future active-medication read models should derive state from qualified activation + revocation lineage rather than mutating `Prescription.status`.
+
+## Audit receipt boundary
+
+`MedicationActivationAuditReceiptV1` is serializable for audit/persistence, but that does **not** make arbitrary deserialized bytes authoritative. Its validation establishes shape/domain consistency only.
+
+A root/verifier service must independently re-establish the receipt's referenced evidence/policy lineage before issuing a DHT verifier authorization. The root authorization is the explicit bridge from reviewed receipt to distributed qualified-attestation authority.
+
+## Emergency/manual path
+
+Emergency/manual medication action is deliberately **not** encoded as `QualifiedMedicationActivation` in v1.
+
+A future emergency path must be distinguishable as something equivalent to:
+
+`Indeterminate + HumanOverride + reason + authority + provenance`
+
+It must not become `Cleared` merely because the system allowed a human to proceed.
+
+## Qualification gates before production
+
+At minimum:
+
+- Rust format/clippy/build/test on the exact combined head;
+- WASM builds for both new zomes;
+- DNA packaging with empty roots proves fail-closed behavior;
+- test DNA with a known root proves authorized issuance succeeds;
+- non-root authorization issuance fails;
+- wrong verifier cannot publish activation;
+- exact receipt substitution fails;
+- attestation field substitution fails;
+- policy substitution fails;
+- activation outside authorization window fails;
+- update/delete attempts fail;
+- forged/mismatched revocations fail;
+- modified-coordinator conductor test proves direct entry commit cannot bypass integrity validation;
+- read-model tests prove duplicate attestation is idempotent and revocation removes semantic activation from the current-state view.
+
+## Non-claims
+
+- The DHT does not itself prove a medication is medically appropriate; it proves a DNA-rooted verifier authorized this exact evidence receipt/attestation.
+- The serialized receipt does not recreate the in-process capability.
+- Root-key compromise remains a high-impact trust event; production roots need strong operational security and eventually threshold/rotation design.
+- v1 does not claim instantaneous verifier revocation; exact-target short-lived authorization bounds that limitation explicitly.
+- Existing legacy `Prescription(status = Active)` records are historical data, not retroactively qualified activations.

--- a/zomes/medication_activation/coordinator/Cargo.toml
+++ b/zomes/medication_activation/coordinator/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "medication_activation"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Thin coordinator for DNA-rooted qualified medication activation attestations"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+medication_activation_integrity = { path = "../integrity" }
+
+[features]
+default = []

--- a/zomes/medication_activation/coordinator/src/lib.rs
+++ b/zomes/medication_activation/coordinator/src/lib.rs
@@ -1,0 +1,71 @@
+#![deny(unsafe_code)]
+//! Thin coordinator for qualified medication activation attestations.
+//!
+//! Deliberately contains no clinical authorization logic. The coordinator only
+//! commits/query entries; the integrity zome independently enforces DNA-rooted
+//! verifier authority, exact policy binding, append-only evidence, and revocation
+//! lineage. A modified coordinator therefore cannot bypass those rules.
+
+use hdk::prelude::*;
+use medication_activation_integrity::*;
+
+#[hdk_extern]
+pub fn issue_verifier_grant(
+    grant: MedicationActivationVerifierGrant,
+) -> ExternResult<Record> {
+    let hash = create_entry(&EntryTypes::MedicationActivationVerifierGrant(grant))?;
+    get_required_record(hash)
+}
+
+#[hdk_extern]
+pub fn record_qualified_activation(
+    activation: QualifiedMedicationActivation,
+) -> ExternResult<Record> {
+    let hash = create_entry(&EntryTypes::QualifiedMedicationActivation(activation))?;
+    get_required_record(hash)
+}
+
+#[hdk_extern]
+pub fn revoke_qualified_activation(
+    revocation: MedicationActivationRevocation,
+) -> ExternResult<Record> {
+    let activation_hash = revocation.activation_hash.clone();
+    let hash = create_entry(&EntryTypes::MedicationActivationRevocation(revocation))?;
+    create_link(
+        activation_hash,
+        hash.clone(),
+        LinkTypes::ActivationToRevocations,
+        (),
+    )?;
+    get_required_record(hash)
+}
+
+#[hdk_extern]
+pub fn get_qualified_activation(hash: ActionHash) -> ExternResult<Option<Record>> {
+    get(hash, GetOptions::default())
+}
+
+#[hdk_extern]
+pub fn get_activation_revocations(
+    activation_hash: ActionHash,
+) -> ExternResult<Vec<Record>> {
+    let links = get_links(
+        LinkQuery::try_new(activation_hash, LinkTypes::ActivationToRevocations)?,
+        GetStrategy::default(),
+    )?;
+    let mut records = Vec::with_capacity(links.len());
+    for link in links {
+        if let Some(hash) = link.target.into_action_hash() {
+            if let Some(record) = get(hash, GetOptions::default())? {
+                records.push(record);
+            }
+        }
+    }
+    Ok(records)
+}
+
+fn get_required_record(hash: ActionHash) -> ExternResult<Record> {
+    get(hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed medication activation record could not be read back".to_string()
+    )))
+}

--- a/zomes/medication_activation/coordinator/src/lib.rs
+++ b/zomes/medication_activation/coordinator/src/lib.rs
@@ -2,18 +2,20 @@
 //! Thin coordinator for qualified medication activation attestations.
 //!
 //! Deliberately contains no clinical authorization logic. The coordinator only
-//! commits/query entries; the integrity zome independently enforces DNA-rooted
-//! verifier authority, exact policy binding, append-only evidence, and revocation
-//! lineage. A modified coordinator therefore cannot bypass those rules.
+//! commits/query entries; the integrity zome independently enforces DNA-rooted,
+//! exact-target verifier authorization and append-only revocation lineage. A
+//! modified coordinator therefore cannot bypass those rules.
 
 use hdk::prelude::*;
 use medication_activation_integrity::*;
 
 #[hdk_extern]
-pub fn issue_verifier_grant(
-    grant: MedicationActivationVerifierGrant,
+pub fn issue_verifier_authorization(
+    authorization: MedicationActivationVerifierAuthorization,
 ) -> ExternResult<Record> {
-    let hash = create_entry(&EntryTypes::MedicationActivationVerifierGrant(grant))?;
+    let hash = create_entry(&EntryTypes::MedicationActivationVerifierAuthorization(
+        authorization,
+    ))?;
     get_required_record(hash)
 }
 

--- a/zomes/medication_activation/integrity/Cargo.toml
+++ b/zomes/medication_activation/integrity/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "medication_activation_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "DNA-rooted medication activation attestation integrity zome"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+mycelix-clinical-integrity = { path = "../../../crates/clinical-integrity" }
+
+[features]
+default = []

--- a/zomes/medication_activation/integrity/src/lib.rs
+++ b/zomes/medication_activation/integrity/src/lib.rs
@@ -30,6 +30,86 @@ pub struct MedicationActivationRootConfig {
     pub max_verifier_authorization_duration_micros: i64,
 }
 
+/// Privacy-minimized activation payload independently digestible before a root
+/// authorization exists. It carries no patient name, medication name, dosage text,
+/// or raw clinical evidence.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MedicationActivationAttestationV1 {
+    pub schema_version: u16,
+    pub activation_id: String,
+    pub medication_artifact_digest: StoredDigest,
+    pub activation_receipt_digest: StoredDigest,
+    pub safety_context_digest: StoredDigest,
+    pub safety_trust_receipt_digest: StoredDigest,
+    pub authority_policy_digest: StoredDigest,
+    pub safety_policy_digest: StoredDigest,
+    pub safety_trust_policy_digest: StoredDigest,
+    pub workflow_policy_digest: StoredDigest,
+}
+
+impl MedicationActivationAttestationV1 {
+    pub fn validate(&self) -> ExternResult<ValidateCallbackResult> {
+        if self.schema_version != 1 {
+            return invalid("Unsupported medication activation attestation version");
+        }
+        if self.activation_id.trim().is_empty() {
+            return invalid("Qualified medication activation ID is required");
+        }
+        require_digest_domain(
+            self.medication_artifact_digest,
+            DigestDomain::MedicationRequestArtifact,
+        )?;
+        require_digest_domain(
+            self.activation_receipt_digest,
+            DigestDomain::MedicationActivationReceipt,
+        )?;
+        require_digest_domain(
+            self.safety_context_digest,
+            DigestDomain::MedicationSafetyContext,
+        )?;
+        require_digest_domain(
+            self.safety_trust_receipt_digest,
+            DigestDomain::MedicationSafetyTrustReceipt,
+        )?;
+        require_digest_domain(self.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+        require_digest_domain(
+            self.safety_policy_digest,
+            DigestDomain::MedicationSafetyPolicy,
+        )?;
+        require_digest_domain(
+            self.safety_trust_policy_digest,
+            DigestDomain::MedicationSafetyTrustPolicy,
+        )?;
+        require_digest_domain(self.workflow_policy_digest, DigestDomain::WorkflowPolicy)?;
+        Ok(ValidateCallbackResult::Valid)
+    }
+
+    pub fn digest(&self) -> ExternResult<StoredDigest> {
+        let shape = self.validate()?;
+        if !matches!(shape, ValidateCallbackResult::Valid) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Cannot hash invalid medication activation attestation".to_string()
+            )));
+        }
+        let encoded = serde_json::to_vec(self).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Failed to serialize medication activation attestation: {error}"
+            )))
+        })?;
+        let mut framed = Vec::with_capacity(ATTESTATION_SCHEMA_TAG.len() + 1 + encoded.len());
+        framed.extend_from_slice(ATTESTATION_SCHEMA_TAG);
+        framed.push(0);
+        framed.extend_from_slice(&encoded);
+        Ok(hash_canonical_bytes(
+            DigestDomain::MedicationActivationAttestation,
+            &framed,
+        )
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .stored())
+    }
+}
+
 /// Root-issued authorization for one exact activation receipt and one exact public
 /// attestation projection. This is deliberately not a reusable role grant.
 #[hdk_entry_helper]
@@ -47,21 +127,11 @@ pub struct MedicationActivationVerifierAuthorization {
     pub valid_until: Timestamp,
 }
 
-/// Privacy-minimized public attestation. It contains cryptographic identities and
-/// policy/evidence lineage, not patient names, medication names, dosage text, or raw
-/// clinical evidence. The exact activation receipt may remain encrypted/local.
+/// Root-authorized publication of the exact attestation proposal.
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq)]
 pub struct QualifiedMedicationActivation {
-    pub activation_id: String,
-    pub medication_artifact_digest: StoredDigest,
-    pub activation_receipt_digest: StoredDigest,
-    pub safety_context_digest: StoredDigest,
-    pub safety_trust_receipt_digest: StoredDigest,
-    pub authority_policy_digest: StoredDigest,
-    pub safety_policy_digest: StoredDigest,
-    pub safety_trust_policy_digest: StoredDigest,
-    pub workflow_policy_digest: StoredDigest,
+    pub attestation: MedicationActivationAttestationV1,
     pub verifier_authorization_hash: ActionHash,
 }
 
@@ -153,7 +223,7 @@ fn validate_create_entry(
             validate_authorization_window(action.timestamp(), &authorization, &config)
         }
         EntryTypes::QualifiedMedicationActivation(activation) => {
-            let shape = validate_activation_shape(&activation)?;
+            let shape = activation.attestation.validate()?;
             if !matches!(shape, ValidateCallbackResult::Valid) {
                 return Ok(shape);
             }
@@ -225,93 +295,6 @@ fn validate_authorization_window(
     Ok(ValidateCallbackResult::Valid)
 }
 
-fn validate_activation_shape(
-    activation: &QualifiedMedicationActivation,
-) -> ExternResult<ValidateCallbackResult> {
-    if activation.activation_id.trim().is_empty() {
-        return invalid("Qualified medication activation ID is required");
-    }
-    require_digest_domain(
-        activation.medication_artifact_digest,
-        DigestDomain::MedicationRequestArtifact,
-    )?;
-    require_digest_domain(
-        activation.activation_receipt_digest,
-        DigestDomain::MedicationActivationReceipt,
-    )?;
-    require_digest_domain(
-        activation.safety_context_digest,
-        DigestDomain::MedicationSafetyContext,
-    )?;
-    require_digest_domain(
-        activation.safety_trust_receipt_digest,
-        DigestDomain::MedicationSafetyTrustReceipt,
-    )?;
-    require_digest_domain(
-        activation.authority_policy_digest,
-        DigestDomain::AuthorityPolicy,
-    )?;
-    require_digest_domain(
-        activation.safety_policy_digest,
-        DigestDomain::MedicationSafetyPolicy,
-    )?;
-    require_digest_domain(
-        activation.safety_trust_policy_digest,
-        DigestDomain::MedicationSafetyTrustPolicy,
-    )?;
-    require_digest_domain(
-        activation.workflow_policy_digest,
-        DigestDomain::WorkflowPolicy,
-    )?;
-    Ok(ValidateCallbackResult::Valid)
-}
-
-/// Compute the exact privacy-minimized attestation identity approved by a root.
-/// `verifier_authorization_hash` is excluded to avoid a circular dependency.
-pub fn activation_attestation_digest(
-    activation: &QualifiedMedicationActivation,
-) -> ExternResult<StoredDigest> {
-    let material = ActivationAttestationMaterial {
-        activation_id: &activation.activation_id,
-        medication_artifact_digest: activation.medication_artifact_digest,
-        activation_receipt_digest: activation.activation_receipt_digest,
-        safety_context_digest: activation.safety_context_digest,
-        safety_trust_receipt_digest: activation.safety_trust_receipt_digest,
-        authority_policy_digest: activation.authority_policy_digest,
-        safety_policy_digest: activation.safety_policy_digest,
-        safety_trust_policy_digest: activation.safety_trust_policy_digest,
-        workflow_policy_digest: activation.workflow_policy_digest,
-    };
-    let encoded = serde_json::to_vec(&material).map_err(|error| {
-        wasm_error!(WasmErrorInner::Guest(format!(
-            "Failed to serialize medication activation attestation: {error}"
-        )))
-    })?;
-    let mut framed = Vec::with_capacity(ATTESTATION_SCHEMA_TAG.len() + 1 + encoded.len());
-    framed.extend_from_slice(ATTESTATION_SCHEMA_TAG);
-    framed.push(0);
-    framed.extend_from_slice(&encoded);
-    Ok(hash_canonical_bytes(
-        DigestDomain::MedicationActivationAttestation,
-        &framed,
-    )
-    .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
-    .stored())
-}
-
-#[derive(Serialize)]
-struct ActivationAttestationMaterial<'a> {
-    activation_id: &'a str,
-    medication_artifact_digest: StoredDigest,
-    activation_receipt_digest: StoredDigest,
-    safety_context_digest: StoredDigest,
-    safety_trust_receipt_digest: StoredDigest,
-    authority_policy_digest: StoredDigest,
-    safety_policy_digest: StoredDigest,
-    safety_trust_policy_digest: StoredDigest,
-    workflow_policy_digest: StoredDigest,
-}
-
 fn validate_revocation_shape(
     revocation: &MedicationActivationRevocation,
 ) -> ExternResult<ValidateCallbackResult> {
@@ -353,17 +336,18 @@ fn require_exact_verifier_authorization(
     {
         return invalid("Qualified activation action timestamp falls outside authorization validity");
     }
-    if activation.activation_receipt_digest != authorization.activation_receipt_digest {
+    if activation.attestation.activation_receipt_digest != authorization.activation_receipt_digest {
         return invalid("Qualified activation receipt does not match root authorization");
     }
-    let actual_attestation_digest = activation_attestation_digest(activation)?;
+    let actual_attestation_digest = activation.attestation.digest()?;
     if actual_attestation_digest != authorization.activation_attestation_digest {
         return invalid("Qualified activation payload does not match root-authorized attestation");
     }
-    if activation.authority_policy_digest != authorization.authority_policy_digest
-        || activation.safety_policy_digest != authorization.safety_policy_digest
-        || activation.safety_trust_policy_digest != authorization.safety_trust_policy_digest
-        || activation.workflow_policy_digest != authorization.workflow_policy_digest
+    if activation.attestation.authority_policy_digest != authorization.authority_policy_digest
+        || activation.attestation.safety_policy_digest != authorization.safety_policy_digest
+        || activation.attestation.safety_trust_policy_digest
+            != authorization.safety_trust_policy_digest
+        || activation.attestation.workflow_policy_digest != authorization.workflow_policy_digest
     {
         return invalid("Qualified activation policy set does not match root authorization");
     }
@@ -377,7 +361,7 @@ fn require_revocation_authority(
     let activation_record = must_get_valid_record(revocation.activation_hash.clone())?;
     let activation: QualifiedMedicationActivation =
         decode_entry(&activation_record, "qualified medication activation")?;
-    if activation.activation_receipt_digest != revocation.activation_receipt_digest {
+    if activation.attestation.activation_receipt_digest != revocation.activation_receipt_digest {
         return invalid("Activation revocation receipt digest does not match target activation");
     }
 
@@ -406,7 +390,8 @@ fn validate_create_link(
             let revocation: MedicationActivationRevocation =
                 decode_entry(&revocation_record, "medication activation revocation")?;
             if revocation.activation_hash != activation_hash
-                || revocation.activation_receipt_digest != activation.activation_receipt_digest
+                || revocation.activation_receipt_digest
+                    != activation.attestation.activation_receipt_digest
             {
                 return invalid(
                     "Activation-revocation link target references another activation lineage",
@@ -516,26 +501,9 @@ mod tests {
         hash_canonical_bytes(domain, &[seed]).unwrap().stored()
     }
 
-    fn authorization() -> MedicationActivationVerifierAuthorization {
-        MedicationActivationVerifierAuthorization {
-            authorization_id: "auth-a".into(),
-            grantee: AgentPubKey::from_raw_36(vec![1; 36]),
-            activation_receipt_digest: digest(DigestDomain::MedicationActivationReceipt, 1),
-            activation_attestation_digest: digest(
-                DigestDomain::MedicationActivationAttestation,
-                2,
-            ),
-            authority_policy_digest: digest(DigestDomain::AuthorityPolicy, 3),
-            safety_policy_digest: digest(DigestDomain::MedicationSafetyPolicy, 4),
-            safety_trust_policy_digest: digest(DigestDomain::MedicationSafetyTrustPolicy, 5),
-            workflow_policy_digest: digest(DigestDomain::WorkflowPolicy, 6),
-            valid_from: Timestamp::from_micros(10),
-            valid_until: Timestamp::from_micros(100),
-        }
-    }
-
-    fn activation() -> QualifiedMedicationActivation {
-        QualifiedMedicationActivation {
+    fn attestation() -> MedicationActivationAttestationV1 {
+        MedicationActivationAttestationV1 {
+            schema_version: 1,
             activation_id: "activation-a".into(),
             medication_artifact_digest: digest(DigestDomain::MedicationRequestArtifact, 7),
             activation_receipt_digest: digest(DigestDomain::MedicationActivationReceipt, 8),
@@ -545,7 +513,22 @@ mod tests {
             safety_policy_digest: digest(DigestDomain::MedicationSafetyPolicy, 12),
             safety_trust_policy_digest: digest(DigestDomain::MedicationSafetyTrustPolicy, 13),
             workflow_policy_digest: digest(DigestDomain::WorkflowPolicy, 14),
-            verifier_authorization_hash: ActionHash::from_raw_36(vec![15; 36]),
+        }
+    }
+
+    fn authorization() -> MedicationActivationVerifierAuthorization {
+        let attestation = attestation();
+        MedicationActivationVerifierAuthorization {
+            authorization_id: "auth-a".into(),
+            grantee: AgentPubKey::from_raw_36(vec![1; 36]),
+            activation_receipt_digest: attestation.activation_receipt_digest,
+            activation_attestation_digest: attestation.digest().unwrap(),
+            authority_policy_digest: attestation.authority_policy_digest,
+            safety_policy_digest: attestation.safety_policy_digest,
+            safety_trust_policy_digest: attestation.safety_trust_policy_digest,
+            workflow_policy_digest: attestation.workflow_policy_digest,
+            valid_from: Timestamp::from_micros(10),
+            valid_until: Timestamp::from_micros(100),
         }
     }
 
@@ -575,13 +558,10 @@ mod tests {
 
     #[test]
     fn attestation_digest_changes_when_safety_policy_changes() {
-        let a = activation();
-        let mut b = activation();
+        let a = attestation();
+        let mut b = attestation();
         b.safety_policy_digest = digest(DigestDomain::MedicationSafetyPolicy, 99);
-        assert_ne!(
-            activation_attestation_digest(&a).unwrap(),
-            activation_attestation_digest(&b).unwrap()
-        );
+        assert_ne!(a.digest().unwrap(), b.digest().unwrap());
     }
 
     #[test]

--- a/zomes/medication_activation/integrity/src/lib.rs
+++ b/zomes/medication_activation/integrity/src/lib.rs
@@ -2,49 +2,54 @@
 #![allow(clippy::collapsible_match)]
 //! DNA-rooted medication activation attestation integrity zome.
 //!
-//! This zome does not repeat the clinical reasoning performed by the pure safety
-//! stack. Instead it creates a narrow DHT trust boundary: only an agent holding a
-//! verifier grant issued by a DNA-pinned root authority may publish a qualified
-//! medication activation attestation, and the grant pins the exact policy digests
-//! that the attestation is allowed to represent.
+//! This zome intentionally does not re-run clinical reasoning. It creates a narrow
+//! DHT trust boundary around the result of the pure clinical workflow stack:
 //!
-//! The attestation is privacy-minimized. It carries cryptographic identities and
-//! policy/evidence lineage, not patient names, medication names, dosage text, or raw
-//! clinical evidence.
+//! 1. a DNA-pinned root authority issues a short-lived authorization for one exact
+//!    activation receipt and one exact privacy-minimized attestation payload;
+//! 2. only the named verifier agent may publish that attestation;
+//! 3. the activation action timestamp must fall inside the authorization window;
+//! 4. activation/revocation evidence is append-only.
+//!
+//! Holochain `must_get_*` ignores later delete/update metadata, so authorization
+//! revocation is NOT modeled as deleting an authorization. Authorizations are exact
+//! target + short-lived. This bounds exposure and avoids a false delete-as-revoke
+//! assumption.
 
 use hdi::prelude::*;
-use mycelix_clinical_integrity::{DigestDomain, StoredDigest};
+use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, StoredDigest};
 
 const ROOT_CONFIG_VERSION: u16 = 1;
+const ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS: i64 = 900_000_000; // 15 minutes
+const ATTESTATION_SCHEMA_TAG: &[u8] = b"mycelix-health/qualified-medication-activation-v1";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MedicationActivationRootConfig {
     pub schema_version: u16,
     pub root_authorities: Vec<AgentPubKey>,
-    pub max_verifier_grant_duration_micros: i64,
+    pub max_verifier_authorization_duration_micros: i64,
 }
 
-/// Root-authorized delegation to a small verifier agent/cell. The verifier is
-/// allowed to attest only activations produced under these exact policy identities.
+/// Root-issued authorization for one exact activation receipt and one exact public
+/// attestation projection. This is deliberately not a reusable role grant.
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq)]
-pub struct MedicationActivationVerifierGrant {
-    pub grant_id: String,
+pub struct MedicationActivationVerifierAuthorization {
+    pub authorization_id: String,
     pub grantee: AgentPubKey,
+    pub activation_receipt_digest: StoredDigest,
+    pub activation_attestation_digest: StoredDigest,
     pub authority_policy_digest: StoredDigest,
     pub safety_policy_digest: StoredDigest,
     pub safety_trust_policy_digest: StoredDigest,
     pub workflow_policy_digest: StoredDigest,
-    pub issued_at: Timestamp,
     pub valid_from: Timestamp,
     pub valid_until: Timestamp,
 }
 
-/// Public, privacy-minimized attestation that an authorized verifier consumed a
-/// complete activation receipt under the policy set pinned in its verifier grant.
-///
-/// This is an attestation, not the underlying clinical record. The exact receipt and
-/// sensitive evidence may remain in an encrypted/local store.
+/// Privacy-minimized public attestation. It contains cryptographic identities and
+/// policy/evidence lineage, not patient names, medication names, dosage text, or raw
+/// clinical evidence. The exact activation receipt may remain encrypted/local.
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq)]
 pub struct QualifiedMedicationActivation {
@@ -57,8 +62,7 @@ pub struct QualifiedMedicationActivation {
     pub safety_policy_digest: StoredDigest,
     pub safety_trust_policy_digest: StoredDigest,
     pub workflow_policy_digest: StoredDigest,
-    pub verifier_grant_hash: ActionHash,
-    pub activated_at: Timestamp,
+    pub verifier_authorization_hash: ActionHash,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -72,25 +76,24 @@ pub enum ActivationRevocationReason {
     Other,
 }
 
-/// Append-only terminal/corrective event. Revocation does not delete the original
-/// clinical history; high-assurance read models derive current state from activation
-/// plus revocation lineage.
+/// Append-only corrective event. The receipt digest gives revocation a semantic
+/// identity even if equivalent activation attestations were committed more than once.
 #[hdk_entry_helper]
 #[derive(Clone, PartialEq)]
 pub struct MedicationActivationRevocation {
     pub revocation_id: String,
     pub activation_hash: ActionHash,
+    pub activation_receipt_digest: StoredDigest,
     pub reason: ActivationRevocationReason,
     /// Optional keyed/content commitment to sensitive human-readable rationale.
     /// Raw rationale/PHI should remain local or encrypted.
     pub reason_commitment: Option<[u8; 32]>,
-    pub revoked_at: Timestamp,
 }
 
 #[hdk_entry_types]
 #[unit_enum(UnitEntryTypes)]
 pub enum EntryTypes {
-    MedicationActivationVerifierGrant(MedicationActivationVerifierGrant),
+    MedicationActivationVerifierAuthorization(MedicationActivationVerifierAuthorization),
     QualifiedMedicationActivation(QualifiedMedicationActivation),
     MedicationActivationRevocation(MedicationActivationRevocation),
 }
@@ -115,7 +118,9 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
         FlatOp::RegisterUpdate(_) => invalid(
             "Medication activation trust/evidence entries are append-only and cannot be updated",
         ),
-        FlatOp::RegisterDelete(OpDelete { action }) => validate_delete_entry(action),
+        FlatOp::RegisterDelete(_) => invalid(
+            "Medication activation trust/evidence entries cannot be deleted; use expiry or append a revocation",
+        ),
         FlatOp::RegisterCreateLink {
             link_type,
             base_address,
@@ -135,8 +140,8 @@ fn validate_create_entry(
     entry: EntryTypes,
 ) -> ExternResult<ValidateCallbackResult> {
     match entry {
-        EntryTypes::MedicationActivationVerifierGrant(grant) => {
-            let shape = validate_grant_shape(&grant)?;
+        EntryTypes::MedicationActivationVerifierAuthorization(authorization) => {
+            let shape = validate_authorization_shape(&authorization)?;
             if !matches!(shape, ValidateCallbackResult::Valid) {
                 return Ok(shape);
             }
@@ -145,14 +150,14 @@ fn validate_create_entry(
             if !matches!(root, ValidateCallbackResult::Valid) {
                 return Ok(root);
             }
-            validate_grant_duration(&grant, &config)
+            validate_authorization_window(action.timestamp(), &authorization, &config)
         }
         EntryTypes::QualifiedMedicationActivation(activation) => {
             let shape = validate_activation_shape(&activation)?;
             if !matches!(shape, ValidateCallbackResult::Valid) {
                 return Ok(shape);
             }
-            require_active_verifier_grant(action.author(), &activation)
+            require_exact_verifier_authorization(action.author(), action.timestamp(), &activation)
         }
         EntryTypes::MedicationActivationRevocation(revocation) => {
             let shape = validate_revocation_shape(&revocation)?;
@@ -164,59 +169,58 @@ fn validate_create_entry(
     }
 }
 
-fn validate_delete_entry(action: Delete) -> ExternResult<ValidateCallbackResult> {
-    let record = must_get_valid_record(action.deletes_address.clone())?;
-    let maybe_grant = record
-        .entry()
-        .to_app_option::<MedicationActivationVerifierGrant>()
-        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
-
-    if maybe_grant.is_none() {
-        return invalid(
-            "Qualified activation and revocation evidence cannot be deleted; append a revocation/correction instead",
-        );
-    }
-
-    let config = activation_root_config()?;
-    require_root_authority(&action.author, &config)
-}
-
-fn validate_grant_shape(
-    grant: &MedicationActivationVerifierGrant,
+fn validate_authorization_shape(
+    authorization: &MedicationActivationVerifierAuthorization,
 ) -> ExternResult<ValidateCallbackResult> {
-    if grant.grant_id.trim().is_empty() {
-        return invalid("Medication activation verifier grant ID is required");
+    if authorization.authorization_id.trim().is_empty() {
+        return invalid("Medication activation verifier authorization ID is required");
     }
-    require_digest_domain(grant.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
     require_digest_domain(
-        grant.safety_policy_digest,
+        authorization.activation_receipt_digest,
+        DigestDomain::MedicationActivationReceipt,
+    )?;
+    require_digest_domain(
+        authorization.activation_attestation_digest,
+        DigestDomain::MedicationActivationAttestation,
+    )?;
+    require_digest_domain(
+        authorization.authority_policy_digest,
+        DigestDomain::AuthorityPolicy,
+    )?;
+    require_digest_domain(
+        authorization.safety_policy_digest,
         DigestDomain::MedicationSafetyPolicy,
     )?;
     require_digest_domain(
-        grant.safety_trust_policy_digest,
+        authorization.safety_trust_policy_digest,
         DigestDomain::MedicationSafetyTrustPolicy,
     )?;
-    require_digest_domain(grant.workflow_policy_digest, DigestDomain::WorkflowPolicy)?;
-
-    if grant.valid_from < grant.issued_at {
-        return invalid("Verifier grant validity cannot begin before issuance");
-    }
-    if grant.valid_until <= grant.valid_from {
-        return invalid("Verifier grant valid_until must follow valid_from");
+    require_digest_domain(
+        authorization.workflow_policy_digest,
+        DigestDomain::WorkflowPolicy,
+    )?;
+    if authorization.valid_until <= authorization.valid_from {
+        return invalid("Verifier authorization valid_until must follow valid_from");
     }
     Ok(ValidateCallbackResult::Valid)
 }
 
-fn validate_grant_duration(
-    grant: &MedicationActivationVerifierGrant,
+fn validate_authorization_window(
+    issued_at: Timestamp,
+    authorization: &MedicationActivationVerifierAuthorization,
     config: &MedicationActivationRootConfig,
 ) -> ExternResult<ValidateCallbackResult> {
-    if config.max_verifier_grant_duration_micros <= 0 {
-        return invalid("DNA medication activation root config has invalid grant-duration policy");
+    let configured_max = config.max_verifier_authorization_duration_micros;
+    if configured_max <= 0 || configured_max > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS {
+        return invalid("DNA medication activation authorization-duration policy is invalid");
     }
-    let duration = grant.valid_until.as_micros() as i128 - grant.valid_from.as_micros() as i128;
-    if duration <= 0 || duration > config.max_verifier_grant_duration_micros as i128 {
-        return invalid("Verifier grant exceeds DNA-pinned maximum duration");
+    if issued_at < authorization.valid_from || issued_at >= authorization.valid_until {
+        return invalid("Root authorization action timestamp must fall inside its validity window");
+    }
+    let duration = authorization.valid_until.as_micros() as i128
+        - authorization.valid_from.as_micros() as i128;
+    if duration <= 0 || duration > configured_max as i128 {
+        return invalid("Verifier authorization exceeds DNA-pinned maximum duration");
     }
     Ok(ValidateCallbackResult::Valid)
 }
@@ -255,8 +259,57 @@ fn validate_activation_shape(
         activation.safety_trust_policy_digest,
         DigestDomain::MedicationSafetyTrustPolicy,
     )?;
-    require_digest_domain(activation.workflow_policy_digest, DigestDomain::WorkflowPolicy)?;
+    require_digest_domain(
+        activation.workflow_policy_digest,
+        DigestDomain::WorkflowPolicy,
+    )?;
     Ok(ValidateCallbackResult::Valid)
+}
+
+/// Compute the exact privacy-minimized attestation identity approved by a root.
+/// `verifier_authorization_hash` is excluded to avoid a circular dependency.
+pub fn activation_attestation_digest(
+    activation: &QualifiedMedicationActivation,
+) -> ExternResult<StoredDigest> {
+    let material = ActivationAttestationMaterial {
+        activation_id: &activation.activation_id,
+        medication_artifact_digest: activation.medication_artifact_digest,
+        activation_receipt_digest: activation.activation_receipt_digest,
+        safety_context_digest: activation.safety_context_digest,
+        safety_trust_receipt_digest: activation.safety_trust_receipt_digest,
+        authority_policy_digest: activation.authority_policy_digest,
+        safety_policy_digest: activation.safety_policy_digest,
+        safety_trust_policy_digest: activation.safety_trust_policy_digest,
+        workflow_policy_digest: activation.workflow_policy_digest,
+    };
+    let encoded = serde_json::to_vec(&material).map_err(|error| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Failed to serialize medication activation attestation: {error}"
+        )))
+    })?;
+    let mut framed = Vec::with_capacity(ATTESTATION_SCHEMA_TAG.len() + 1 + encoded.len());
+    framed.extend_from_slice(ATTESTATION_SCHEMA_TAG);
+    framed.push(0);
+    framed.extend_from_slice(&encoded);
+    Ok(hash_canonical_bytes(
+        DigestDomain::MedicationActivationAttestation,
+        &framed,
+    )
+    .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+    .stored())
+}
+
+#[derive(Serialize)]
+struct ActivationAttestationMaterial<'a> {
+    activation_id: &'a str,
+    medication_artifact_digest: StoredDigest,
+    activation_receipt_digest: StoredDigest,
+    safety_context_digest: StoredDigest,
+    safety_trust_receipt_digest: StoredDigest,
+    authority_policy_digest: StoredDigest,
+    safety_policy_digest: StoredDigest,
+    safety_trust_policy_digest: StoredDigest,
+    workflow_policy_digest: StoredDigest,
 }
 
 fn validate_revocation_shape(
@@ -265,6 +318,10 @@ fn validate_revocation_shape(
     if revocation.revocation_id.trim().is_empty() {
         return invalid("Medication activation revocation ID is required");
     }
+    require_digest_domain(
+        revocation.activation_receipt_digest,
+        DigestDomain::MedicationActivationReceipt,
+    )?;
     if revocation
         .reason_commitment
         .is_some_and(|commitment| commitment == [0u8; 32])
@@ -279,25 +336,36 @@ fn validate_revocation_shape(
     Ok(ValidateCallbackResult::Valid)
 }
 
-fn require_active_verifier_grant(
+fn require_exact_verifier_authorization(
     author: &AgentPubKey,
+    activation_timestamp: Timestamp,
     activation: &QualifiedMedicationActivation,
 ) -> ExternResult<ValidateCallbackResult> {
-    let record = must_get_valid_record(activation.verifier_grant_hash.clone())?;
-    let grant: MedicationActivationVerifierGrant = decode_entry(&record, "verifier grant")?;
+    let record = must_get_valid_record(activation.verifier_authorization_hash.clone())?;
+    let authorization: MedicationActivationVerifierAuthorization =
+        decode_entry(&record, "verifier authorization")?;
 
-    if &grant.grantee != author {
-        return invalid("Qualified activation author is not the verifier grant grantee");
+    if &authorization.grantee != author {
+        return invalid("Qualified activation author is not the verifier authorization grantee");
     }
-    if activation.activated_at < grant.valid_from || activation.activated_at >= grant.valid_until {
-        return invalid("Qualified activation falls outside verifier grant validity");
-    }
-    if activation.authority_policy_digest != grant.authority_policy_digest
-        || activation.safety_policy_digest != grant.safety_policy_digest
-        || activation.safety_trust_policy_digest != grant.safety_trust_policy_digest
-        || activation.workflow_policy_digest != grant.workflow_policy_digest
+    if activation_timestamp < authorization.valid_from
+        || activation_timestamp >= authorization.valid_until
     {
-        return invalid("Qualified activation policy set does not match verifier grant");
+        return invalid("Qualified activation action timestamp falls outside authorization validity");
+    }
+    if activation.activation_receipt_digest != authorization.activation_receipt_digest {
+        return invalid("Qualified activation receipt does not match root authorization");
+    }
+    let actual_attestation_digest = activation_attestation_digest(activation)?;
+    if actual_attestation_digest != authorization.activation_attestation_digest {
+        return invalid("Qualified activation payload does not match root-authorized attestation");
+    }
+    if activation.authority_policy_digest != authorization.authority_policy_digest
+        || activation.safety_policy_digest != authorization.safety_policy_digest
+        || activation.safety_trust_policy_digest != authorization.safety_trust_policy_digest
+        || activation.workflow_policy_digest != authorization.workflow_policy_digest
+    {
+        return invalid("Qualified activation policy set does not match root authorization");
     }
     Ok(ValidateCallbackResult::Valid)
 }
@@ -309,8 +377,8 @@ fn require_revocation_authority(
     let activation_record = must_get_valid_record(revocation.activation_hash.clone())?;
     let activation: QualifiedMedicationActivation =
         decode_entry(&activation_record, "qualified medication activation")?;
-    if revocation.revoked_at < activation.activated_at {
-        return invalid("Activation revocation cannot predate activation");
+    if activation.activation_receipt_digest != revocation.activation_receipt_digest {
+        return invalid("Activation revocation receipt digest does not match target activation");
     }
 
     if activation_record.action().author() == author {
@@ -332,13 +400,17 @@ fn validate_create_link(
             let activation_hash = require_action_hash(base_address, "activation link base")?;
             let revocation_hash = require_action_hash(target_address, "revocation link target")?;
             let activation_record = must_get_valid_record(activation_hash.clone())?;
-            let _: QualifiedMedicationActivation =
+            let activation: QualifiedMedicationActivation =
                 decode_entry(&activation_record, "qualified medication activation")?;
             let revocation_record = must_get_valid_record(revocation_hash)?;
             let revocation: MedicationActivationRevocation =
                 decode_entry(&revocation_record, "medication activation revocation")?;
-            if revocation.activation_hash != activation_hash {
-                return invalid("Activation-revocation link target references another activation");
+            if revocation.activation_hash != activation_hash
+                || revocation.activation_receipt_digest != activation.activation_receipt_digest
+            {
+                return invalid(
+                    "Activation-revocation link target references another activation lineage",
+                );
             }
             if revocation_record.action().author() != &action.author {
                 return invalid("Activation-revocation link must be authored by revocation author");
@@ -376,9 +448,13 @@ fn parse_activation_root_config(bytes: &[u8]) -> ExternResult<MedicationActivati
             config.schema_version
         ))));
     }
-    if config.max_verifier_grant_duration_micros <= 0 {
+    if config.max_verifier_authorization_duration_micros <= 0
+        || config.max_verifier_authorization_duration_micros
+            > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS
+    {
         return Err(wasm_error!(WasmErrorInner::Guest(
-            "Medication activation root config maximum grant duration must be positive".to_string()
+            "Medication activation root config authorization duration must be > 0 and <= 15 minutes"
+                .to_string()
         )));
     }
     Ok(config)
@@ -389,15 +465,14 @@ fn require_root_authority(
     config: &MedicationActivationRootConfig,
 ) -> ExternResult<ValidateCallbackResult> {
     if !config.root_authorities.contains(author) {
-        return invalid("Medication activation verifier grant/revocation requires a DNA-pinned root authority");
+        return invalid(
+            "Medication activation verifier authorization requires a DNA-pinned root authority",
+        );
     }
     Ok(ValidateCallbackResult::Valid)
 }
 
-fn require_digest_domain(
-    digest: StoredDigest,
-    expected: DigestDomain,
-) -> ExternResult<()> {
+fn require_digest_domain(digest: StoredDigest, expected: DigestDomain) -> ExternResult<()> {
     digest
         .validate_shape()
         .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
@@ -410,10 +485,7 @@ fn require_digest_domain(
     Ok(())
 }
 
-fn require_action_hash(
-    hash: AnyLinkableHash,
-    field: &'static str,
-) -> ExternResult<ActionHash> {
+fn require_action_hash(hash: AnyLinkableHash, field: &'static str) -> ExternResult<ActionHash> {
     hash.into_action_hash().ok_or(wasm_error!(WasmErrorInner::Guest(
         format!("{field} must be an ActionHash")
     )))
@@ -439,46 +511,77 @@ fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain};
 
     fn digest(domain: DigestDomain, seed: u8) -> StoredDigest {
         hash_canonical_bytes(domain, &[seed]).unwrap().stored()
     }
 
-    fn grant() -> MedicationActivationVerifierGrant {
-        MedicationActivationVerifierGrant {
-            grant_id: "grant-a".into(),
+    fn authorization() -> MedicationActivationVerifierAuthorization {
+        MedicationActivationVerifierAuthorization {
+            authorization_id: "auth-a".into(),
             grantee: AgentPubKey::from_raw_36(vec![1; 36]),
-            authority_policy_digest: digest(DigestDomain::AuthorityPolicy, 1),
-            safety_policy_digest: digest(DigestDomain::MedicationSafetyPolicy, 2),
-            safety_trust_policy_digest: digest(DigestDomain::MedicationSafetyTrustPolicy, 3),
-            workflow_policy_digest: digest(DigestDomain::WorkflowPolicy, 4),
-            issued_at: Timestamp::from_micros(10),
+            activation_receipt_digest: digest(DigestDomain::MedicationActivationReceipt, 1),
+            activation_attestation_digest: digest(
+                DigestDomain::MedicationActivationAttestation,
+                2,
+            ),
+            authority_policy_digest: digest(DigestDomain::AuthorityPolicy, 3),
+            safety_policy_digest: digest(DigestDomain::MedicationSafetyPolicy, 4),
+            safety_trust_policy_digest: digest(DigestDomain::MedicationSafetyTrustPolicy, 5),
+            workflow_policy_digest: digest(DigestDomain::WorkflowPolicy, 6),
             valid_from: Timestamp::from_micros(10),
             valid_until: Timestamp::from_micros(100),
         }
     }
 
-    #[test]
-    fn grant_shape_requires_exact_policy_domains() {
-        let mut grant = grant();
-        grant.safety_policy_digest = digest(DigestDomain::AuthorityPolicy, 9);
-        assert!(matches!(
-            validate_grant_shape(&grant),
-            Err(WasmError { .. })
-        ));
+    fn activation() -> QualifiedMedicationActivation {
+        QualifiedMedicationActivation {
+            activation_id: "activation-a".into(),
+            medication_artifact_digest: digest(DigestDomain::MedicationRequestArtifact, 7),
+            activation_receipt_digest: digest(DigestDomain::MedicationActivationReceipt, 8),
+            safety_context_digest: digest(DigestDomain::MedicationSafetyContext, 9),
+            safety_trust_receipt_digest: digest(DigestDomain::MedicationSafetyTrustReceipt, 10),
+            authority_policy_digest: digest(DigestDomain::AuthorityPolicy, 11),
+            safety_policy_digest: digest(DigestDomain::MedicationSafetyPolicy, 12),
+            safety_trust_policy_digest: digest(DigestDomain::MedicationSafetyTrustPolicy, 13),
+            workflow_policy_digest: digest(DigestDomain::WorkflowPolicy, 14),
+            verifier_authorization_hash: ActionHash::from_raw_36(vec![15; 36]),
+        }
     }
 
     #[test]
-    fn grant_duration_is_bounded_by_dna_policy() {
-        let grant = grant();
+    fn authorization_shape_requires_exact_policy_domains() {
+        let mut authorization = authorization();
+        authorization.safety_policy_digest = digest(DigestDomain::AuthorityPolicy, 9);
+        assert!(validate_authorization_shape(&authorization).is_err());
+    }
+
+    #[test]
+    fn authorization_duration_is_hard_bounded() {
+        let authorization = authorization();
         let config = MedicationActivationRootConfig {
             schema_version: 1,
             root_authorities: vec![],
-            max_verifier_grant_duration_micros: 50,
+            max_verifier_authorization_duration_micros: 50,
         };
-        let result = validate_grant_duration(&grant, &config).unwrap();
+        let result = validate_authorization_window(
+            Timestamp::from_micros(10),
+            &authorization,
+            &config,
+        )
+        .unwrap();
         assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn attestation_digest_changes_when_safety_policy_changes() {
+        let a = activation();
+        let mut b = activation();
+        b.safety_policy_digest = digest(DigestDomain::MedicationSafetyPolicy, 99);
+        assert_ne!(
+            activation_attestation_digest(&a).unwrap(),
+            activation_attestation_digest(&b).unwrap()
+        );
     }
 
     #[test]
@@ -486,9 +589,9 @@ mod tests {
         let revocation = MedicationActivationRevocation {
             revocation_id: "rev-a".into(),
             activation_hash: ActionHash::from_raw_36(vec![2; 36]),
+            activation_receipt_digest: digest(DigestDomain::MedicationActivationReceipt, 3),
             reason: ActivationRevocationReason::Other,
             reason_commitment: None,
-            revoked_at: Timestamp::from_micros(100),
         };
         let result = validate_revocation_shape(&revocation).unwrap();
         assert!(matches!(result, ValidateCallbackResult::Invalid(_)));

--- a/zomes/medication_activation/integrity/src/lib.rs
+++ b/zomes/medication_activation/integrity/src/lib.rs
@@ -1,0 +1,496 @@
+#![deny(unsafe_code)]
+#![allow(clippy::collapsible_match)]
+//! DNA-rooted medication activation attestation integrity zome.
+//!
+//! This zome does not repeat the clinical reasoning performed by the pure safety
+//! stack. Instead it creates a narrow DHT trust boundary: only an agent holding a
+//! verifier grant issued by a DNA-pinned root authority may publish a qualified
+//! medication activation attestation, and the grant pins the exact policy digests
+//! that the attestation is allowed to represent.
+//!
+//! The attestation is privacy-minimized. It carries cryptographic identities and
+//! policy/evidence lineage, not patient names, medication names, dosage text, or raw
+//! clinical evidence.
+
+use hdi::prelude::*;
+use mycelix_clinical_integrity::{DigestDomain, StoredDigest};
+
+const ROOT_CONFIG_VERSION: u16 = 1;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MedicationActivationRootConfig {
+    pub schema_version: u16,
+    pub root_authorities: Vec<AgentPubKey>,
+    pub max_verifier_grant_duration_micros: i64,
+}
+
+/// Root-authorized delegation to a small verifier agent/cell. The verifier is
+/// allowed to attest only activations produced under these exact policy identities.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct MedicationActivationVerifierGrant {
+    pub grant_id: String,
+    pub grantee: AgentPubKey,
+    pub authority_policy_digest: StoredDigest,
+    pub safety_policy_digest: StoredDigest,
+    pub safety_trust_policy_digest: StoredDigest,
+    pub workflow_policy_digest: StoredDigest,
+    pub issued_at: Timestamp,
+    pub valid_from: Timestamp,
+    pub valid_until: Timestamp,
+}
+
+/// Public, privacy-minimized attestation that an authorized verifier consumed a
+/// complete activation receipt under the policy set pinned in its verifier grant.
+///
+/// This is an attestation, not the underlying clinical record. The exact receipt and
+/// sensitive evidence may remain in an encrypted/local store.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct QualifiedMedicationActivation {
+    pub activation_id: String,
+    pub medication_artifact_digest: StoredDigest,
+    pub activation_receipt_digest: StoredDigest,
+    pub safety_context_digest: StoredDigest,
+    pub safety_trust_receipt_digest: StoredDigest,
+    pub authority_policy_digest: StoredDigest,
+    pub safety_policy_digest: StoredDigest,
+    pub safety_trust_policy_digest: StoredDigest,
+    pub workflow_policy_digest: StoredDigest,
+    pub verifier_grant_hash: ActionHash,
+    pub activated_at: Timestamp,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum ActivationRevocationReason {
+    Superseded,
+    MedicationStopped,
+    SafetyEvidenceRevoked,
+    ProfessionalAuthorityRevoked,
+    SourceTrustRevoked,
+    EnteredInError,
+    Other,
+}
+
+/// Append-only terminal/corrective event. Revocation does not delete the original
+/// clinical history; high-assurance read models derive current state from activation
+/// plus revocation lineage.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct MedicationActivationRevocation {
+    pub revocation_id: String,
+    pub activation_hash: ActionHash,
+    pub reason: ActivationRevocationReason,
+    /// Optional keyed/content commitment to sensitive human-readable rationale.
+    /// Raw rationale/PHI should remain local or encrypted.
+    pub reason_commitment: Option<[u8; 32]>,
+    pub revoked_at: Timestamp,
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    MedicationActivationVerifierGrant(MedicationActivationVerifierGrant),
+    QualifiedMedicationActivation(QualifiedMedicationActivation),
+    MedicationActivationRevocation(MedicationActivationRevocation),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    ActivationToRevocations,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => {
+                validate_create_entry(EntryCreationAction::Create(action), app_entry)
+            }
+            OpEntry::UpdateEntry { .. } => invalid(
+                "Medication activation trust/evidence entries are append-only and cannot be updated",
+            ),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterUpdate(_) => invalid(
+            "Medication activation trust/evidence entries are append-only and cannot be updated",
+        ),
+        FlatOp::RegisterDelete(OpDelete { action }) => validate_delete_entry(action),
+        FlatOp::RegisterCreateLink {
+            link_type,
+            base_address,
+            target_address,
+            action,
+            ..
+        } => validate_create_link(link_type, base_address, target_address, action),
+        FlatOp::RegisterDeleteLink { .. } => invalid(
+            "Medication activation revocation links are append-only and cannot be deleted",
+        ),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_create_entry(
+    action: EntryCreationAction,
+    entry: EntryTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    match entry {
+        EntryTypes::MedicationActivationVerifierGrant(grant) => {
+            let shape = validate_grant_shape(&grant)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let config = activation_root_config()?;
+            let root = require_root_authority(action.author(), &config)?;
+            if !matches!(root, ValidateCallbackResult::Valid) {
+                return Ok(root);
+            }
+            validate_grant_duration(&grant, &config)
+        }
+        EntryTypes::QualifiedMedicationActivation(activation) => {
+            let shape = validate_activation_shape(&activation)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_active_verifier_grant(action.author(), &activation)
+        }
+        EntryTypes::MedicationActivationRevocation(revocation) => {
+            let shape = validate_revocation_shape(&revocation)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_revocation_authority(action.author(), &revocation)
+        }
+    }
+}
+
+fn validate_delete_entry(action: Delete) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(action.deletes_address.clone())?;
+    let maybe_grant = record
+        .entry()
+        .to_app_option::<MedicationActivationVerifierGrant>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+
+    if maybe_grant.is_none() {
+        return invalid(
+            "Qualified activation and revocation evidence cannot be deleted; append a revocation/correction instead",
+        );
+    }
+
+    let config = activation_root_config()?;
+    require_root_authority(&action.author, &config)
+}
+
+fn validate_grant_shape(
+    grant: &MedicationActivationVerifierGrant,
+) -> ExternResult<ValidateCallbackResult> {
+    if grant.grant_id.trim().is_empty() {
+        return invalid("Medication activation verifier grant ID is required");
+    }
+    require_digest_domain(grant.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+    require_digest_domain(
+        grant.safety_policy_digest,
+        DigestDomain::MedicationSafetyPolicy,
+    )?;
+    require_digest_domain(
+        grant.safety_trust_policy_digest,
+        DigestDomain::MedicationSafetyTrustPolicy,
+    )?;
+    require_digest_domain(grant.workflow_policy_digest, DigestDomain::WorkflowPolicy)?;
+
+    if grant.valid_from < grant.issued_at {
+        return invalid("Verifier grant validity cannot begin before issuance");
+    }
+    if grant.valid_until <= grant.valid_from {
+        return invalid("Verifier grant valid_until must follow valid_from");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_grant_duration(
+    grant: &MedicationActivationVerifierGrant,
+    config: &MedicationActivationRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    if config.max_verifier_grant_duration_micros <= 0 {
+        return invalid("DNA medication activation root config has invalid grant-duration policy");
+    }
+    let duration = grant.valid_until.as_micros() as i128 - grant.valid_from.as_micros() as i128;
+    if duration <= 0 || duration > config.max_verifier_grant_duration_micros as i128 {
+        return invalid("Verifier grant exceeds DNA-pinned maximum duration");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_activation_shape(
+    activation: &QualifiedMedicationActivation,
+) -> ExternResult<ValidateCallbackResult> {
+    if activation.activation_id.trim().is_empty() {
+        return invalid("Qualified medication activation ID is required");
+    }
+    require_digest_domain(
+        activation.medication_artifact_digest,
+        DigestDomain::MedicationRequestArtifact,
+    )?;
+    require_digest_domain(
+        activation.activation_receipt_digest,
+        DigestDomain::MedicationActivationReceipt,
+    )?;
+    require_digest_domain(
+        activation.safety_context_digest,
+        DigestDomain::MedicationSafetyContext,
+    )?;
+    require_digest_domain(
+        activation.safety_trust_receipt_digest,
+        DigestDomain::MedicationSafetyTrustReceipt,
+    )?;
+    require_digest_domain(
+        activation.authority_policy_digest,
+        DigestDomain::AuthorityPolicy,
+    )?;
+    require_digest_domain(
+        activation.safety_policy_digest,
+        DigestDomain::MedicationSafetyPolicy,
+    )?;
+    require_digest_domain(
+        activation.safety_trust_policy_digest,
+        DigestDomain::MedicationSafetyTrustPolicy,
+    )?;
+    require_digest_domain(activation.workflow_policy_digest, DigestDomain::WorkflowPolicy)?;
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_revocation_shape(
+    revocation: &MedicationActivationRevocation,
+) -> ExternResult<ValidateCallbackResult> {
+    if revocation.revocation_id.trim().is_empty() {
+        return invalid("Medication activation revocation ID is required");
+    }
+    if revocation
+        .reason_commitment
+        .is_some_and(|commitment| commitment == [0u8; 32])
+    {
+        return invalid("Medication activation revocation reason commitment cannot be zero");
+    }
+    if matches!(revocation.reason, ActivationRevocationReason::Other)
+        && revocation.reason_commitment.is_none()
+    {
+        return invalid("Other activation-revocation reason requires a rationale commitment");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_active_verifier_grant(
+    author: &AgentPubKey,
+    activation: &QualifiedMedicationActivation,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(activation.verifier_grant_hash.clone())?;
+    let grant: MedicationActivationVerifierGrant = decode_entry(&record, "verifier grant")?;
+
+    if &grant.grantee != author {
+        return invalid("Qualified activation author is not the verifier grant grantee");
+    }
+    if activation.activated_at < grant.valid_from || activation.activated_at >= grant.valid_until {
+        return invalid("Qualified activation falls outside verifier grant validity");
+    }
+    if activation.authority_policy_digest != grant.authority_policy_digest
+        || activation.safety_policy_digest != grant.safety_policy_digest
+        || activation.safety_trust_policy_digest != grant.safety_trust_policy_digest
+        || activation.workflow_policy_digest != grant.workflow_policy_digest
+    {
+        return invalid("Qualified activation policy set does not match verifier grant");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_revocation_authority(
+    author: &AgentPubKey,
+    revocation: &MedicationActivationRevocation,
+) -> ExternResult<ValidateCallbackResult> {
+    let activation_record = must_get_valid_record(revocation.activation_hash.clone())?;
+    let activation: QualifiedMedicationActivation =
+        decode_entry(&activation_record, "qualified medication activation")?;
+    if revocation.revoked_at < activation.activated_at {
+        return invalid("Activation revocation cannot predate activation");
+    }
+
+    if activation_record.action().author() == author {
+        return Ok(ValidateCallbackResult::Valid);
+    }
+
+    let config = activation_root_config()?;
+    require_root_authority(author, &config)
+}
+
+fn validate_create_link(
+    link_type: LinkTypes,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    action: CreateLink,
+) -> ExternResult<ValidateCallbackResult> {
+    match link_type {
+        LinkTypes::ActivationToRevocations => {
+            let activation_hash = require_action_hash(base_address, "activation link base")?;
+            let revocation_hash = require_action_hash(target_address, "revocation link target")?;
+            let activation_record = must_get_valid_record(activation_hash.clone())?;
+            let _: QualifiedMedicationActivation =
+                decode_entry(&activation_record, "qualified medication activation")?;
+            let revocation_record = must_get_valid_record(revocation_hash)?;
+            let revocation: MedicationActivationRevocation =
+                decode_entry(&revocation_record, "medication activation revocation")?;
+            if revocation.activation_hash != activation_hash {
+                return invalid("Activation-revocation link target references another activation");
+            }
+            if revocation_record.action().author() != &action.author {
+                return invalid("Activation-revocation link must be authored by revocation author");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+    }
+}
+
+fn activation_root_config() -> ExternResult<MedicationActivationRootConfig> {
+    let info = dna_info()?;
+    parse_activation_root_config(info.modifiers.properties.bytes())
+}
+
+fn parse_activation_root_config(bytes: &[u8]) -> ExternResult<MedicationActivationRootConfig> {
+    let properties: serde_json::Value = serde_json::from_slice(bytes).map_err(|error| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "DNA properties are not valid JSON for medication activation: {error}"
+        )))
+    })?;
+    let value = properties.get("medication_activation").ok_or(wasm_error!(
+        WasmErrorInner::Guest(
+            "DNA properties do not configure medication_activation trust roots".to_string()
+        )
+    ))?;
+    let config: MedicationActivationRootConfig =
+        serde_json::from_value(value.clone()).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Invalid medication_activation DNA properties: {error}"
+            )))
+        })?;
+    if config.schema_version != ROOT_CONFIG_VERSION {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Unsupported medication_activation root config version {}",
+            config.schema_version
+        ))));
+    }
+    if config.max_verifier_grant_duration_micros <= 0 {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Medication activation root config maximum grant duration must be positive".to_string()
+        )));
+    }
+    Ok(config)
+}
+
+fn require_root_authority(
+    author: &AgentPubKey,
+    config: &MedicationActivationRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    if !config.root_authorities.contains(author) {
+        return invalid("Medication activation verifier grant/revocation requires a DNA-pinned root authority");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_digest_domain(
+    digest: StoredDigest,
+    expected: DigestDomain,
+) -> ExternResult<()> {
+    digest
+        .validate_shape()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+    if digest.domain != expected {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Medication activation digest domain mismatch: expected {expected:?}, got {:?}",
+            digest.domain
+        ))));
+    }
+    Ok(())
+}
+
+fn require_action_hash(
+    hash: AnyLinkableHash,
+    field: &'static str,
+) -> ExternResult<ActionHash> {
+    hash.into_action_hash().ok_or(wasm_error!(WasmErrorInner::Guest(
+        format!("{field} must be an ActionHash")
+    )))
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain};
+
+    fn digest(domain: DigestDomain, seed: u8) -> StoredDigest {
+        hash_canonical_bytes(domain, &[seed]).unwrap().stored()
+    }
+
+    fn grant() -> MedicationActivationVerifierGrant {
+        MedicationActivationVerifierGrant {
+            grant_id: "grant-a".into(),
+            grantee: AgentPubKey::from_raw_36(vec![1; 36]),
+            authority_policy_digest: digest(DigestDomain::AuthorityPolicy, 1),
+            safety_policy_digest: digest(DigestDomain::MedicationSafetyPolicy, 2),
+            safety_trust_policy_digest: digest(DigestDomain::MedicationSafetyTrustPolicy, 3),
+            workflow_policy_digest: digest(DigestDomain::WorkflowPolicy, 4),
+            issued_at: Timestamp::from_micros(10),
+            valid_from: Timestamp::from_micros(10),
+            valid_until: Timestamp::from_micros(100),
+        }
+    }
+
+    #[test]
+    fn grant_shape_requires_exact_policy_domains() {
+        let mut grant = grant();
+        grant.safety_policy_digest = digest(DigestDomain::AuthorityPolicy, 9);
+        assert!(matches!(
+            validate_grant_shape(&grant),
+            Err(WasmError { .. })
+        ));
+    }
+
+    #[test]
+    fn grant_duration_is_bounded_by_dna_policy() {
+        let grant = grant();
+        let config = MedicationActivationRootConfig {
+            schema_version: 1,
+            root_authorities: vec![],
+            max_verifier_grant_duration_micros: 50,
+        };
+        let result = validate_grant_duration(&grant, &config).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn other_revocation_requires_private_reason_commitment() {
+        let revocation = MedicationActivationRevocation {
+            revocation_id: "rev-a".into(),
+            activation_hash: ActionHash::from_raw_36(vec![2; 36]),
+            reason: ActivationRevocationReason::Other,
+            reason_commitment: None,
+            revoked_at: Timestamp::from_micros(100),
+        };
+        let result = validate_revocation_shape(&revocation).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+}


### PR DESCRIPTION
## Stack

Depends on #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

Advances P0 #50 and the runtime trust-root portion of #47.

## Why

The pure medication capability stack can prove exact requester identity, professional authority, safety coverage, evaluator/knowledge admission, and workflow binding in-process. But a serialized receipt is not automatically trustworthy, and an ordinary/modified coordinator must not be able to mint a distributed `qualified activation` claim by choosing its own policy roots.

This PR adds a narrow DHT trust boundary rooted in DNA properties.

## Core design

### 1. Consume capability -> audit receipt

Adds `mycelix-medication-activation-receipt`.

`consume_activation_capability(...)` consumes the non-cloneable `MedicationActivationCapability` into a serializable `MedicationActivationAuditReceiptV1` that preserves all four proof lineages:

1. requester identity resolution;
2. professional prescribing authority;
3. medication safety clearance;
4. evaluator/knowledge source trust.

The receipt is explicitly **evidence, not authority**. Deserialization cannot recreate the workflow capability.

A dedicated `MedicationActivationReceipt` BLAKE3/domain-separated identity prevents receipt bytes from being confused with other clinical artifacts.

### 2. Standalone privacy-minimized attestation

Adds `MedicationActivationAttestationV1`, containing only opaque IDs/digests and exact policy identities. It does not require patient names, medication names, diagnoses, dosage text, labs, allergies, or raw safety evidence on the distributed surface.

The attestation has its own `MedicationActivationAttestation` digest domain and can be hashed before any authorization entry exists, avoiding circular identity.

### 3. DNA-pinned root authority

The integrity zome reads `dna_info()?.modifiers.properties` and requires root authorization from `medication_activation.root_authorities`.

The repository DNA deliberately ships with:

```yaml
root_authorities: []
```

so qualified activation is **disabled by default**. A test/production deployment must intentionally repack the DNA with trusted root AgentPubKeys, changing the DNA hash and making the trust decision explicit.

### 4. Exact, short-lived verifier authorization

A DNA root may issue `MedicationActivationVerifierAuthorization` for:

- one exact verifier AgentPubKey;
- one exact activation receipt digest;
- one exact attestation digest;
- one exact authority-policy digest;
- one exact medication-safety-policy digest;
- one exact safety-source-trust-policy digest;
- one exact workflow-policy digest;
- one bounded validity window.

This is deliberately **not a reusable verifier role grant**.

The DNA config and integrity code cap v1 authorization lifetime to at most 15 minutes.

### 5. Important Holochain revocation correction

Holochain's `must_get_*` functions intentionally ignore mutable metadata such as later updates/deletes. Therefore deleting a verifier grant cannot safely be treated as instant revocation of the original record for inductive validation.

This PR corrects that assumption:

- verifier authorizations are append-only;
- no delete-as-revocation claim;
- each authorization is exact-receipt + exact-attestation + short-lived;
- the activation **action timestamp**, not request-controlled `activated_at`, must fall inside the authorization window;
- if a root stops trusting a verifier, it stops issuing future exact authorizations and exposure is bounded to already-issued exact targets/windows.

### 6. Qualified DHT activation

`QualifiedMedicationActivation` consists only of:

- the exact attestation proposal;
- the verifier-authorization ActionHash.

Integrity validation:

1. `must_get_valid_record`s the root-issued authorization;
2. requires activation author == authorization grantee;
3. checks the Holochain action timestamp against the authorization window;
4. recomputes the exact attestation digest;
5. requires exact activation-receipt equality;
6. requires exact authority/safety/source-trust/workflow policy equality.

Changing any safety-significant field invalidates the authorization.

### 7. Append-only revocation lineage

`MedicationActivationRevocation` references an exact activation action and exact receipt digest, carries a typed reason, and may include only a commitment to sensitive rationale. Raw rationale/PHI can stay local/encrypted.

Activation trust/evidence entries cannot be updated/deleted. Revocation links are append-only.

## Coordinator

The new coordinator is intentionally thin: create/read/link only. Clinical authorization logic lives in integrity validation so a modified coordinator cannot route around the DHT boundary.

## Qualification required

This PR remains draft until exact-head CI and conductor tests prove at least:

- empty-root DNA fails closed;
- configured root can issue exact authorization;
- non-root cannot issue authorization;
- wrong verifier cannot attest;
- receipt/attestation/policy substitution fails;
- activation outside authorization window fails;
- updates/deletes fail;
- malformed/forged revocations fail;
- modified coordinator cannot directly commit around integrity validation;
- duplicate attestations are idempotent in the read model.

## Non-claims

- The DHT does not independently rerun medical reasoning; it proves that a DNA-rooted authority approved this exact receipt/attestation under this exact policy set.
- A serialized audit receipt is not inherently trusted; the root/verifier service must revalidate referenced evidence before issuing authorization.
- Root-key compromise remains high impact; production needs strong operational security and later threshold/rotation design.
- v1 does not claim instantaneous verifier revocation; exact-target short-lived authorization bounds this explicitly.
- Emergency/manual care remains a separate future evidence-bearing path and must never be mislabeled as `Cleared`.