### PR TITLE
security(emergency): add separate DNA-rooted medication override state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
     "zomes/prescriptions/coordinator",
     "zomes/medication_activation/integrity",
     "zomes/medication_activation/coordinator",
+    "zomes/medication_emergency/integrity",
+    "zomes/medication_emergency/coordinator",
     "zomes/consent/integrity",
     "zomes/consent/coordinator",
     "zomes/bridge/integrity",

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -34,6 +34,7 @@ pub enum DigestDomain {
     MedicationActivationAttestation,
     EmergencyMedicationOverridePolicy,
     EmergencyMedicationOverrideReceipt,
+    EmergencyMedicationOverrideAttestation,
     QuarantineEvent,
     QuarantineDecision,
     AuthorityPolicy,
@@ -62,6 +63,9 @@ impl DigestDomain {
             Self::MedicationActivationAttestation => b"medication-activation-attestation",
             Self::EmergencyMedicationOverridePolicy => b"emergency-medication-override-policy",
             Self::EmergencyMedicationOverrideReceipt => b"emergency-medication-override-receipt",
+            Self::EmergencyMedicationOverrideAttestation => {
+                b"emergency-medication-override-attestation"
+            }
             Self::QuarantineEvent => b"quarantine-event",
             Self::QuarantineDecision => b"quarantine-decision",
             Self::AuthorityPolicy => b"authority-policy",
@@ -226,6 +230,7 @@ mod tests {
             DigestDomain::MedicationActivationAttestation,
             DigestDomain::EmergencyMedicationOverridePolicy,
             DigestDomain::EmergencyMedicationOverrideReceipt,
+            DigestDomain::EmergencyMedicationOverrideAttestation,
             DigestDomain::AuthorityPolicy,
         ];
         let values: Vec<[u8; 32]> = domains

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -13,6 +13,15 @@ integrity:
       # The integrity zome also hard-caps this value, so accidental packaging with a
       # longer window fails validation rather than silently weakening the contract.
       max_verifier_authorization_duration_micros: 900000000
+    medication_emergency:
+      schema_version: 1
+      # Emergency override trust is intentionally distinct from ordinary qualified
+      # activation trust. Empty by default: no emergency activation can validate
+      # until a deployment deliberately repacks the DNA with trusted root keys.
+      root_authorities: []
+      # Exact-receipt emergency verifier authorizations are also capped at 15 minutes.
+      # Deployments may choose a shorter value when repacking the DNA.
+      max_verifier_authorization_duration_micros: 900000000
   zomes:
     # Tier 1: MVP Core
     - name: patient_integrity
@@ -25,6 +34,8 @@ integrity:
       path: ../target/wasm32-unknown-unknown/release/prescriptions_integrity.wasm
     - name: medication_activation_integrity
       path: ../target/wasm32-unknown-unknown/release/medication_activation_integrity.wasm
+    - name: medication_emergency_integrity
+      path: ../target/wasm32-unknown-unknown/release/medication_emergency_integrity.wasm
     - name: consent_integrity
       path: ../target/wasm32-unknown-unknown/release/consent_integrity.wasm
     - name: bridge_integrity
@@ -55,6 +66,10 @@ coordinator:
       path: ../target/wasm32-unknown-unknown/release/medication_activation.wasm
       dependencies:
         - name: medication_activation_integrity
+    - name: medication_emergency
+      path: ../target/wasm32-unknown-unknown/release/medication_emergency.wasm
+      dependencies:
+        - name: medication_emergency_integrity
     - name: consent
       path: ../target/wasm32-unknown-unknown/release/consent.wasm
       dependencies:

--- a/docs/security/EMERGENCY_MEDICATION_DHT_TRUST_V1.md
+++ b/docs/security/EMERGENCY_MEDICATION_DHT_TRUST_V1.md
@@ -1,0 +1,127 @@
+# Emergency Medication DHT Trust v1
+
+## Purpose
+
+Emergency medication activation is a **different clinical provenance class** from ordinary qualified activation.
+
+The pure emergency capability from `mycelix-emergency-medication-override` proves that one exact, activation-valid MedicationRequest crossed the emergency uncertainty policy with:
+
+- resolved requester identity;
+- professional prescribing authority;
+- an evidence-bearing non-cleared medication-safety assessment;
+- a versioned emergency policy;
+- typed emergency reason;
+- protected rationale commitment.
+
+That in-process capability is consumed into an `EmergencyMedicationOverrideReceiptV1`. A serialized receipt remains evidence, not authority. This zome pair adds the distributed trust boundary that allows an institution/deployment to attest that it revalidated one exact private receipt.
+
+## Structural separation
+
+Emergency state is intentionally placed in a separate zome:
+
+- ordinary: `medication_activation`
+- emergency: `medication_emergency`
+
+The emergency public type is `EmergencyMedicationActivation`, not `QualifiedMedicationActivation`.
+
+A future combined read model must preserve this distinction, for example:
+
+```text
+MedicationActivationState::Qualified(...)
+MedicationActivationState::EmergencyOverride(...)
+```
+
+It must not flatten both into `active: true` or otherwise erase provenance.
+
+## Privacy-minimized attestation
+
+`EmergencyMedicationAttestationV1` carries only:
+
+- exact MedicationRequest artifact digest;
+- exact emergency override receipt digest;
+- exact medication-safety assessment digest;
+- exact medication-safety policy digest;
+- exact professional-authority policy digest;
+- exact emergency policy digest;
+- `EmergencySafetyBasis::{Indeterminate, RequiresReview}`;
+- an opaque activation ID.
+
+It does **not** require patient identity, drug name, diagnosis, dosage, allergies, labs, clinical notes, or emergency rationale text on the DHT.
+
+`EmergencySafetyBasis` deliberately has no `Cleared` or `Blocked` variant. Fully cleared medication belongs on ordinary qualified activation. Known-danger evidence is not uncertainty and requires a separately designed break-glass path if one is ever clinically justified.
+
+## DNA-pinned emergency trust root
+
+The integrity zome reads `dna_info()?.modifiers.properties.medication_emergency`.
+
+The repository manifest ships with:
+
+```yaml
+medication_emergency:
+  schema_version: 1
+  root_authorities: []
+  max_verifier_authorization_duration_micros: 900000000
+```
+
+This means emergency activation is disabled by default. A test or production deployment must deliberately repack the DNA with its trusted emergency root AgentPubKeys. Ordinary activation roots do not automatically become emergency roots.
+
+The integrity zome independently hard-caps v1 verifier authorization lifetime at 15 minutes. A deployment may package a shorter limit.
+
+## Exact-target verifier authorization
+
+A DNA root can issue `EmergencyMedicationVerifierAuthorization` for exactly:
+
+- one verifier AgentPubKey;
+- one private emergency override receipt digest;
+- one public emergency attestation digest;
+- one medication-safety assessment digest;
+- one safety policy digest;
+- one professional authority policy digest;
+- one emergency policy digest;
+- one safety basis;
+- one short validity window.
+
+This is not a reusable emergency role grant.
+
+The root/verifier service is responsible for revalidating the private receipt/evidence before issuing this authorization. The DHT does not pretend to infer a private safety result from a digest it cannot inspect.
+
+## Activation validation
+
+To publish `EmergencyMedicationActivation`, integrity validation requires:
+
+1. the referenced root-issued authorization exists and is valid;
+2. activation author equals the named verifier grantee;
+3. the Holochain activation action timestamp lies inside the authorization window;
+4. the exact public attestation digest matches the authorization;
+5. exact override receipt, safety assessment, safety policy, authority policy, emergency policy, and safety basis all match the root authorization.
+
+Changing any safety-significant field invalidates the authorization.
+
+## No delete-as-revocation assumption
+
+Holochain `must_get_*` does not make later delete/update metadata part of inductive validity. Therefore this design does not rely on deleting verifier authorization records to revoke their past validity.
+
+All emergency trust/evidence entries are append-only. Authorizations are exact-target and short-lived. If a root no longer trusts a verifier, it stops issuing future authorizations.
+
+Emergency medication state itself is ended/corrected with append-only `EmergencyMedicationTermination` events.
+
+## Termination
+
+Termination references:
+
+- exact emergency activation action;
+- exact emergency override receipt digest;
+- typed termination reason;
+- optional commitment to protected rationale.
+
+The activation verifier or a DNA-pinned emergency root can publish a termination. Termination links are append-only.
+
+## Threat model and non-claims
+
+This layer protects against an ordinary/modified coordinator minting an emergency activation without the exact DNA-rooted authorization.
+
+It does not prove that a root authority is operationally uncompromised. Root-key compromise is high impact and production deployments should use strong key custody; threshold/rotation support is a later hardening target.
+
+The DHT does not independently rerun private medical reasoning. It verifies that a deployment-pinned authority approved one exact evidence receipt and public projection.
+
+No emergency activation in this design is represented as `Cleared`.

--- a/zomes/medication_emergency/coordinator/Cargo.toml
+++ b/zomes/medication_emergency/coordinator/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "medication_emergency"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Thin coordinator for emergency medication override activation attestations"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+medication_emergency_integrity = { path = "../integrity" }
+
+[features]
+default = []

--- a/zomes/medication_emergency/coordinator/src/lib.rs
+++ b/zomes/medication_emergency/coordinator/src/lib.rs
@@ -1,0 +1,74 @@
+#![deny(unsafe_code)]
+//! Thin coordinator for emergency medication override activation attestations.
+//!
+//! Clinical/emergency authority is intentionally not implemented here. This zome
+//! only commits and queries entries; the integrity zome independently enforces
+//! DNA-rooted exact-target verifier authorization and append-only lineage.
+
+use hdk::prelude::*;
+use medication_emergency_integrity::*;
+
+#[hdk_extern]
+pub fn issue_emergency_verifier_authorization(
+    authorization: EmergencyMedicationVerifierAuthorization,
+) -> ExternResult<Record> {
+    let hash = create_entry(&EntryTypes::EmergencyMedicationVerifierAuthorization(
+        authorization,
+    ))?;
+    get_required_record(hash)
+}
+
+#[hdk_extern]
+pub fn record_emergency_medication_activation(
+    activation: EmergencyMedicationActivation,
+) -> ExternResult<Record> {
+    let hash = create_entry(&EntryTypes::EmergencyMedicationActivation(activation))?;
+    get_required_record(hash)
+}
+
+#[hdk_extern]
+pub fn terminate_emergency_medication_activation(
+    termination: EmergencyMedicationTermination,
+) -> ExternResult<Record> {
+    let activation_hash = termination.activation_hash.clone();
+    let hash = create_entry(&EntryTypes::EmergencyMedicationTermination(termination))?;
+    create_link(
+        activation_hash,
+        hash.clone(),
+        LinkTypes::ActivationToTerminations,
+        (),
+    )?;
+    get_required_record(hash)
+}
+
+#[hdk_extern]
+pub fn get_emergency_medication_activation(
+    hash: ActionHash,
+) -> ExternResult<Option<Record>> {
+    get(hash, GetOptions::default())
+}
+
+#[hdk_extern]
+pub fn get_emergency_activation_terminations(
+    activation_hash: ActionHash,
+) -> ExternResult<Vec<Record>> {
+    let links = get_links(
+        LinkQuery::try_new(activation_hash, LinkTypes::ActivationToTerminations)?,
+        GetStrategy::default(),
+    )?;
+    let mut records = Vec::with_capacity(links.len());
+    for link in links {
+        if let Some(hash) = link.target.into_action_hash() {
+            if let Some(record) = get(hash, GetOptions::default())? {
+                records.push(record);
+            }
+        }
+    }
+    Ok(records)
+}
+
+fn get_required_record(hash: ActionHash) -> ExternResult<Record> {
+    get(hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed emergency medication record could not be read back".to_string()
+    )))
+}

