### PR TITLE
security(dispense): add DNA-pinned refill-slot adjudication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ members = [
     "zomes/medication_activation/coordinator",
     "zomes/medication_emergency/integrity",
     "zomes/medication_emergency/coordinator",
+    "zomes/medication_dispense/integrity",
+    "zomes/medication_dispense/coordinator",
     "zomes/consent/integrity",
     "zomes/consent/coordinator",
     "zomes/bridge/integrity",

--- a/crates/medication-dispensing/tests/adversarial.rs
+++ b/crates/medication-dispensing/tests/adversarial.rs
@@ -4,8 +4,8 @@ use mycelix_clinical_integrity::{
     hash_canonical_bytes, DigestAlgorithm, DigestDomain, StoredDigest,
 };
 use mycelix_medication_activation_state::{
-    CurrentActivation, CurrentActivationState, LegacyPrescriptionRecord, LegacyPrescriptionStatus,
-    MedicationActivationView, QualifiedActivationLineage, ActivationLifecycle,
+    ActivationLifecycle, CurrentActivation, CurrentActivationState, LegacyPrescriptionRecord,
+    LegacyPrescriptionStatus, MedicationActivationView, QualifiedActivationLineage,
 };
 use mycelix_medication_dispensing::{
     resolve_current_activation_for_dispense, DispenseError, DispenseLedgerSnapshotV1,
@@ -126,21 +126,18 @@ fn pharmacy_context_requires_domain_specific_evidence() {
         10,
     );
 
-    assert!(matches!(
-        result,
-        Err(DispenseError::Integrity(_))
-    ));
+    assert!(matches!(result, Err(DispenseError::Integrity(_))));
 }
 
 #[test]
-fn duplicate_prior_receipt_cannot_fill_two_slots() {
+fn duplicate_prior_final_receipt_cannot_fill_two_slots() {
     let medication = verified(DigestDomain::MedicationRequestArtifact, 1);
     let activation = stored(DigestDomain::MedicationActivationReceipt, 2);
     let receipt = verified(DigestDomain::MedicationDispenseReceipt, 3);
-    let first = PriorDispenseEvidence::from_verified_receipt(0, receipt).unwrap();
-    let replay = PriorDispenseEvidence::from_verified_receipt(1, receipt).unwrap();
+    let first = PriorDispenseEvidence::from_verified_final_receipt(0, receipt).unwrap();
+    let replay = PriorDispenseEvidence::from_verified_final_receipt(1, receipt).unwrap();
 
-    let result = DispenseLedgerSnapshotV1::from_verified_receipts(
+    let result = DispenseLedgerSnapshotV1::from_verified_final_receipts(
         medication,
         activation,
         vec![first, replay],

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -22,6 +22,15 @@ integrity:
       # Exact-receipt emergency verifier authorizations are also capped at 15 minutes.
       # Deployments may choose a shorter value when repacking the DNA.
       max_verifier_authorization_duration_micros: 900000000
+    medication_dispense:
+      schema_version: 1
+      # Fail closed by default. Deployments must explicitly pin allocator AgentPubKeys.
+      # The ordered list is part of the DNA hash; each MedicationRequest artifact maps
+      # deterministically to exactly one allocator by digest prefix modulo list length.
+      slot_allocators: []
+      # Exact refill-slot authorizations are short-lived and hard-capped by the
+      # integrity zome at five minutes. Deployments may choose a shorter value.
+      max_slot_authorization_duration_micros: 300000000
   zomes:
     # Tier 1: MVP Core
     - name: patient_integrity
@@ -36,6 +45,8 @@ integrity:
       path: ../target/wasm32-unknown-unknown/release/medication_activation_integrity.wasm
     - name: medication_emergency_integrity
       path: ../target/wasm32-unknown-unknown/release/medication_emergency_integrity.wasm
+    - name: medication_dispense_integrity
+      path: ../target/wasm32-unknown-unknown/release/medication_dispense_integrity.wasm
     - name: consent_integrity
       path: ../target/wasm32-unknown-unknown/release/consent_integrity.wasm
     - name: bridge_integrity
@@ -70,6 +81,10 @@ coordinator:
       path: ../target/wasm32-unknown-unknown/release/medication_emergency.wasm
       dependencies:
         - name: medication_emergency_integrity
+    - name: medication_dispense
+      path: ../target/wasm32-unknown-unknown/release/medication_dispense.wasm
+      dependencies:
+        - name: medication_dispense_integrity
     - name: consent
       path: ../target/wasm32-unknown-unknown/release/consent.wasm
       dependencies:

--- a/docs/security/MEDICATION_DISPENSE_SLOT_ADJUDICATION_V1.md
+++ b/docs/security/MEDICATION_DISPENSE_SLOT_ADJUDICATION_V1.md
@@ -1,0 +1,140 @@
+# Medication Dispense Slot Adjudication v1
+
+## Purpose
+
+A dispense preflight proves local clinical/authority/evidence coherence. It does not prove exclusive ownership of a refill slot.
+
+This tranche adds the first runtime serialization boundary for that scarce resource.
+
+## Why DHT observation is not a lock
+
+Holochain provides agent-local atomic source-chain transactions and deterministic DHT validation, but validators do not share one globally linearizable database view. A validation rule that asks "does no competing slot record exist anywhere?" is therefore not a sound uniqueness primitive.
+
+Holochain countersigning is also not treated as a double-spend oracle. The upstream documentation explicitly distinguishes atomic multi-party agreement from prevention of double spending. Countersigning is additionally behind the unstable-countersigning feature in the Holochain 0.6.x line used by this workspace.
+
+V1 therefore does not make countersigning a safety-critical dependency.
+
+## V1 model: deterministic narrow allocator
+
+DNA properties contain an ordered set of allocator AgentPubKeys:
+
+```yaml
+medication_dispense:
+  schema_version: 1
+  slot_allocators: []
+  max_slot_authorization_duration_micros: 300000000
+```
+
+The empty set intentionally disables finalized dispensing.
+
+When configured, a MedicationRequest artifact selects exactly one allocator by:
+
+1. validating the digest as `MedicationRequestArtifact`;
+2. reading the first eight digest bytes as big-endian `u64`;
+3. taking modulo the DNA-pinned allocator-list length.
+
+The allocator-list ordering is part of DNA properties and therefore part of the DNA hash.
+
+This serializes only one medication-order/refill lineage at a time. It does not introduce a global healthcare lock.
+
+## Exact one-shot authorization
+
+`MedicationDispenseSlotAuthorization` is short-lived and bound to:
+
+- one allocator-selected medication artifact;
+- one activation semantic receipt;
+- one activation-state snapshot digest;
+- one dispense request;
+- one dispense preflight receipt;
+- one slot index;
+- one pharmacist AgentPubKey;
+- one private pharmacist-principal binding;
+- one pharmacy record/affiliation/status evidence set;
+- one authority policy;
+- one dispense policy;
+- one exact final semantic receipt digest;
+- one validity window of at most five minutes.
+
+The final dispense action timestamp must fall inside that window.
+
+## Refill continuity
+
+Slot 0 has no predecessor.
+
+Slot N>0 must reference a DHT-valid `FinalizedMedicationDispense` for slot N-1 with the same medication artifact and activation semantic receipt.
+
+This prevents a valid allocator from skipping over missing finalized slots or moving a prior dispense from another medication lineage into the chain.
+
+## Finalization
+
+`FinalizedMedicationDispense` is authored by the pharmacist AgentPubKey named as the authorization grantee. Its privacy-minimized attestation must hash to the exact `MedicationDispenseReceipt` authorized by the allocator and must reproduce the exact evidence/policy/slot fields from the authorization.
+
+The final receipt attestation does not duplicate medication name, diagnosis, dose instructions, patient identity, or other raw PHI. Those details remain committed through the request/preflight/artifact digests.
+
+A final receipt, unlike a preflight receipt, can be counted as a consumed slot by later dispense-ledger snapshots.
+
+## Allocator equivocation
+
+V1 makes an explicit trust assumption: the selected allocator is expected not to authorize two incompatible outcomes for the same semantic refill slot.
+
+If that assumption is violated, `AllocatorEquivocationEvidence` can reference two DHT-valid slot authorizations. Validation independently verifies that both were authored by the same DNA-selected allocator and target the same medication + activation + slot while carrying conflicting authorization payloads.
+
+This provides objective, append-only evidence of allocator misbehavior.
+
+It does **not** prove that a conflicting physical release could not happen before the conflict propagated. That is a v1 non-claim.
+
+## Safety / availability tradeoff
+
+V1 intentionally chooses a small CP-like dependency for a very narrow scarce resource:
+
+- when the selected allocator is reachable and non-equivocating, a refill slot can be serialized;
+- when it is unavailable, final dispensing should fail closed or enter a separately designed emergency/manual process;
+- another allocator does not automatically take over, because automatic failover without consensus can recreate the double-allocation problem.
+
+Future availability work can add controlled allocator rotation or threshold witnessing, but it must preserve one authoritative slot decision per medication lineage.
+
+## Why not unstable countersigning in v1
+
+Countersigning could later be useful for pharmacist + allocator co-commitment or optional majority witnesses, but it is not the uniqueness primitive in v1 because:
+
+- the current upstream feature is unstable;
+- ordinary countersigning does not itself prevent double spending;
+- optional witness/lightweight-consensus designs need their own liveness and failure analysis.
+
+## Append-only model
+
+Slot authorizations, finalized dispenses, and equivocation evidence are append-only. Updates/deletes are rejected by integrity validation.
+
+V1 intentionally defines no discovery links. Privacy-safe discovery and a canonical dispense read model should be reviewed separately instead of leaking patient-medication relationships through convenient global indexes.
+
+## Threat model / non-claims
+
+V1 does not claim safety against a fully compromised selected allocator that intentionally equivocated before detection. It also does not claim that software can prevent a malicious pharmacy from physically handing out medication twice outside the system.
+
+It does establish:
+
+- deterministic allocator responsibility;
+- no request-selected allocator;
+- exact-target short-lived authorization;
+- pharmacist-authored finalization;
+- predecessor refill continuity;
+- cryptographic separation of preflight vs slot authorization vs final receipt;
+- objective allocator-equivocation evidence;
+- fail-closed default deployment configuration.
+
+## Qualification required
+
+Before promotion, exact-head CI and conductor tests should prove:
+
+- empty allocator configuration disables slot authorization;
+- wrong allocator cannot authorize a slot;
+- deterministic allocator selection is stable for fixed DNA properties;
+- slot 0 rejects a predecessor;
+- slot N>0 requires finalized N-1 in the same medication/activation lineage;
+- wrong pharmacist cannot finalize;
+- stale authorization cannot finalize;
+- request/preflight/policy/pharmacy/slot substitution fails;
+- finalized receipt digest must exactly match authorization;
+- update/delete attempts fail;
+- conflicting same-slot authorizations generate verifiable equivocation evidence;
+- modified coordinators cannot bypass the integrity rules.

--- a/zomes/medication_dispense/coordinator/Cargo.toml
+++ b/zomes/medication_dispense/coordinator/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "medication_dispense"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Coordinator for exact refill-slot authorization and finalized medication dispense receipts"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { workspace = true }
+serde = { workspace = true }
+medication_dispense_integrity = { path = "../integrity" }
+
+[features]
+default = []

--- a/zomes/medication_dispense/coordinator/src/lib.rs
+++ b/zomes/medication_dispense/coordinator/src/lib.rs
@@ -1,0 +1,31 @@
+#![deny(unsafe_code)]
+//! Thin coordinator for medication dispense slot adjudication.
+//!
+//! Authorization lives in the integrity zome. These functions intentionally do not
+//! duplicate trust checks that a modified coordinator could bypass.
+
+use hdk::prelude::*;
+pub use medication_dispense_integrity::*;
+
+#[hdk_extern]
+pub fn issue_dispense_slot_authorization(
+    authorization: MedicationDispenseSlotAuthorization,
+) -> ExternResult<ActionHash> {
+    create_entry(EntryTypes::MedicationDispenseSlotAuthorization(
+        authorization,
+    ))
+}
+
+#[hdk_extern]
+pub fn finalize_medication_dispense(
+    finalized: FinalizedMedicationDispense,
+) -> ExternResult<ActionHash> {
+    create_entry(EntryTypes::FinalizedMedicationDispense(finalized))
+}
+
+#[hdk_extern]
+pub fn report_allocator_equivocation(
+    evidence: AllocatorEquivocationEvidence,
+) -> ExternResult<ActionHash> {
+    create_entry(EntryTypes::AllocatorEquivocationEvidence(evidence))
+}

--- a/zomes/medication_dispense/integrity/Cargo.toml
+++ b/zomes/medication_dispense/integrity/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "medication_dispense_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "DNA-pinned refill-slot adjudication and finalized medication dispense integrity zome"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+mycelix-clinical-integrity = { path = "../../../crates/clinical-integrity" }
+
+[features]
+default = []

--- a/zomes/medication_dispense/integrity/src/lib.rs
+++ b/zomes/medication_dispense/integrity/src/lib.rs
@@ -1,0 +1,676 @@
+#![deny(unsafe_code)]
+#![allow(clippy::collapsible_match)]
+//! DNA-pinned refill-slot adjudication and finalized medication dispense integrity.
+//!
+//! Holochain DHT visibility is not treated as a linearizable lock. Instead, each
+//! medication artifact deterministically maps to one allocator AgentPubKey pinned in
+//! DNA properties. That allocator may issue a short-lived authorization for one exact
+//! preflight, one exact refill slot, one exact pharmacist, and one exact final receipt.
+//!
+//! This gives strong serialization under the explicit non-equivocating allocator
+//! assumption. If an allocator issues conflicting authorizations for the same semantic
+//! slot, anyone may publish objective `AllocatorEquivocationEvidence` referencing both
+//! records. V1 detects that Byzantine failure; it does not claim to prevent a
+//! compromised allocator from signing conflicting authorizations before detection.
+
+use hdi::prelude::*;
+use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, StoredDigest};
+
+const CONFIG_VERSION: u16 = 1;
+const ENTRY_SCHEMA_VERSION: u16 = 1;
+const ABSOLUTE_MAX_SLOT_AUTHORIZATION_MICROS: i64 = 300_000_000; // 5 minutes
+const FINAL_RECEIPT_SCHEMA_TAG: &[u8] = b"mycelix-health/final-medication-dispense-v1";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MedicationDispenseRootConfig {
+    pub schema_version: u16,
+    /// Ordered allocator set. The exact order is part of DNA properties and therefore
+    /// part of the DNA hash. One medication artifact deterministically selects one key.
+    pub slot_allocators: Vec<AgentPubKey>,
+    pub max_slot_authorization_duration_micros: i64,
+}
+
+/// Privacy-minimized final dispense receipt payload. Clinical/product/quantity details
+/// remain bound through the exact request + preflight digests rather than duplicated.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct MedicationDispenseFinalAttestationV1 {
+    pub schema_version: u16,
+    pub dispense_id: String,
+    pub medication_artifact_digest: StoredDigest,
+    pub activation_semantic_receipt_digest: StoredDigest,
+    pub activation_state_digest: StoredDigest,
+    pub dispense_request_digest: StoredDigest,
+    pub preflight_receipt_digest: StoredDigest,
+    pub slot_index: u32,
+    /// Binding produced by the private clinical-authority layer. The DHT additionally
+    /// requires the final action author to equal the authorization grantee AgentPubKey.
+    pub pharmacist_principal_binding: [u8; 32],
+    pub pharmacy_record_digest: StoredDigest,
+    pub pharmacy_affiliation_evidence_digest: StoredDigest,
+    pub pharmacy_status_evidence_digest: StoredDigest,
+    pub authority_policy_digest: StoredDigest,
+    pub dispense_policy_digest: StoredDigest,
+}
+
+impl MedicationDispenseFinalAttestationV1 {
+    pub fn validate(&self) -> ExternResult<ValidateCallbackResult> {
+        if self.schema_version != ENTRY_SCHEMA_VERSION {
+            return invalid("Unsupported finalized medication dispense attestation version");
+        }
+        if self.dispense_id.trim().is_empty() {
+            return invalid("Finalized medication dispense ID is required");
+        }
+        if self.pharmacist_principal_binding == [0u8; 32] {
+            return invalid("Finalized medication dispense pharmacist principal binding cannot be zero");
+        }
+        require_digest_domain(
+            self.medication_artifact_digest,
+            DigestDomain::MedicationRequestArtifact,
+        )?;
+        require_activation_receipt_domain(self.activation_semantic_receipt_digest)?;
+        require_digest_domain(
+            self.activation_state_digest,
+            DigestDomain::MedicationActivationState,
+        )?;
+        require_digest_domain(
+            self.dispense_request_digest,
+            DigestDomain::MedicationDispenseRequest,
+        )?;
+        require_digest_domain(
+            self.preflight_receipt_digest,
+            DigestDomain::MedicationDispensePreflightReceipt,
+        )?;
+        require_digest_domain(self.pharmacy_record_digest, DigestDomain::PharmacyRecord)?;
+        require_digest_domain(
+            self.pharmacy_affiliation_evidence_digest,
+            DigestDomain::PharmacyAffiliationEvidence,
+        )?;
+        require_digest_domain(
+            self.pharmacy_status_evidence_digest,
+            DigestDomain::PharmacyStatusEvidence,
+        )?;
+        require_digest_domain(self.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+        require_digest_domain(
+            self.dispense_policy_digest,
+            DigestDomain::MedicationDispensePolicy,
+        )?;
+        Ok(ValidateCallbackResult::Valid)
+    }
+
+    /// Semantic finalized-dispense identity. Duplicate DHT publications of this exact
+    /// attestation are one idempotent clinical dispense event in later read models.
+    pub fn receipt_digest(&self) -> ExternResult<StoredDigest> {
+        let shape = self.validate()?;
+        if !matches!(shape, ValidateCallbackResult::Valid) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Cannot hash invalid finalized medication dispense attestation".to_string()
+            )));
+        }
+        let encoded = serde_json::to_vec(self).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Failed to serialize finalized medication dispense attestation: {error}"
+            )))
+        })?;
+        let mut framed = Vec::with_capacity(FINAL_RECEIPT_SCHEMA_TAG.len() + 1 + encoded.len());
+        framed.extend_from_slice(FINAL_RECEIPT_SCHEMA_TAG);
+        framed.push(0);
+        framed.extend_from_slice(&encoded);
+        Ok(hash_canonical_bytes(DigestDomain::MedicationDispenseReceipt, &framed)
+            .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+            .stored())
+    }
+}
+
+/// Exact, short-lived authorization issued by the deterministic allocator selected for
+/// this medication artifact. This is not a reusable pharmacy or pharmacist role.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct MedicationDispenseSlotAuthorization {
+    pub schema_version: u16,
+    pub authorization_id: String,
+    pub grantee: AgentPubKey,
+    pub medication_artifact_digest: StoredDigest,
+    pub activation_semantic_receipt_digest: StoredDigest,
+    pub activation_state_digest: StoredDigest,
+    pub dispense_request_digest: StoredDigest,
+    pub preflight_receipt_digest: StoredDigest,
+    pub slot_index: u32,
+    /// Slot N>0 must reference a finalized dispense for slot N-1 in the same lineage.
+    pub previous_final_dispense_hash: Option<ActionHash>,
+    pub pharmacist_principal_binding: [u8; 32],
+    pub pharmacy_record_digest: StoredDigest,
+    pub pharmacy_affiliation_evidence_digest: StoredDigest,
+    pub pharmacy_status_evidence_digest: StoredDigest,
+    pub authority_policy_digest: StoredDigest,
+    pub dispense_policy_digest: StoredDigest,
+    /// Exact semantic receipt the grantee is allowed to publish.
+    pub final_receipt_digest: StoredDigest,
+    pub valid_from: Timestamp,
+    pub valid_until: Timestamp,
+}
+
+/// Pharmacist-authored finalization of one exact allocator-authorized slot.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct FinalizedMedicationDispense {
+    pub attestation: MedicationDispenseFinalAttestationV1,
+    pub slot_authorization_hash: ActionHash,
+}
+
+/// Objective proof that one allocator issued two different authorizations for the
+/// same medication + activation lineage + refill slot.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct AllocatorEquivocationEvidence {
+    pub evidence_id: String,
+    pub left_authorization_hash: ActionHash,
+    pub right_authorization_hash: ActionHash,
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    MedicationDispenseSlotAuthorization(MedicationDispenseSlotAuthorization),
+    FinalizedMedicationDispense(FinalizedMedicationDispense),
+    AllocatorEquivocationEvidence(AllocatorEquivocationEvidence),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => {
+                validate_create_entry(EntryCreationAction::Create(action), app_entry)
+            }
+            OpEntry::UpdateEntry { .. } => invalid(
+                "Medication dispense adjudication/finalization records are append-only",
+            ),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterUpdate(_) => invalid(
+            "Medication dispense adjudication/finalization records cannot be updated",
+        ),
+        FlatOp::RegisterDelete(_) => invalid(
+            "Medication dispense adjudication/finalization records cannot be deleted",
+        ),
+        FlatOp::RegisterCreateLink { .. } | FlatOp::RegisterDeleteLink { .. } => {
+            invalid("Medication dispense v1 defines no DHT link surface")
+        }
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_create_entry(
+    action: EntryCreationAction,
+    entry: EntryTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    match entry {
+        EntryTypes::MedicationDispenseSlotAuthorization(authorization) => {
+            let shape = validate_slot_authorization_shape(&authorization)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let config = dispense_root_config()?;
+            let allocator = selected_allocator(&config, authorization.medication_artifact_digest)?;
+            if action.author() != &allocator {
+                return invalid(
+                    "Refill-slot authorization author is not the DNA-selected allocator for this medication",
+                );
+            }
+            let window = validate_authorization_window(action.timestamp(), &authorization, &config)?;
+            if !matches!(window, ValidateCallbackResult::Valid) {
+                return Ok(window);
+            }
+            validate_previous_final_dispense(&authorization)
+        }
+        EntryTypes::FinalizedMedicationDispense(finalized) => {
+            let shape = finalized.attestation.validate()?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_exact_slot_authorization(action.author(), action.timestamp(), &finalized)
+        }
+        EntryTypes::AllocatorEquivocationEvidence(evidence) => {
+            validate_allocator_equivocation(&evidence)
+        }
+    }
+}
+
+fn validate_slot_authorization_shape(
+    authorization: &MedicationDispenseSlotAuthorization,
+) -> ExternResult<ValidateCallbackResult> {
+    if authorization.schema_version != ENTRY_SCHEMA_VERSION {
+        return invalid("Unsupported medication dispense slot authorization version");
+    }
+    if authorization.authorization_id.trim().is_empty() {
+        return invalid("Medication dispense slot authorization ID is required");
+    }
+    if authorization.pharmacist_principal_binding == [0u8; 32] {
+        return invalid("Slot authorization pharmacist principal binding cannot be zero");
+    }
+    require_digest_domain(
+        authorization.medication_artifact_digest,
+        DigestDomain::MedicationRequestArtifact,
+    )?;
+    require_activation_receipt_domain(authorization.activation_semantic_receipt_digest)?;
+    require_digest_domain(
+        authorization.activation_state_digest,
+        DigestDomain::MedicationActivationState,
+    )?;
+    require_digest_domain(
+        authorization.dispense_request_digest,
+        DigestDomain::MedicationDispenseRequest,
+    )?;
+    require_digest_domain(
+        authorization.preflight_receipt_digest,
+        DigestDomain::MedicationDispensePreflightReceipt,
+    )?;
+    require_digest_domain(authorization.pharmacy_record_digest, DigestDomain::PharmacyRecord)?;
+    require_digest_domain(
+        authorization.pharmacy_affiliation_evidence_digest,
+        DigestDomain::PharmacyAffiliationEvidence,
+    )?;
+    require_digest_domain(
+        authorization.pharmacy_status_evidence_digest,
+        DigestDomain::PharmacyStatusEvidence,
+    )?;
+    require_digest_domain(authorization.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+    require_digest_domain(
+        authorization.dispense_policy_digest,
+        DigestDomain::MedicationDispensePolicy,
+    )?;
+    require_digest_domain(
+        authorization.final_receipt_digest,
+        DigestDomain::MedicationDispenseReceipt,
+    )?;
+    if authorization.valid_until <= authorization.valid_from {
+        return invalid("Slot authorization valid_until must follow valid_from");
+    }
+    match (authorization.slot_index, &authorization.previous_final_dispense_hash) {
+        (0, None) => {}
+        (0, Some(_)) => {
+            return invalid("Initial dispense slot must not reference a previous finalized dispense")
+        }
+        (_, None) => {
+            return invalid("Refill slot requires the immediately previous finalized dispense")
+        }
+        (_, Some(_)) => {}
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_authorization_window(
+    issued_at: Timestamp,
+    authorization: &MedicationDispenseSlotAuthorization,
+    config: &MedicationDispenseRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    let configured_max = config.max_slot_authorization_duration_micros;
+    if configured_max <= 0 || configured_max > ABSOLUTE_MAX_SLOT_AUTHORIZATION_MICROS {
+        return invalid("DNA dispense slot authorization-duration policy is invalid");
+    }
+    if issued_at < authorization.valid_from || issued_at >= authorization.valid_until {
+        return invalid("Allocator authorization action timestamp must fall inside validity window");
+    }
+    let duration = authorization.valid_until.as_micros() as i128
+        - authorization.valid_from.as_micros() as i128;
+    if duration <= 0 || duration > configured_max as i128 {
+        return invalid("Refill-slot authorization exceeds DNA-pinned maximum duration");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_previous_final_dispense(
+    authorization: &MedicationDispenseSlotAuthorization,
+) -> ExternResult<ValidateCallbackResult> {
+    if authorization.slot_index == 0 {
+        return Ok(ValidateCallbackResult::Valid);
+    }
+    let previous_hash = authorization
+        .previous_final_dispense_hash
+        .clone()
+        .ok_or(wasm_error!(WasmErrorInner::Guest(
+            "Refill slot is missing previous finalized dispense hash".to_string()
+        )))?;
+    let record = must_get_valid_record(previous_hash)?;
+    let previous: FinalizedMedicationDispense = decode_entry(&record, "previous finalized dispense")?;
+    let previous_slot = previous
+        .attestation
+        .slot_index
+        .checked_add(1)
+        .ok_or(wasm_error!(WasmErrorInner::Guest(
+            "Previous finalized dispense slot index overflow".to_string()
+        )))?;
+    if previous_slot != authorization.slot_index {
+        return invalid("Refill authorization does not immediately follow previous finalized slot");
+    }
+    if previous.attestation.medication_artifact_digest != authorization.medication_artifact_digest
+        || previous.attestation.activation_semantic_receipt_digest
+            != authorization.activation_semantic_receipt_digest
+    {
+        return invalid("Previous finalized dispense belongs to another medication activation lineage");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_exact_slot_authorization(
+    author: &AgentPubKey,
+    finalized_at: Timestamp,
+    finalized: &FinalizedMedicationDispense,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(finalized.slot_authorization_hash.clone())?;
+    let authorization: MedicationDispenseSlotAuthorization =
+        decode_entry(&record, "medication dispense slot authorization")?;
+
+    if &authorization.grantee != author {
+        return invalid("Finalized dispense author is not the slot authorization grantee");
+    }
+    if finalized_at < authorization.valid_from || finalized_at >= authorization.valid_until {
+        return invalid("Finalized dispense action timestamp falls outside slot authorization window");
+    }
+    let actual_receipt_digest = finalized.attestation.receipt_digest()?;
+    if actual_receipt_digest != authorization.final_receipt_digest {
+        return invalid("Finalized dispense payload does not match allocator-authorized receipt");
+    }
+    if finalized.attestation.medication_artifact_digest != authorization.medication_artifact_digest
+        || finalized.attestation.activation_semantic_receipt_digest
+            != authorization.activation_semantic_receipt_digest
+        || finalized.attestation.activation_state_digest != authorization.activation_state_digest
+        || finalized.attestation.dispense_request_digest != authorization.dispense_request_digest
+        || finalized.attestation.preflight_receipt_digest != authorization.preflight_receipt_digest
+        || finalized.attestation.slot_index != authorization.slot_index
+        || finalized.attestation.pharmacist_principal_binding
+            != authorization.pharmacist_principal_binding
+        || finalized.attestation.pharmacy_record_digest != authorization.pharmacy_record_digest
+        || finalized.attestation.pharmacy_affiliation_evidence_digest
+            != authorization.pharmacy_affiliation_evidence_digest
+        || finalized.attestation.pharmacy_status_evidence_digest
+            != authorization.pharmacy_status_evidence_digest
+        || finalized.attestation.authority_policy_digest != authorization.authority_policy_digest
+        || finalized.attestation.dispense_policy_digest != authorization.dispense_policy_digest
+    {
+        return invalid("Finalized dispense evidence set does not match exact slot authorization");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_allocator_equivocation(
+    evidence: &AllocatorEquivocationEvidence,
+) -> ExternResult<ValidateCallbackResult> {
+    if evidence.evidence_id.trim().is_empty() {
+        return invalid("Allocator equivocation evidence ID is required");
+    }
+    if evidence.left_authorization_hash == evidence.right_authorization_hash {
+        return invalid("Allocator equivocation requires two distinct authorization actions");
+    }
+    let left_record = must_get_valid_record(evidence.left_authorization_hash.clone())?;
+    let right_record = must_get_valid_record(evidence.right_authorization_hash.clone())?;
+    let left: MedicationDispenseSlotAuthorization =
+        decode_entry(&left_record, "left slot authorization")?;
+    let right: MedicationDispenseSlotAuthorization =
+        decode_entry(&right_record, "right slot authorization")?;
+
+    if left_record.action().author() != right_record.action().author() {
+        return invalid("Equivocation evidence authorizations were issued by different allocators");
+    }
+    if left.medication_artifact_digest != right.medication_artifact_digest
+        || left.activation_semantic_receipt_digest != right.activation_semantic_receipt_digest
+        || left.slot_index != right.slot_index
+    {
+        return invalid("Equivocation evidence does not target the same semantic refill slot");
+    }
+    if left == right {
+        return invalid("Equivalent duplicate authorization payloads are idempotent, not equivocation");
+    }
+
+    let config = dispense_root_config()?;
+    let expected = selected_allocator(&config, left.medication_artifact_digest)?;
+    if left_record.action().author() != &expected {
+        return invalid("Equivocation evidence does not involve the DNA-selected allocator");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn dispense_root_config() -> ExternResult<MedicationDispenseRootConfig> {
+    let info = dna_info()?;
+    parse_dispense_root_config(info.modifiers.properties.bytes())
+}
+
+fn parse_dispense_root_config(bytes: &[u8]) -> ExternResult<MedicationDispenseRootConfig> {
+    let properties: serde_json::Value = serde_json::from_slice(bytes).map_err(|error| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "DNA properties are not valid JSON for medication dispense: {error}"
+        )))
+    })?;
+    let value = properties.get("medication_dispense").ok_or(wasm_error!(
+        WasmErrorInner::Guest(
+            "DNA properties do not configure medication_dispense slot allocators".to_string()
+        )
+    ))?;
+    let config: MedicationDispenseRootConfig = serde_json::from_value(value.clone()).map_err(|error| {
+        wasm_error!(WasmErrorInner::Guest(format!(
+            "Invalid medication_dispense DNA properties: {error}"
+        )))
+    })?;
+    if config.schema_version != CONFIG_VERSION {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Unsupported medication_dispense config version {}",
+            config.schema_version
+        ))));
+    }
+    if config.max_slot_authorization_duration_micros <= 0
+        || config.max_slot_authorization_duration_micros
+            > ABSOLUTE_MAX_SLOT_AUTHORIZATION_MICROS
+    {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Medication dispense slot authorization duration must be > 0 and <= 5 minutes"
+                .to_string()
+        )));
+    }
+    for (index, allocator) in config.slot_allocators.iter().enumerate() {
+        if config.slot_allocators[..index].contains(allocator) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Medication dispense allocator list contains duplicate AgentPubKeys".to_string()
+            )));
+        }
+    }
+    Ok(config)
+}
+
+fn selected_allocator(
+    config: &MedicationDispenseRootConfig,
+    medication_artifact_digest: StoredDigest,
+) -> ExternResult<AgentPubKey> {
+    require_digest_domain(
+        medication_artifact_digest,
+        DigestDomain::MedicationRequestArtifact,
+    )?;
+    if config.slot_allocators.is_empty() {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Medication dispense is disabled because no slot allocators are pinned in DNA properties"
+                .to_string()
+        )));
+    }
+    let mut prefix = [0u8; 8];
+    prefix.copy_from_slice(&medication_artifact_digest.value[..8]);
+    let index = (u64::from_be_bytes(prefix) % config.slot_allocators.len() as u64) as usize;
+    Ok(config.slot_allocators[index].clone())
+}
+
+fn require_activation_receipt_domain(digest: StoredDigest) -> ExternResult<()> {
+    digest
+        .validate_shape()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+    if !matches!(
+        digest.domain,
+        DigestDomain::MedicationActivationReceipt
+            | DigestDomain::EmergencyMedicationOverrideReceipt
+    ) {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Medication dispense activation receipt has invalid domain {:?}",
+            digest.domain
+        ))));
+    }
+    Ok(())
+}
+
+fn require_digest_domain(digest: StoredDigest, expected: DigestDomain) -> ExternResult<()> {
+    digest
+        .validate_shape()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+    if digest.domain != expected {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Medication dispense digest domain mismatch: expected {expected:?}, got {:?}",
+            digest.domain
+        ))));
+    }
+    Ok(())
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn digest(domain: DigestDomain, seed: u8) -> StoredDigest {
+        hash_canonical_bytes(domain, &[seed]).unwrap().stored()
+    }
+
+    fn agent(seed: u8) -> AgentPubKey {
+        AgentPubKey::from_raw_36(vec![seed; 36])
+    }
+
+    fn final_attestation(slot_index: u32) -> MedicationDispenseFinalAttestationV1 {
+        MedicationDispenseFinalAttestationV1 {
+            schema_version: 1,
+            dispense_id: format!("dispense-{slot_index}"),
+            medication_artifact_digest: digest(DigestDomain::MedicationRequestArtifact, 1),
+            activation_semantic_receipt_digest: digest(DigestDomain::MedicationActivationReceipt, 2),
+            activation_state_digest: digest(DigestDomain::MedicationActivationState, 3),
+            dispense_request_digest: digest(DigestDomain::MedicationDispenseRequest, 4),
+            preflight_receipt_digest: digest(DigestDomain::MedicationDispensePreflightReceipt, 5),
+            slot_index,
+            pharmacist_principal_binding: [6u8; 32],
+            pharmacy_record_digest: digest(DigestDomain::PharmacyRecord, 7),
+            pharmacy_affiliation_evidence_digest: digest(
+                DigestDomain::PharmacyAffiliationEvidence,
+                8,
+            ),
+            pharmacy_status_evidence_digest: digest(DigestDomain::PharmacyStatusEvidence, 9),
+            authority_policy_digest: digest(DigestDomain::AuthorityPolicy, 10),
+            dispense_policy_digest: digest(DigestDomain::MedicationDispensePolicy, 11),
+        }
+    }
+
+    fn authorization(slot_index: u32) -> MedicationDispenseSlotAuthorization {
+        let attestation = final_attestation(slot_index);
+        MedicationDispenseSlotAuthorization {
+            schema_version: 1,
+            authorization_id: format!("slot-auth-{slot_index}"),
+            grantee: agent(12),
+            medication_artifact_digest: attestation.medication_artifact_digest,
+            activation_semantic_receipt_digest: attestation.activation_semantic_receipt_digest,
+            activation_state_digest: attestation.activation_state_digest,
+            dispense_request_digest: attestation.dispense_request_digest,
+            preflight_receipt_digest: attestation.preflight_receipt_digest,
+            slot_index,
+            previous_final_dispense_hash: if slot_index == 0 {
+                None
+            } else {
+                Some(ActionHash::from_raw_36(vec![13; 36]))
+            },
+            pharmacist_principal_binding: attestation.pharmacist_principal_binding,
+            pharmacy_record_digest: attestation.pharmacy_record_digest,
+            pharmacy_affiliation_evidence_digest: attestation.pharmacy_affiliation_evidence_digest,
+            pharmacy_status_evidence_digest: attestation.pharmacy_status_evidence_digest,
+            authority_policy_digest: attestation.authority_policy_digest,
+            dispense_policy_digest: attestation.dispense_policy_digest,
+            final_receipt_digest: attestation.receipt_digest().unwrap(),
+            valid_from: Timestamp::from_micros(100),
+            valid_until: Timestamp::from_micros(200),
+        }
+    }
+
+    #[test]
+    fn initial_slot_cannot_claim_previous_final_dispense() {
+        let mut auth = authorization(0);
+        auth.previous_final_dispense_hash = Some(ActionHash::from_raw_36(vec![1; 36]));
+        let result = validate_slot_authorization_shape(&auth).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn refill_slot_requires_previous_final_dispense() {
+        let mut auth = authorization(1);
+        auth.previous_final_dispense_hash = None;
+        let result = validate_slot_authorization_shape(&auth).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn allocator_selection_is_deterministic_and_dna_ordered() {
+        let config = MedicationDispenseRootConfig {
+            schema_version: 1,
+            slot_allocators: vec![agent(1), agent(2), agent(3)],
+            max_slot_authorization_duration_micros: 100,
+        };
+        let medication = digest(DigestDomain::MedicationRequestArtifact, 42);
+        assert_eq!(
+            selected_allocator(&config, medication).unwrap(),
+            selected_allocator(&config, medication).unwrap()
+        );
+    }
+
+    #[test]
+    fn empty_allocator_set_fails_closed() {
+        let config = MedicationDispenseRootConfig {
+            schema_version: 1,
+            slot_allocators: vec![],
+            max_slot_authorization_duration_micros: 100,
+        };
+        assert!(selected_allocator(
+            &config,
+            digest(DigestDomain::MedicationRequestArtifact, 1)
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn authorization_duration_is_hard_bounded() {
+        let auth = authorization(0);
+        let config = MedicationDispenseRootConfig {
+            schema_version: 1,
+            slot_allocators: vec![agent(1)],
+            max_slot_authorization_duration_micros: 50,
+        };
+        let result = validate_authorization_window(Timestamp::from_micros(100), &auth, &config)
+            .unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn final_receipt_digest_changes_with_slot() {
+        let a = final_attestation(0).receipt_digest().unwrap();
+        let b = final_attestation(1).receipt_digest().unwrap();
+        assert_ne!(a, b);
+    }
+}


### PR DESCRIPTION
## Stack

Depends on #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

Implements the first runtime adjudication tranche of P0 #59.

## Why

A dispense preflight cannot prove exclusive refill-slot ownership from a local Holochain/DHT snapshot. Two pharmacies may observe the same prior finalized dispenses during partition/propagation delay.

This PR introduces an explicit narrow serialization dependency instead of pretending DHT convergence is a linearizable lock.

## V1 allocator model

DNA properties contain an ordered `slot_allocators` list. The exact list/order is DNA-hash-pinned. A MedicationRequest artifact deterministically selects exactly one allocator using the first eight artifact-digest bytes modulo allocator-list length.

The packaged DNA uses an empty allocator list, so final dispensing is disabled by default until a deployment deliberately pins allocator keys.

## Exact slot authorization

The selected allocator may issue a short-lived authorization bound to one exact:

- MedicationRequest artifact;
- activation semantic receipt;
- activation-state digest;
- dispense request;
- preflight receipt;
- slot index;
- pharmacist AgentPubKey + principal binding;
- pharmacy record/affiliation/status evidence;
- authority policy;
- dispense policy;
- final semantic `MedicationDispenseReceipt` digest.

Authorization lifetime is hard-capped at five minutes.

Slot 0 must have no predecessor. Slot N>0 must reference a DHT-valid finalized N-1 dispense in the same medication + activation lineage.

## Finalization

`FinalizedMedicationDispense` must be authored by the exact pharmacist AgentPubKey named as authorization grantee, inside the authorization window, and its attestation must hash to the exact final receipt digest approved by the allocator.

The public attestation remains privacy-minimized; medication/product/quantity/patient details stay committed through exact request/preflight/artifact digests rather than being duplicated on the DHT.

## Equivocation evidence

Adds append-only `AllocatorEquivocationEvidence`. A report is valid only when two distinct DHT-valid authorization actions come from the same DNA-selected allocator and target the same medication + activation + slot while carrying conflicting authorization payloads.

This makes allocator Byzantine behavior objectively detectable.

## Deliberate non-claims

V1 does **not** claim that DHT validation prevents a compromised allocator from issuing conflicting grants before propagation. Safety is conditional on a non-equivocating selected allocator; equivocation is detectable/auditable.

The upstream Holochain docs explicitly state countersigning is not a double-spend prevention primitive, and the workspace's Holochain 0.6.x family exposes it behind `unstable-countersigning`, so this PR does not make countersigning a safety-critical dependency.

Future work may use threshold witnesses/notaries to reduce unilateral allocator trust, but that requires separate failure/liveness qualification.

## Qualification required

Draft until exact-head CI + conductor tests prove:

- empty allocator list fails closed;
- wrong allocator cannot authorize;
- deterministic selection is stable for fixed DNA properties;
- slot 0/refill predecessor rules;
- wrong pharmacist cannot finalize;
- stale authorization cannot finalize;
- request/preflight/policy/pharmacy/slot substitution fails;
- final receipt digest matches exactly;
- update/delete attempts fail;
- same-slot conflicting grants produce verifiable equivocation evidence;
- modified coordinators cannot bypass integrity validation.