--- a/zomes/medication_emergency/integrity/Cargo.toml
+++ b/zomes/medication_emergency/integrity/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "medication_emergency_integrity"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "DNA-rooted emergency medication override activation integrity zome"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+mycelix-clinical-integrity = { path = "../../../crates/clinical-integrity" }
+
+[features]
+default = []

--- a/zomes/medication_emergency/integrity/src/lib.rs
+++ b/zomes/medication_emergency/integrity/src/lib.rs
@@ -1,0 +1,555 @@
+#![deny(unsafe_code)]
+#![allow(clippy::collapsible_match)]
+//! DNA-rooted emergency medication override activation integrity zome.
+//!
+//! Emergency medication activation is intentionally a different provenance class
+//! from ordinary qualified medication activation. This zome validates only the
+//! privacy-minimized distributed attestation boundary; it does not re-run private
+//! clinical reasoning or turn uncertainty into `Cleared`.
+//!
+//! A DNA-pinned root issues a short-lived authorization for one exact verifier,
+//! override receipt, public attestation, safety basis, and policy set. Only that
+//! verifier can publish the exact attestation during the authorization window.
+//! All trust/evidence entries are append-only because Holochain `must_get_*` does
+//! not make later delete metadata part of inductive entry validity.
+
+use hdi::prelude::*;
+use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, StoredDigest};
+
+const ROOT_CONFIG_VERSION: u16 = 1;
+const ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS: i64 = 900_000_000; // 15 minutes
+const ATTESTATION_SCHEMA_TAG: &[u8] = b"mycelix-health/emergency-medication-activation-v1";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EmergencyMedicationRootConfig {
+    pub schema_version: u16,
+    pub root_authorities: Vec<AgentPubKey>,
+    pub max_verifier_authorization_duration_micros: i64,
+}
+
+/// Emergency uncertainty basis. There is intentionally no `Cleared` or `Blocked`
+/// variant in this type. Cleared medication belongs on the ordinary qualified path;
+/// known-danger evidence requires a separately designed break-glass path, if any.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum EmergencySafetyBasis {
+    Indeterminate,
+    RequiresReview,
+}
+
+/// Privacy-minimized public statement of one emergency override activation.
+///
+/// Patient identity, medication display text, diagnosis, dosage, laboratory data,
+/// allergy data, and rationale text stay outside this DHT entry. Their exact private
+/// evidence lineage is committed through the receipt/assessment/artifact digests.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct EmergencyMedicationAttestationV1 {
+    pub schema_version: u16,
+    pub activation_id: String,
+    pub medication_artifact_digest: StoredDigest,
+    pub override_receipt_digest: StoredDigest,
+    pub safety_assessment_digest: StoredDigest,
+    pub safety_policy_digest: StoredDigest,
+    pub authority_policy_digest: StoredDigest,
+    pub emergency_policy_digest: StoredDigest,
+    pub safety_basis: EmergencySafetyBasis,
+}
+
+impl EmergencyMedicationAttestationV1 {
+    pub fn validate(&self) -> ExternResult<ValidateCallbackResult> {
+        if self.schema_version != 1 {
+            return invalid("Unsupported emergency medication attestation version");
+        }
+        if self.activation_id.trim().is_empty() {
+            return invalid("Emergency medication activation ID is required");
+        }
+        require_digest_domain(
+            self.medication_artifact_digest,
+            DigestDomain::MedicationRequestArtifact,
+        )?;
+        require_digest_domain(
+            self.override_receipt_digest,
+            DigestDomain::EmergencyMedicationOverrideReceipt,
+        )?;
+        require_digest_domain(
+            self.safety_assessment_digest,
+            DigestDomain::MedicationSafetyAssessment,
+        )?;
+        require_digest_domain(
+            self.safety_policy_digest,
+            DigestDomain::MedicationSafetyPolicy,
+        )?;
+        require_digest_domain(self.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+        require_digest_domain(
+            self.emergency_policy_digest,
+            DigestDomain::EmergencyMedicationOverridePolicy,
+        )?;
+        Ok(ValidateCallbackResult::Valid)
+    }
+
+    pub fn digest(&self) -> ExternResult<StoredDigest> {
+        let shape = self.validate()?;
+        if !matches!(shape, ValidateCallbackResult::Valid) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Cannot hash invalid emergency medication attestation".to_string()
+            )));
+        }
+        let encoded = serde_json::to_vec(self).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Failed to serialize emergency medication attestation: {error}"
+            )))
+        })?;
+        let mut framed = Vec::with_capacity(ATTESTATION_SCHEMA_TAG.len() + 1 + encoded.len());
+        framed.extend_from_slice(ATTESTATION_SCHEMA_TAG);
+        framed.push(0);
+        framed.extend_from_slice(&encoded);
+        Ok(hash_canonical_bytes(
+            DigestDomain::EmergencyMedicationOverrideAttestation,
+            &framed,
+        )
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .stored())
+    }
+}
+
+/// Root-issued authorization for one exact private emergency receipt and one exact
+/// public attestation. This is not a reusable emergency-verifier role.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct EmergencyMedicationVerifierAuthorization {
+    pub authorization_id: String,
+    pub grantee: AgentPubKey,
+    pub override_receipt_digest: StoredDigest,
+    pub emergency_attestation_digest: StoredDigest,
+    pub safety_assessment_digest: StoredDigest,
+    pub safety_policy_digest: StoredDigest,
+    pub authority_policy_digest: StoredDigest,
+    pub emergency_policy_digest: StoredDigest,
+    pub safety_basis: EmergencySafetyBasis,
+    pub valid_from: Timestamp,
+    pub valid_until: Timestamp,
+}
+
+/// Distributed emergency activation. The provenance class is structural: this
+/// cannot be decoded as `QualifiedMedicationActivation` from the ordinary zome.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct EmergencyMedicationActivation {
+    pub attestation: EmergencyMedicationAttestationV1,
+    pub verifier_authorization_hash: ActionHash,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum EmergencyActivationTerminationReason {
+    MedicationStopped,
+    QualifiedActivationSuperseded,
+    SafetyEvidenceResolved,
+    ProfessionalAuthorityRevoked,
+    EnteredInError,
+    Other,
+}
+
+/// Append-only terminal/corrective event for emergency activation state.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct EmergencyMedicationTermination {
+    pub termination_id: String,
+    pub activation_hash: ActionHash,
+    pub override_receipt_digest: StoredDigest,
+    pub reason: EmergencyActivationTerminationReason,
+    /// Commitment to protected rationale when needed. No raw PHI/rationale is
+    /// required on the DHT.
+    pub reason_commitment: Option<[u8; 32]>,
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    EmergencyMedicationVerifierAuthorization(EmergencyMedicationVerifierAuthorization),
+    EmergencyMedicationActivation(EmergencyMedicationActivation),
+    EmergencyMedicationTermination(EmergencyMedicationTermination),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    ActivationToTerminations,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => {
+                validate_create_entry(EntryCreationAction::Create(action), app_entry)
+            }
+            OpEntry::UpdateEntry { .. } => invalid(
+                "Emergency medication trust/evidence entries are append-only and cannot be updated",
+            ),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterUpdate(_) => invalid(
+            "Emergency medication trust/evidence entries are append-only and cannot be updated",
+        ),
+        FlatOp::RegisterDelete(_) => invalid(
+            "Emergency medication trust/evidence entries cannot be deleted; append a termination/correction",
+        ),
+        FlatOp::RegisterCreateLink {
+            link_type,
+            base_address,
+            target_address,
+            action,
+            ..
+        } => validate_create_link(link_type, base_address, target_address, action),
+        FlatOp::RegisterDeleteLink { .. } => invalid(
+            "Emergency medication termination links are append-only and cannot be deleted",
+        ),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_create_entry(
+    action: EntryCreationAction,
+    entry: EntryTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    match entry {
+        EntryTypes::EmergencyMedicationVerifierAuthorization(authorization) => {
+            let shape = validate_authorization_shape(&authorization)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let config = emergency_root_config()?;
+            let root = require_root_authority(action.author(), &config)?;
+            if !matches!(root, ValidateCallbackResult::Valid) {
+                return Ok(root);
+            }
+            validate_authorization_window(action.timestamp(), &authorization, &config)
+        }
+        EntryTypes::EmergencyMedicationActivation(activation) => {
+            let shape = activation.attestation.validate()?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_exact_verifier_authorization(action.author(), action.timestamp(), &activation)
+        }
+        EntryTypes::EmergencyMedicationTermination(termination) => {
+            let shape = validate_termination_shape(&termination)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_termination_authority(action.author(), &termination)
+        }
+    }
+}
+
+fn validate_authorization_shape(
+    authorization: &EmergencyMedicationVerifierAuthorization,
+) -> ExternResult<ValidateCallbackResult> {
+    if authorization.authorization_id.trim().is_empty() {
+        return invalid("Emergency medication verifier authorization ID is required");
+    }
+    require_digest_domain(
+        authorization.override_receipt_digest,
+        DigestDomain::EmergencyMedicationOverrideReceipt,
+    )?;
+    require_digest_domain(
+        authorization.emergency_attestation_digest,
+        DigestDomain::EmergencyMedicationOverrideAttestation,
+    )?;
+    require_digest_domain(
+        authorization.safety_assessment_digest,
+        DigestDomain::MedicationSafetyAssessment,
+    )?;
+    require_digest_domain(
+        authorization.safety_policy_digest,
+        DigestDomain::MedicationSafetyPolicy,
+    )?;
+    require_digest_domain(
+        authorization.authority_policy_digest,
+        DigestDomain::AuthorityPolicy,
+    )?;
+    require_digest_domain(
+        authorization.emergency_policy_digest,
+        DigestDomain::EmergencyMedicationOverridePolicy,
+    )?;
+    if authorization.valid_until <= authorization.valid_from {
+        return invalid("Emergency verifier authorization valid_until must follow valid_from");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_authorization_window(
+    issued_at: Timestamp,
+    authorization: &EmergencyMedicationVerifierAuthorization,
+    config: &EmergencyMedicationRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    let configured_max = config.max_verifier_authorization_duration_micros;
+    if configured_max <= 0 || configured_max > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS {
+        return invalid("DNA emergency medication authorization-duration policy is invalid");
+    }
+    if issued_at < authorization.valid_from || issued_at >= authorization.valid_until {
+        return invalid("Root emergency authorization action timestamp must fall inside its validity window");
+    }
+    let duration = authorization.valid_until.as_micros() as i128
+        - authorization.valid_from.as_micros() as i128;
+    if duration <= 0 || duration > configured_max as i128 {
+        return invalid("Emergency verifier authorization exceeds DNA-pinned maximum duration");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_termination_shape(
+    termination: &EmergencyMedicationTermination,
+) -> ExternResult<ValidateCallbackResult> {
+    if termination.termination_id.trim().is_empty() {
+        return invalid("Emergency medication termination ID is required");
+    }
+    require_digest_domain(
+        termination.override_receipt_digest,
+        DigestDomain::EmergencyMedicationOverrideReceipt,
+    )?;
+    if termination
+        .reason_commitment
+        .is_some_and(|commitment| commitment == [0u8; 32])
+    {
+        return invalid("Emergency termination reason commitment cannot be zero");
+    }
+    if matches!(termination.reason, EmergencyActivationTerminationReason::Other)
+        && termination.reason_commitment.is_none()
+    {
+        return invalid("Other emergency termination reason requires a rationale commitment");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_exact_verifier_authorization(
+    author: &AgentPubKey,
+    activation_timestamp: Timestamp,
+    activation: &EmergencyMedicationActivation,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(activation.verifier_authorization_hash.clone())?;
+    let authorization: EmergencyMedicationVerifierAuthorization =
+        decode_entry(&record, "emergency verifier authorization")?;
+
+    if &authorization.grantee != author {
+        return invalid("Emergency activation author is not the verifier authorization grantee");
+    }
+    if activation_timestamp < authorization.valid_from
+        || activation_timestamp >= authorization.valid_until
+    {
+        return invalid("Emergency activation action timestamp falls outside authorization validity");
+    }
+    let attestation = &activation.attestation;
+    if attestation.override_receipt_digest != authorization.override_receipt_digest {
+        return invalid("Emergency activation receipt does not match root authorization");
+    }
+    let actual_attestation_digest = attestation.digest()?;
+    if actual_attestation_digest != authorization.emergency_attestation_digest {
+        return invalid("Emergency activation payload does not match root-authorized attestation");
+    }
+    if attestation.safety_assessment_digest != authorization.safety_assessment_digest
+        || attestation.safety_policy_digest != authorization.safety_policy_digest
+        || attestation.authority_policy_digest != authorization.authority_policy_digest
+        || attestation.emergency_policy_digest != authorization.emergency_policy_digest
+        || attestation.safety_basis != authorization.safety_basis
+    {
+        return invalid("Emergency activation evidence/policy set does not match root authorization");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_termination_authority(
+    author: &AgentPubKey,
+    termination: &EmergencyMedicationTermination,
+) -> ExternResult<ValidateCallbackResult> {
+    let activation_record = must_get_valid_record(termination.activation_hash.clone())?;
+    let activation: EmergencyMedicationActivation =
+        decode_entry(&activation_record, "emergency medication activation")?;
+    if activation.attestation.override_receipt_digest != termination.override_receipt_digest {
+        return invalid("Emergency termination receipt digest does not match target activation");
+    }
+
+    if activation_record.action().author() == author {
+        return Ok(ValidateCallbackResult::Valid);
+    }
+
+    let config = emergency_root_config()?;
+    require_root_authority(author, &config)
+}
+
+fn validate_create_link(
+    link_type: LinkTypes,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    action: CreateLink,
+) -> ExternResult<ValidateCallbackResult> {
+    match link_type {
+        LinkTypes::ActivationToTerminations => {
+            let activation_hash = require_action_hash(base_address, "emergency activation link base")?;
+            let termination_hash =
+                require_action_hash(target_address, "emergency termination link target")?;
+            let activation_record = must_get_valid_record(activation_hash.clone())?;
+            let activation: EmergencyMedicationActivation =
+                decode_entry(&activation_record, "emergency medication activation")?;
+            let termination_record = must_get_valid_record(termination_hash)?;
+            let termination: EmergencyMedicationTermination =
+                decode_entry(&termination_record, "emergency medication termination")?;
+            if termination.activation_hash != activation_hash
+                || termination.override_receipt_digest
+                    != activation.attestation.override_receipt_digest
+            {
+                return invalid(
+                    "Emergency activation-termination link references another activation lineage",
+                );
+            }
+            if termination_record.action().author() != &action.author {
+                return invalid("Emergency termination link must be authored by termination author");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+    }
+}
+
+fn emergency_root_config() -> ExternResult<EmergencyMedicationRootConfig> {
+    let info = dna_info()?;
+    parse_emergency_root_config(info.modifiers.properties.bytes())
+}
+
+fn parse_emergency_root_config(bytes: &[u8]) -> ExternResult<EmergencyMedicationRootConfig> {
+    let properties: serde_json::Value = serde_json::from_slice(bytes).map_err(|error| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "DNA properties are not valid JSON for emergency medication activation: {error}"
+        )))
+    })?;
+    let value = properties.get("medication_emergency").ok_or(wasm_error!(
+        WasmErrorInner::Guest(
+            "DNA properties do not configure medication_emergency trust roots".to_string()
+        )
+    ))?;
+    let config: EmergencyMedicationRootConfig =
+        serde_json::from_value(value.clone()).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Invalid medication_emergency DNA properties: {error}"
+            )))
+        })?;
+    if config.schema_version != ROOT_CONFIG_VERSION {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Unsupported medication_emergency root config version {}",
+            config.schema_version
+        ))));
+    }
+    if config.max_verifier_authorization_duration_micros <= 0
+        || config.max_verifier_authorization_duration_micros
+            > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS
+    {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Medication emergency authorization duration must be positive and no more than 15 minutes"
+                .to_string()
+        )));
+    }
+    Ok(config)
+}
+
+fn require_root_authority(
+    author: &AgentPubKey,
+    config: &EmergencyMedicationRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    if !config.root_authorities.contains(author) {
+        return invalid(
+            "Emergency medication verifier authorization/termination requires a DNA-pinned root authority",
+        );
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_digest_domain(digest: StoredDigest, expected: DigestDomain) -> ExternResult<()> {
+    digest
+        .validate_shape()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+    if digest.domain != expected {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Emergency medication digest domain mismatch: expected {expected:?}, got {:?}",
+            digest.domain
+        ))));
+    }
+    Ok(())
+}
+
+fn require_action_hash(hash: AnyLinkableHash, field: &'static str) -> ExternResult<ActionHash> {
+    hash.into_action_hash().ok_or(wasm_error!(WasmErrorInner::Guest(
+        format!("{field} must be an ActionHash")
+    )))
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_integrity::DigestAlgorithm;
+
+    fn stored(domain: DigestDomain, seed: u8) -> StoredDigest {
+        StoredDigest {
+            algorithm: DigestAlgorithm::Blake3_256,
+            domain,
+            value: [seed; 32],
+        }
+    }
+
+    fn attestation() -> EmergencyMedicationAttestationV1 {
+        EmergencyMedicationAttestationV1 {
+            schema_version: 1,
+            activation_id: "emergency-1".into(),
+            medication_artifact_digest: stored(DigestDomain::MedicationRequestArtifact, 1),
+            override_receipt_digest: stored(DigestDomain::EmergencyMedicationOverrideReceipt, 2),
+            safety_assessment_digest: stored(DigestDomain::MedicationSafetyAssessment, 3),
+            safety_policy_digest: stored(DigestDomain::MedicationSafetyPolicy, 4),
+            authority_policy_digest: stored(DigestDomain::AuthorityPolicy, 5),
+            emergency_policy_digest: stored(DigestDomain::EmergencyMedicationOverridePolicy, 6),
+            safety_basis: EmergencySafetyBasis::Indeterminate,
+        }
+    }
+
+    #[test]
+    fn valid_attestation_has_dedicated_domain() {
+        let digest = attestation().digest().unwrap();
+        assert_eq!(
+            digest.domain,
+            DigestDomain::EmergencyMedicationOverrideAttestation
+        );
+    }
+
+    #[test]
+    fn ordinary_activation_receipt_cannot_substitute_for_emergency_receipt() {
+        let mut value = attestation();
+        value.override_receipt_digest = stored(DigestDomain::MedicationActivationReceipt, 2);
+        assert!(value.digest().is_err());
+    }
+
+    #[test]
+    fn root_config_rejects_duration_over_absolute_cap() {
+        let bytes = serde_json::to_vec(&serde_json::json!({
+            "medication_emergency": {
+                "schema_version": 1,
+                "root_authorities": [],
+                "max_verifier_authorization_duration_micros": 900000001_i64
+            }
+        }))
+        .unwrap();
+        assert!(parse_emergency_root_config(&bytes).is_err());
+    }
+}


### PR DESCRIPTION
## Stack

Depends on #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

Advances the DHT/runtime portion of P0 #50.

## Why

An emergency medication override must remain distinguishable from ordinary qualified activation at every layer. Treating both as a shared `active=true` record would erase whether care proceeded with fully cleared safety evidence or under explicitly documented uncertainty.

## Structural separation

Adds a separate `medication_emergency` integrity/coordinator zome pair rather than extending `medication_activation` with an emergency flag.

The public state type is `EmergencyMedicationActivation`, not `QualifiedMedicationActivation`.

`EmergencySafetyBasis` contains only:

- `Indeterminate`
- `RequiresReview`

There is deliberately no `Cleared` or `Blocked` variant. Cleared medication belongs on the ordinary qualified path; known-danger evidence requires a separately designed stronger break-glass path if clinically justified.

## Privacy-minimized attestation

`EmergencyMedicationAttestationV1` carries only opaque activation/evidence/policy digests plus the emergency safety basis. It requires no patient identity, medication name, diagnosis, dosage, allergies, labs, or rationale text on the DHT.

A dedicated `EmergencyMedicationOverrideAttestation` digest domain prevents ordinary/other clinical payloads from substituting for this provenance class.

## Separate DNA trust root

Adds independent DNA properties:

```yaml
medication_emergency:
  schema_version: 1
  root_authorities: []
  max_verifier_authorization_duration_micros: 900000000
```

The empty root set intentionally disables emergency activation by default. Deployments must deliberately repack the DNA with trusted emergency root keys. Ordinary medication-activation roots do not automatically receive emergency authority.

## Exact-target authorization

A DNA-pinned emergency root may authorize exactly:

- one verifier AgentPubKey;
- one emergency override receipt digest;
- one public emergency attestation digest;
- one medication-safety assessment digest;
- one safety-policy digest;
- one professional-authority policy digest;
- one emergency-policy digest;
- one `Indeterminate`/`RequiresReview` basis;
- one short validity window.

The integrity zome hard-caps v1 authorization lifetime at 15 minutes; the packaged value may be shorter.

The activation action timestamp, not request-controlled time, must fall inside the window.

## Private-evidence trust boundary

The DHT does not pretend it can derive a safety outcome from a private receipt digest. The root/verifier service must revalidate the protected emergency receipt/evidence before issuing the exact authorization. The DHT then proves that this exact receipt/projection/policy set was approved by the deployment-pinned trust root.

## Append-only correction

All emergency trust/evidence entries are non-updatable/non-deletable. Emergency activation ends through `EmergencyMedicationTermination`, which binds the exact activation and exact override receipt digest with a typed reason and optional protected-rationale commitment.

No delete-as-revocation assumption is made.

## Future read-model invariant

Any combined active-medication view must preserve provenance, e.g.:

```text
MedicationActivationState::Qualified(...)
MedicationActivationState::EmergencyOverride(...)
```

It must never flatten these into an unaudited boolean.

## Qualification required

Draft until exact-head CI + conductor tests prove at least:

- empty emergency roots fail closed;
- ordinary activation roots do not confer emergency authority;
- non-root cannot issue verifier authorization;
- wrong verifier cannot publish activation;
- receipt/attestation/assessment/policy/basis substitution fails;
- action outside authorization window fails;
- update/delete attempts fail;
- malformed/forged termination fails;
- modified coordinator cannot directly commit around integrity validation.

## Non-claims

This does not make a serialized emergency receipt inherently trusted, does not re-run private medical reasoning on the DHT, and does not make `Blocked` evidence overridable. It also does not yet replace the legacy prescriptions API's misleading `Safe` reporting paths tracked in #50.