### PR TITLE
security(admin): add DNA-rooted qualified administration attestations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ members = [
     "zomes/medication_emergency/coordinator",
     "zomes/medication_dispense/integrity",
     "zomes/medication_dispense/coordinator",
+    "zomes/medication_administration/integrity",
+    "zomes/medication_administration/coordinator",
     "zomes/consent/integrity",
     "zomes/consent/coordinator",
     "zomes/bridge/integrity",

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -49,6 +49,7 @@ pub enum DigestDomain {
     MedicationAdministrationPolicy,
     MedicationAdministrationEvent,
     MedicationAdministrationReceipt,
+    MedicationAdministrationAttestation,
     MedicationAdministrationSupplyEvidence,
     QuarantineEvent,
     QuarantineDecision,
@@ -93,6 +94,7 @@ impl DigestDomain {
             Self::MedicationAdministrationPolicy => b"medication-administration-policy",
             Self::MedicationAdministrationEvent => b"medication-administration-event",
             Self::MedicationAdministrationReceipt => b"medication-administration-receipt",
+            Self::MedicationAdministrationAttestation => b"medication-administration-attestation",
             Self::MedicationAdministrationSupplyEvidence => b"medication-administration-supply-evidence",
             Self::QuarantineEvent => b"quarantine-event",
             Self::QuarantineDecision => b"quarantine-decision",
@@ -273,6 +275,7 @@ mod tests {
             DigestDomain::MedicationAdministrationPolicy,
             DigestDomain::MedicationAdministrationEvent,
             DigestDomain::MedicationAdministrationReceipt,
+            DigestDomain::MedicationAdministrationAttestation,
             DigestDomain::MedicationAdministrationSupplyEvidence,
             DigestDomain::AuthorityPolicy,
         ];

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -31,6 +31,16 @@ integrity:
       # Exact refill-slot authorizations are short-lived and hard-capped by the
       # integrity zome at five minutes. Deployments may choose a shorter value.
       max_slot_authorization_duration_micros: 300000000
+    medication_administration:
+      schema_version: 1
+      # Clinician-administration attestation trust is intentionally independent of
+      # prescription, activation, emergency, and dispensing trust. Empty by default:
+      # no qualified performed-administration attestation can validate until a
+      # deployment deliberately repacks the DNA with trusted root AgentPubKeys.
+      root_authorities: []
+      # Exact receipt + attestation verifier authorizations are short-lived and
+      # hard-capped by the integrity zome at 15 minutes. Deployments may choose less.
+      max_verifier_authorization_duration_micros: 900000000
   zomes:
     # Tier 1: MVP Core
     - name: patient_integrity
@@ -47,6 +57,8 @@ integrity:
       path: ../target/wasm32-unknown-unknown/release/medication_emergency_integrity.wasm
     - name: medication_dispense_integrity
       path: ../target/wasm32-unknown-unknown/release/medication_dispense_integrity.wasm
+    - name: medication_administration_integrity
+      path: ../target/wasm32-unknown-unknown/release/medication_administration_integrity.wasm
     - name: consent_integrity
       path: ../target/wasm32-unknown-unknown/release/consent_integrity.wasm
     - name: bridge_integrity
@@ -85,6 +97,10 @@ coordinator:
       path: ../target/wasm32-unknown-unknown/release/medication_dispense.wasm
       dependencies:
         - name: medication_dispense_integrity
+    - name: medication_administration
+      path: ../target/wasm32-unknown-unknown/release/medication_administration.wasm
+      dependencies:
+        - name: medication_administration_integrity
     - name: consent
       path: ../target/wasm32-unknown-unknown/release/consent.wasm
       dependencies:

--- a/docs/security/MEDICATION_ADMINISTRATION_ATTESTATION_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/MEDICATION_ADMINISTRATION_ATTESTATION_QUALIFICATION_CHECKLIST.md
@@ -1,0 +1,64 @@
+# Medication Administration Attestation v1 — Qualification Checklist
+
+Status: draft / not qualified
+
+## Source/build gates
+
+- [ ] `cargo fmt -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] `cargo test --workspace`
+- [ ] build `medication_administration_integrity` for `wasm32-unknown-unknown --release`
+- [ ] build `medication_administration` coordinator for `wasm32-unknown-unknown --release`
+- [ ] package the DNA with administration zomes present
+
+## Pure/DHT semantic gates
+
+- [ ] attestation digest is deterministic and domain-separated
+- [ ] changing `administration_id` changes attestation digest
+- [ ] empty/zero/wrong-domain evidence is rejected
+- [ ] ordinary and emergency activation receipt domains are accepted distinctly
+- [ ] wrong receipt/event/medication/activation/dispense/principal/policy binding is rejected
+- [ ] authorization validity interval is positive and <= configured/hard maximum
+- [ ] verifier action must occur inside the exact authorization interval
+- [ ] update/delete of authorization, administration, and correction entries is rejected
+- [ ] correction `Other` requires a nonzero protected-rationale commitment
+
+## Conductor/adversarial gates
+
+Use a real packaged DNA and at least root/verifier/attacker agents.
+
+- [ ] default DNA with `root_authorities: []` rejects authorization creation
+- [ ] non-root cannot create verifier authorization
+- [ ] root can create one exact short-lived authorization
+- [ ] wrong verifier cannot publish the authorized administration
+- [ ] correct verifier cannot publish after expiration
+- [ ] correct verifier cannot alter `administration_id`
+- [ ] correct verifier cannot substitute any receipt/evidence/policy digest
+- [ ] equivalent duplicate publication is preserved as duplicate provenance, not duplicate clinical administration
+- [ ] unauthorized correction is rejected
+- [ ] correction targeting a different semantic receipt is rejected
+- [ ] correction link crossing administration lineage is rejected
+- [ ] update/delete and correction-link delete are rejected from a modified coordinator/raw call path
+
+## Read-model gates
+
+Before consumers may treat DHT administration records as canonical state:
+
+- [ ] reducer groups equivalent publications by semantic administration receipt
+- [ ] corrections apply to the semantic receipt lineage, not just one publication action
+- [ ] corrected/entered-in-error administrations do not remain `CurrentPerformed`
+- [ ] competing distinct current administration receipts are explicit conflict when they represent the same intended administration slot/event
+- [ ] no last-write-wins rule exists
+- [ ] incomplete referenced read sets fail closed
+- [ ] legacy `MedicationAdherence { dose_taken: true }` cannot become qualified administration
+
+## Deployment gates
+
+- [ ] production roots are explicitly documented and independently controlled
+- [ ] verifier process revalidates protected receipt/evidence before requesting root authorization
+- [ ] root keys are not exposed to ordinary application/coordinator processes
+- [ ] verifier/root audit logs bind exact receipt + attestation digest
+- [ ] PHI is absent from public DHT attestation and public correction rationale
+- [ ] emergency provenance is visible in downstream administration reads
+
+No checklist completion may be inferred from source presence alone. Exact-head execution evidence is required.

--- a/docs/security/MEDICATION_ADMINISTRATION_ATTESTATION_STACK_NOTES.md
+++ b/docs/security/MEDICATION_ADMINISTRATION_ATTESTATION_STACK_NOTES.md
@@ -1,0 +1,11 @@
+# Administration Attestation Stack Notes
+
+This tranche is intentionally stacked on the pure clinician-administration boundary rather than merged into it.
+
+Review order:
+
+1. `mycelix-medication-administration` proves exact clinical/event composition in process.
+2. `medication_administration_integrity` proves that only a DNA-rooted, exact-target verifier authorization may publish the privacy-minimized DHT projection.
+3. A later administration-state reducer will derive current interpretation from qualified publications plus append-only corrections.
+
+The DHT zome does not recreate the private administration capability from serialized data and does not treat a stored receipt digest as proof of clinical correctness by itself.

--- a/docs/security/MEDICATION_ADMINISTRATION_ATTESTATION_V1.md
+++ b/docs/security/MEDICATION_ADMINISTRATION_ATTESTATION_V1.md
@@ -1,0 +1,113 @@
+# Medication Administration Attestation v1
+
+Status: experimental / draft qualification
+
+This contract defines the first DHT boundary for clinician-performed medication administration. It is intentionally downstream of the pure `mycelix-medication-administration` capability/receipt layer.
+
+## Purpose
+
+A private `MedicationAdministrationReceiptV1` is not itself a DHT-valid clinical fact. Before publication, a deployment-trusted verifier must revalidate the protected receipt and its referenced evidence, then obtain an exact, short-lived authorization from a DNA-pinned administration root.
+
+The DHT publishes only a privacy-minimized projection of that verified lineage.
+
+## Fail-closed deployment root
+
+DNA properties contain:
+
+```yaml
+medication_administration:
+  schema_version: 1
+  root_authorities: []
+  max_verifier_authorization_duration_micros: 900000000
+```
+
+The repository ships with an empty root set. Qualified administration publication is therefore disabled until a deployment deliberately repacks the DNA with trusted root AgentPubKeys. This trust-root change is part of the DNA hash.
+
+Administration roots are intentionally independent from prescription, activation, emergency-override, and dispensing roots.
+
+## Publication chain
+
+1. A clinician-performed administration event passes the pure administration gate.
+2. The non-cloneable capability is consumed into a private administration receipt.
+3. A deployment verifier revalidates the receipt and referenced protected evidence.
+4. A DNA-pinned root issues a short-lived authorization for one exact verifier and one exact receipt lineage.
+5. Only that verifier may publish the matching `QualifiedMedicationAdministration` during the authorization window.
+6. Peers validate exact field equality against the root authorization.
+
+No reusable verifier role is created by this protocol.
+
+## Public attestation contents
+
+`MedicationAdministrationAttestationV1` contains only:
+
+- administration identifier;
+- administration receipt digest;
+- private event digest;
+- MedicationRequest artifact digest;
+- qualified/emergency activation semantic receipt digest;
+- finalized dispense receipt digest;
+- administrator principal binding;
+- authority-policy digest;
+- administration-policy digest.
+
+It intentionally omits patient identity, medication name, dose, route, site, method, diagnosis, notes, and narrative rationale.
+
+## Corrections
+
+Qualified administration entries are append-only. They cannot be updated or deleted.
+
+Corrections use `MedicationAdministrationCorrection` with typed reasons including entered-in-error, wrong patient, wrong medication, wrong dose, wrong route, duplicate documentation, and source-evidence revocation. Sensitive explanatory text remains protected; the public record may contain only a commitment to that rationale.
+
+A correction may be authored by the original qualified-administration publisher or a DNA-pinned administration root. Correction links must bind the exact administration action and semantic receipt lineage and are append-only.
+
+The canonical current interpretation must therefore be derived from:
+
+`qualified administration + valid correction lineage`
+
+rather than from mutable status or deletion metadata.
+
+## Why deletion is not revocation
+
+Holochain dependency retrieval with `must_get_*` does not make later mutable metadata such as delete/update activity part of the referenced record proof. Administration authorization and correction semantics therefore do not rely on deleting an old grant or entry.
+
+Verifier authorization is exact-target and short-lived; clinical correction is append-only.
+
+## Security invariants
+
+- an unconfigured DNA cannot validate a qualified administration;
+- a non-root cannot mint verifier authorization;
+- a verifier authorization is exact receipt + event + medication + activation + dispense + principal + policies;
+- a verifier cannot publish outside its authorization validity window;
+- wrong receipt/event/medication/activation/dispense/principal/policy substitution fails closed;
+- `Prescribe`/`Dispense` authority cannot be reconstructed from a DHT attestation as `Administer` authority;
+- emergency-origin activation remains visible through its digest domain;
+- corrections never erase the original claim;
+- raw PHI is not required in the distributed administration entry.
+
+## Non-claims
+
+This zome does **not** prove:
+
+- that the physical administration occurred merely because an attestation was committed;
+- that an upstream patient-binding adapter is institutionally trustworthy;
+- that a private receipt was clinically correct unless the configured verifier actually performs the required revalidation;
+- causal attribution between administration and later outcomes;
+- global completeness of a read query;
+- regulatory or clinical qualification.
+
+Those are separate physical-world, deployment, evidence, read-model, and qualification boundaries.
+
+## Required qualification
+
+Before promotion beyond experimental status, require exact-head build/test plus conductor tests proving at minimum:
+
+- empty-root DNA rejects verifier authorization;
+- non-root authorization creation is rejected;
+- wrong verifier cannot publish;
+- expired/not-yet-valid verifier authorization cannot publish;
+- every exact-target substitution fails;
+- update/delete of trust/evidence entries is rejected;
+- unauthorized correction is rejected;
+- wrong-lineage correction/link is rejected;
+- duplicate equivalent publication is handled deterministically by the future administration-state reducer;
+- competing/corrected administration claims never become a last-write-wins `performed=true` state.

--- a/zomes/medication_administration/coordinator/Cargo.toml
+++ b/zomes/medication_administration/coordinator/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "medication_administration"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Coordinator for DNA-rooted qualified medication administration attestations"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { workspace = true }
+medication_administration_integrity = { path = "../integrity" }
+
+[features]
+default = []

--- a/zomes/medication_administration/coordinator/src/lib.rs
+++ b/zomes/medication_administration/coordinator/src/lib.rs
@@ -1,0 +1,53 @@
+#![deny(unsafe_code)]
+//! Thin coordinator for qualified medication administration attestations.
+//!
+//! Clinical qualification belongs to the pure administration stack and DHT trust
+//! enforcement belongs to the integrity zome. This coordinator only commits exact
+//! entries/links; a modified coordinator must not be able to bypass validation.
+
+use hdk::prelude::*;
+use medication_administration_integrity::{
+    EntryTypes, LinkTypes, MedicationAdministrationCorrection,
+    MedicationAdministrationVerifierAuthorization, QualifiedMedicationAdministration,
+};
+
+#[hdk_extern]
+pub fn create_verifier_authorization(
+    authorization: MedicationAdministrationVerifierAuthorization,
+) -> ExternResult<Record> {
+    let hash = create_entry(EntryTypes::MedicationAdministrationVerifierAuthorization(
+        authorization,
+    ))?;
+    get(hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed administration verifier authorization could not be read back".to_string()
+    )))
+}
+
+#[hdk_extern]
+pub fn publish_qualified_administration(
+    administration: QualifiedMedicationAdministration,
+) -> ExternResult<Record> {
+    let hash = create_entry(EntryTypes::QualifiedMedicationAdministration(administration))?;
+    get(hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed qualified administration could not be read back".to_string()
+    )))
+}
+
+#[hdk_extern]
+pub fn append_administration_correction(
+    correction: MedicationAdministrationCorrection,
+) -> ExternResult<Record> {
+    let administration_hash = correction.administration_hash.clone();
+    let correction_hash = create_entry(EntryTypes::MedicationAdministrationCorrection(
+        correction,
+    ))?;
+    create_link(
+        administration_hash,
+        correction_hash.clone(),
+        LinkTypes::AdministrationToCorrections,
+        (),
+    )?;
+    get(correction_hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed administration correction could not be read back".to_string()
+    )))
+}

--- a/zomes/medication_administration/integrity/Cargo.toml
+++ b/zomes/medication_administration/integrity/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "medication_administration_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "DNA-rooted qualified medication administration attestation integrity zome"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+mycelix-clinical-integrity = { path = "../../../crates/clinical-integrity" }
+
+[features]
+default = []

--- a/zomes/medication_administration/integrity/src/lib.rs
+++ b/zomes/medication_administration/integrity/src/lib.rs
@@ -124,7 +124,7 @@ pub struct QualifiedMedicationAdministration {
     pub verifier_authorization_hash: ActionHash,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum AdministrationCorrectionReason {
     EnteredInError,
     WrongPatient,

--- a/zomes/medication_administration/integrity/src/lib.rs
+++ b/zomes/medication_administration/integrity/src/lib.rs
@@ -1,0 +1,542 @@
+#![deny(unsafe_code)]
+#![allow(clippy::collapsible_match)]
+//! DNA-rooted qualified clinician medication administration attestations.
+//!
+//! The detailed administration event and receipt remain protected off-DHT. The DHT
+//! stores only a privacy-minimized projection after a DNA-pinned root has authorized
+//! one exact verifier to publish one exact receipt lineage inside a short window.
+//! Corrections are append-only; update/delete are never used as clinical revocation.
+
+use hdi::prelude::*;
+use mycelix_clinical_integrity::{DigestDomain, StoredDigest};
+
+const CONFIG_VERSION: u16 = 1;
+const ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS: i64 = 900_000_000; // 15 min
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MedicationAdministrationRootConfig {
+    pub schema_version: u16,
+    pub root_authorities: Vec<AgentPubKey>,
+    pub max_verifier_authorization_duration_micros: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MedicationAdministrationAttestationV1 {
+    pub schema_version: u16,
+    pub administration_id: String,
+    pub administration_receipt_digest: StoredDigest,
+    pub event_digest: StoredDigest,
+    pub medication_artifact_digest: StoredDigest,
+    pub activation_semantic_receipt_digest: StoredDigest,
+    pub finalized_dispense_receipt_digest: StoredDigest,
+    pub administrator_principal_binding: [u8; 32],
+    pub authority_policy_digest: StoredDigest,
+    pub administration_policy_digest: StoredDigest,
+}
+
+impl MedicationAdministrationAttestationV1 {
+    pub fn validate(&self) -> ExternResult<ValidateCallbackResult> {
+        if self.schema_version != 1 {
+            return invalid("Unsupported medication administration attestation version");
+        }
+        if self.administration_id.trim().is_empty() {
+            return invalid("Medication administration ID is required");
+        }
+        if self.administrator_principal_binding == [0u8; 32] {
+            return invalid("Administrator principal binding cannot be zero");
+        }
+        require_digest_domain(
+            self.administration_receipt_digest,
+            DigestDomain::MedicationAdministrationReceipt,
+        )?;
+        require_digest_domain(
+            self.event_digest,
+            DigestDomain::MedicationAdministrationEvent,
+        )?;
+        require_digest_domain(
+            self.medication_artifact_digest,
+            DigestDomain::MedicationRequestArtifact,
+        )?;
+        require_activation_receipt_domain(self.activation_semantic_receipt_digest)?;
+        require_digest_domain(
+            self.finalized_dispense_receipt_digest,
+            DigestDomain::MedicationDispenseReceipt,
+        )?;
+        require_digest_domain(self.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+        require_digest_domain(
+            self.administration_policy_digest,
+            DigestDomain::MedicationAdministrationPolicy,
+        )?;
+        Ok(ValidateCallbackResult::Valid)
+    }
+}
+
+/// Exact, short-lived root authorization. This is not a reusable verifier role.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct MedicationAdministrationVerifierAuthorization {
+    pub authorization_id: String,
+    pub grantee: AgentPubKey,
+    pub administration_receipt_digest: StoredDigest,
+    pub event_digest: StoredDigest,
+    pub medication_artifact_digest: StoredDigest,
+    pub activation_semantic_receipt_digest: StoredDigest,
+    pub finalized_dispense_receipt_digest: StoredDigest,
+    pub administrator_principal_binding: [u8; 32],
+    pub authority_policy_digest: StoredDigest,
+    pub administration_policy_digest: StoredDigest,
+    pub valid_from: Timestamp,
+    pub valid_until: Timestamp,
+}
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct QualifiedMedicationAdministration {
+    pub attestation: MedicationAdministrationAttestationV1,
+    pub verifier_authorization_hash: ActionHash,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub enum AdministrationCorrectionReason {
+    EnteredInError,
+    WrongPatient,
+    WrongMedication,
+    WrongDose,
+    WrongRoute,
+    DuplicateDocumentation,
+    SourceEvidenceRevoked,
+    Other,
+}
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct MedicationAdministrationCorrection {
+    pub correction_id: String,
+    pub administration_hash: ActionHash,
+    pub administration_receipt_digest: StoredDigest,
+    pub reason: AdministrationCorrectionReason,
+    /// Commitment to protected human-readable rationale. Raw rationale stays private.
+    pub rationale_commitment: Option<[u8; 32]>,
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    MedicationAdministrationVerifierAuthorization(MedicationAdministrationVerifierAuthorization),
+    QualifiedMedicationAdministration(QualifiedMedicationAdministration),
+    MedicationAdministrationCorrection(MedicationAdministrationCorrection),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    AdministrationToCorrections,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => {
+                validate_create_entry(EntryCreationAction::Create(action), app_entry)
+            }
+            OpEntry::UpdateEntry { .. } => invalid(
+                "Medication administration trust/evidence entries are append-only and cannot be updated",
+            ),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterUpdate(_) => invalid(
+            "Medication administration trust/evidence entries are append-only and cannot be updated",
+        ),
+        FlatOp::RegisterDelete(_) => invalid(
+            "Medication administration trust/evidence entries cannot be deleted; append a correction",
+        ),
+        FlatOp::RegisterCreateLink {
+            link_type,
+            base_address,
+            target_address,
+            action,
+            ..
+        } => validate_create_link(link_type, base_address, target_address, action),
+        FlatOp::RegisterDeleteLink { .. } => invalid(
+            "Medication administration correction links are append-only and cannot be deleted",
+        ),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_create_entry(
+    action: EntryCreationAction,
+    entry: EntryTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    match entry {
+        EntryTypes::MedicationAdministrationVerifierAuthorization(authorization) => {
+            let shape = validate_authorization_shape(&authorization)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let config = administration_root_config()?;
+            let root = require_root_authority(action.author(), &config)?;
+            if !matches!(root, ValidateCallbackResult::Valid) {
+                return Ok(root);
+            }
+            validate_authorization_window(action.timestamp(), &authorization, &config)
+        }
+        EntryTypes::QualifiedMedicationAdministration(administration) => {
+            let shape = administration.attestation.validate()?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_exact_verifier_authorization(
+                action.author(),
+                action.timestamp(),
+                &administration,
+            )
+        }
+        EntryTypes::MedicationAdministrationCorrection(correction) => {
+            let shape = validate_correction_shape(&correction)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_correction_authority(action.author(), &correction)
+        }
+    }
+}
+
+fn validate_authorization_shape(
+    authorization: &MedicationAdministrationVerifierAuthorization,
+) -> ExternResult<ValidateCallbackResult> {
+    if authorization.authorization_id.trim().is_empty() {
+        return invalid("Medication administration verifier authorization ID is required");
+    }
+    if authorization.administrator_principal_binding == [0u8; 32] {
+        return invalid("Administrator principal binding cannot be zero");
+    }
+    require_digest_domain(
+        authorization.administration_receipt_digest,
+        DigestDomain::MedicationAdministrationReceipt,
+    )?;
+    require_digest_domain(
+        authorization.event_digest,
+        DigestDomain::MedicationAdministrationEvent,
+    )?;
+    require_digest_domain(
+        authorization.medication_artifact_digest,
+        DigestDomain::MedicationRequestArtifact,
+    )?;
+    require_activation_receipt_domain(authorization.activation_semantic_receipt_digest)?;
+    require_digest_domain(
+        authorization.finalized_dispense_receipt_digest,
+        DigestDomain::MedicationDispenseReceipt,
+    )?;
+    require_digest_domain(authorization.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+    require_digest_domain(
+        authorization.administration_policy_digest,
+        DigestDomain::MedicationAdministrationPolicy,
+    )?;
+    if authorization.valid_until <= authorization.valid_from {
+        return invalid("Administration verifier authorization validity window is invalid");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_authorization_window(
+    action_timestamp: Timestamp,
+    authorization: &MedicationAdministrationVerifierAuthorization,
+    config: &MedicationAdministrationRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    let duration = authorization.valid_until.as_micros() as i128
+        - authorization.valid_from.as_micros() as i128;
+    if duration <= 0
+        || duration > config.max_verifier_authorization_duration_micros as i128
+        || duration > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS as i128
+    {
+        return invalid("Administration verifier authorization duration exceeds configured/hard limit");
+    }
+    if action_timestamp > authorization.valid_until {
+        return invalid("Administration verifier authorization was already expired when created");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_exact_verifier_authorization(
+    author: &AgentPubKey,
+    action_timestamp: Timestamp,
+    administration: &QualifiedMedicationAdministration,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(administration.verifier_authorization_hash.clone())?;
+    let authorization: MedicationAdministrationVerifierAuthorization =
+        decode_entry(&record, "administration verifier authorization")?;
+    if &authorization.grantee != author {
+        return invalid("Administration author is not authorization grantee");
+    }
+    if action_timestamp < authorization.valid_from || action_timestamp >= authorization.valid_until {
+        return invalid("Administration action timestamp is outside authorization validity");
+    }
+    let attestation = &administration.attestation;
+    if attestation.administration_receipt_digest != authorization.administration_receipt_digest
+        || attestation.event_digest != authorization.event_digest
+        || attestation.medication_artifact_digest != authorization.medication_artifact_digest
+        || attestation.activation_semantic_receipt_digest
+            != authorization.activation_semantic_receipt_digest
+        || attestation.finalized_dispense_receipt_digest
+            != authorization.finalized_dispense_receipt_digest
+        || attestation.administrator_principal_binding
+            != authorization.administrator_principal_binding
+        || attestation.authority_policy_digest != authorization.authority_policy_digest
+        || attestation.administration_policy_digest != authorization.administration_policy_digest
+    {
+        return invalid("Administration attestation does not exactly match root authorization");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_correction_shape(
+    correction: &MedicationAdministrationCorrection,
+) -> ExternResult<ValidateCallbackResult> {
+    if correction.correction_id.trim().is_empty() {
+        return invalid("Medication administration correction ID is required");
+    }
+    require_digest_domain(
+        correction.administration_receipt_digest,
+        DigestDomain::MedicationAdministrationReceipt,
+    )?;
+    if correction
+        .rationale_commitment
+        .is_some_and(|commitment| commitment == [0u8; 32])
+    {
+        return invalid("Administration correction rationale commitment cannot be zero");
+    }
+    if matches!(correction.reason, AdministrationCorrectionReason::Other)
+        && correction.rationale_commitment.is_none()
+    {
+        return invalid("Other administration correction requires a rationale commitment");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_correction_authority(
+    author: &AgentPubKey,
+    correction: &MedicationAdministrationCorrection,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(correction.administration_hash.clone())?;
+    let administration: QualifiedMedicationAdministration =
+        decode_entry(&record, "qualified medication administration")?;
+    if administration.attestation.administration_receipt_digest
+        != correction.administration_receipt_digest
+    {
+        return invalid("Administration correction receipt digest does not match target");
+    }
+    if record.action().author() == author {
+        return Ok(ValidateCallbackResult::Valid);
+    }
+    let config = administration_root_config()?;
+    require_root_authority(author, &config)
+}
+
+fn validate_create_link(
+    link_type: LinkTypes,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    action: CreateLink,
+) -> ExternResult<ValidateCallbackResult> {
+    match link_type {
+        LinkTypes::AdministrationToCorrections => {
+            let administration_hash = require_action_hash(base_address, "administration link base")?;
+            let correction_hash = require_action_hash(target_address, "correction link target")?;
+            let administration_record = must_get_valid_record(administration_hash.clone())?;
+            let administration: QualifiedMedicationAdministration =
+                decode_entry(&administration_record, "qualified medication administration")?;
+            let correction_record = must_get_valid_record(correction_hash)?;
+            let correction: MedicationAdministrationCorrection =
+                decode_entry(&correction_record, "administration correction")?;
+            if correction.administration_hash != administration_hash
+                || correction.administration_receipt_digest
+                    != administration.attestation.administration_receipt_digest
+            {
+                return invalid("Administration-correction link crosses receipt lineage");
+            }
+            if correction_record.action().author() != &action.author {
+                return invalid("Administration-correction link must be authored by correction author");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+    }
+}
+
+fn administration_root_config() -> ExternResult<MedicationAdministrationRootConfig> {
+    let info = dna_info()?;
+    let properties: serde_json::Value = serde_json::from_slice(info.modifiers.properties.bytes())
+        .map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "DNA properties are not valid JSON for medication administration: {error}"
+            )))
+        })?;
+    let value = properties.get("medication_administration").ok_or(wasm_error!(
+        WasmErrorInner::Guest(
+            "DNA properties do not configure medication_administration trust roots".to_string()
+        )
+    ))?;
+    let config: MedicationAdministrationRootConfig = serde_json::from_value(value.clone())
+        .map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Invalid medication_administration DNA properties: {error}"
+            )))
+        })?;
+    if config.schema_version != CONFIG_VERSION {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Unsupported medication_administration root config version {}",
+            config.schema_version
+        ))));
+    }
+    if config.max_verifier_authorization_duration_micros <= 0
+        || config.max_verifier_authorization_duration_micros
+            > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS
+    {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Medication administration authorization duration must be > 0 and <= 15 minutes"
+                .to_string()
+        )));
+    }
+    for (index, root) in config.root_authorities.iter().enumerate() {
+        if config.root_authorities[..index].contains(root) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Medication administration root list contains duplicate AgentPubKeys".to_string()
+            )));
+        }
+    }
+    Ok(config)
+}
+
+fn require_root_authority(
+    author: &AgentPubKey,
+    config: &MedicationAdministrationRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    if !config.root_authorities.contains(author) {
+        return invalid(
+            "Medication administration verifier authorization requires a DNA-pinned root authority",
+        );
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_activation_receipt_domain(digest: StoredDigest) -> ExternResult<()> {
+    digest
+        .validate_shape()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+    if !matches!(
+        digest.domain,
+        DigestDomain::MedicationActivationReceipt
+            | DigestDomain::EmergencyMedicationOverrideReceipt
+    ) {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Medication administration activation receipt has invalid domain {:?}",
+            digest.domain
+        ))));
+    }
+    Ok(())
+}
+
+fn require_digest_domain(digest: StoredDigest, expected: DigestDomain) -> ExternResult<()> {
+    digest
+        .validate_shape()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+    if digest.domain != expected {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Medication administration digest domain mismatch: expected {expected:?}, got {:?}",
+            digest.domain
+        ))));
+    }
+    Ok(())
+}
+
+fn require_action_hash(hash: AnyLinkableHash, field: &'static str) -> ExternResult<ActionHash> {
+    hash.into_action_hash().ok_or(wasm_error!(WasmErrorInner::Guest(
+        format!("{field} must be an ActionHash")
+    )))
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_integrity::{hash_canonical_bytes, DigestAlgorithm};
+
+    fn digest(domain: DigestDomain, seed: u8) -> StoredDigest {
+        hash_canonical_bytes(domain, &[seed]).unwrap().stored()
+    }
+
+    fn stored(domain: DigestDomain, seed: u8) -> StoredDigest {
+        StoredDigest {
+            algorithm: DigestAlgorithm::Blake3_256,
+            domain,
+            value: [seed; 32],
+        }
+    }
+
+    fn authorization() -> MedicationAdministrationVerifierAuthorization {
+        MedicationAdministrationVerifierAuthorization {
+            authorization_id: "admin-auth-a".into(),
+            grantee: AgentPubKey::from_raw_36(vec![1; 36]),
+            administration_receipt_digest: digest(DigestDomain::MedicationAdministrationReceipt, 2),
+            event_digest: digest(DigestDomain::MedicationAdministrationEvent, 3),
+            medication_artifact_digest: digest(DigestDomain::MedicationRequestArtifact, 4),
+            activation_semantic_receipt_digest: digest(DigestDomain::MedicationActivationReceipt, 5),
+            finalized_dispense_receipt_digest: digest(DigestDomain::MedicationDispenseReceipt, 6),
+            administrator_principal_binding: [7; 32],
+            authority_policy_digest: digest(DigestDomain::AuthorityPolicy, 8),
+            administration_policy_digest: digest(DigestDomain::MedicationAdministrationPolicy, 9),
+            valid_from: Timestamp::from_micros(10),
+            valid_until: Timestamp::from_micros(100),
+        }
+    }
+
+    #[test]
+    fn authorization_rejects_wrong_receipt_domain() {
+        let mut value = authorization();
+        value.administration_receipt_digest = stored(DigestDomain::MedicationDispenseReceipt, 2);
+        assert!(validate_authorization_shape(&value).is_err());
+    }
+
+    #[test]
+    fn correction_other_requires_commitment() {
+        let value = MedicationAdministrationCorrection {
+            correction_id: "correction-a".into(),
+            administration_hash: ActionHash::from_raw_36(vec![2; 36]),
+            administration_receipt_digest: digest(DigestDomain::MedicationAdministrationReceipt, 3),
+            reason: AdministrationCorrectionReason::Other,
+            rationale_commitment: None,
+        };
+        let result = validate_correction_shape(&value).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn authorization_duration_is_hard_bounded() {
+        let value = authorization();
+        let config = MedicationAdministrationRootConfig {
+            schema_version: 1,
+            root_authorities: Vec::new(),
+            max_verifier_authorization_duration_micros: 50,
+        };
+        let result = validate_authorization_window(Timestamp::from_micros(10), &value, &config)
+            .unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+}

--- a/zomes/medication_administration/integrity/src/lib.rs
+++ b/zomes/medication_administration/integrity/src/lib.rs
@@ -4,14 +4,15 @@
 //!
 //! The detailed administration event and receipt remain protected off-DHT. The DHT
 //! stores only a privacy-minimized projection after a DNA-pinned root has authorized
-//! one exact verifier to publish one exact receipt lineage inside a short window.
+//! one exact verifier to publish one exact receipt + attestation inside a short window.
 //! Corrections are append-only; update/delete are never used as clinical revocation.
 
 use hdi::prelude::*;
-use mycelix_clinical_integrity::{DigestDomain, StoredDigest};
+use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, StoredDigest};
 
 const CONFIG_VERSION: u16 = 1;
 const ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS: i64 = 900_000_000; // 15 min
+const ATTESTATION_SCHEMA_TAG: &[u8] = b"mycelix-health/medication-administration-attestation-v1";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MedicationAdministrationRootConfig {
@@ -20,6 +21,7 @@ pub struct MedicationAdministrationRootConfig {
     pub max_verifier_authorization_duration_micros: i64,
 }
 
+/// Privacy-minimized public projection of one protected administration receipt.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct MedicationAdministrationAttestationV1 {
@@ -70,6 +72,30 @@ impl MedicationAdministrationAttestationV1 {
         )?;
         Ok(ValidateCallbackResult::Valid)
     }
+
+    pub fn digest(&self) -> ExternResult<StoredDigest> {
+        let shape = self.validate()?;
+        if !matches!(shape, ValidateCallbackResult::Valid) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Cannot hash invalid medication administration attestation".to_string()
+            )));
+        }
+        let encoded = serde_json::to_vec(self).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Failed to serialize medication administration attestation: {error}"
+            )))
+        })?;
+        let mut framed = Vec::with_capacity(ATTESTATION_SCHEMA_TAG.len() + 1 + encoded.len());
+        framed.extend_from_slice(ATTESTATION_SCHEMA_TAG);
+        framed.push(0);
+        framed.extend_from_slice(&encoded);
+        Ok(hash_canonical_bytes(
+            DigestDomain::MedicationAdministrationAttestation,
+            &framed,
+        )
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .stored())
+    }
 }
 
 /// Exact, short-lived root authorization. This is not a reusable verifier role.
@@ -79,6 +105,7 @@ pub struct MedicationAdministrationVerifierAuthorization {
     pub authorization_id: String,
     pub grantee: AgentPubKey,
     pub administration_receipt_digest: StoredDigest,
+    pub administration_attestation_digest: StoredDigest,
     pub event_digest: StoredDigest,
     pub medication_artifact_digest: StoredDigest,
     pub activation_semantic_receipt_digest: StoredDigest,
@@ -217,6 +244,10 @@ fn validate_authorization_shape(
         DigestDomain::MedicationAdministrationReceipt,
     )?;
     require_digest_domain(
+        authorization.administration_attestation_digest,
+        DigestDomain::MedicationAdministrationAttestation,
+    )?;
+    require_digest_domain(
         authorization.event_digest,
         DigestDomain::MedicationAdministrationEvent,
     )?;
@@ -273,8 +304,11 @@ fn require_exact_verifier_authorization(
     if action_timestamp < authorization.valid_from || action_timestamp >= authorization.valid_until {
         return invalid("Administration action timestamp is outside authorization validity");
     }
+
     let attestation = &administration.attestation;
-    if attestation.administration_receipt_digest != authorization.administration_receipt_digest
+    let attestation_digest = attestation.digest()?;
+    if attestation_digest != authorization.administration_attestation_digest
+        || attestation.administration_receipt_digest != authorization.administration_receipt_digest
         || attestation.event_digest != authorization.event_digest
         || attestation.medication_artifact_digest != authorization.medication_artifact_digest
         || attestation.activation_semantic_receipt_digest
@@ -490,10 +524,10 @@ mod tests {
         }
     }
 
-    fn authorization() -> MedicationAdministrationVerifierAuthorization {
-        MedicationAdministrationVerifierAuthorization {
-            authorization_id: "admin-auth-a".into(),
-            grantee: AgentPubKey::from_raw_36(vec![1; 36]),
+    fn attestation() -> MedicationAdministrationAttestationV1 {
+        MedicationAdministrationAttestationV1 {
+            schema_version: 1,
+            administration_id: "admin-a".into(),
             administration_receipt_digest: digest(DigestDomain::MedicationAdministrationReceipt, 2),
             event_digest: digest(DigestDomain::MedicationAdministrationEvent, 3),
             medication_artifact_digest: digest(DigestDomain::MedicationRequestArtifact, 4),
@@ -502,6 +536,23 @@ mod tests {
             administrator_principal_binding: [7; 32],
             authority_policy_digest: digest(DigestDomain::AuthorityPolicy, 8),
             administration_policy_digest: digest(DigestDomain::MedicationAdministrationPolicy, 9),
+        }
+    }
+
+    fn authorization() -> MedicationAdministrationVerifierAuthorization {
+        let attestation = attestation();
+        MedicationAdministrationVerifierAuthorization {
+            authorization_id: "admin-auth-a".into(),
+            grantee: AgentPubKey::from_raw_36(vec![1; 36]),
+            administration_receipt_digest: attestation.administration_receipt_digest,
+            administration_attestation_digest: attestation.digest().unwrap(),
+            event_digest: attestation.event_digest,
+            medication_artifact_digest: attestation.medication_artifact_digest,
+            activation_semantic_receipt_digest: attestation.activation_semantic_receipt_digest,
+            finalized_dispense_receipt_digest: attestation.finalized_dispense_receipt_digest,
+            administrator_principal_binding: attestation.administrator_principal_binding,
+            authority_policy_digest: attestation.authority_policy_digest,
+            administration_policy_digest: attestation.administration_policy_digest,
             valid_from: Timestamp::from_micros(10),
             valid_until: Timestamp::from_micros(100),
         }
@@ -512,6 +563,15 @@ mod tests {
         let mut value = authorization();
         value.administration_receipt_digest = stored(DigestDomain::MedicationDispenseReceipt, 2);
         assert!(validate_authorization_shape(&value).is_err());
+    }
+
+    #[test]
+    fn attestation_id_changes_authorized_identity() {
+        let original = attestation();
+        let original_digest = original.digest().unwrap();
+        let mut changed = original.clone();
+        changed.administration_id = "admin-b".into();
+        assert_ne!(original_digest, changed.digest().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Stack

Depends on #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

Implements the DHT/runtime trust boundary for the clinician-administration tranche of P0 #63.

## Why

The pure `mycelix-medication-administration` crate can compose exact clinical semantics and authority in-process, but a serialized receipt is not itself a DHT-valid clinical fact. This PR adds a separate DNA-rooted attestation boundary so a modified ordinary coordinator cannot publish a qualified performed-administration claim without an exact deployment-rooted verifier authorization.

## Model

Adds `medication_administration_integrity` + thin coordinator with:

- fail-closed DNA property `medication_administration.root_authorities: []` by default;
- exact, short-lived verifier authorization (hard cap 15 minutes);
- privacy-minimized `MedicationAdministrationAttestationV1`;
- domain-separated `MedicationAdministrationAttestation` digest;
- authorization bound to the exact attestation digest **and** exact receipt/event/medication/activation/dispense/principal/policies;
- qualified administration publication only by the named verifier during the authorization window;
- append-only correction lineage for entered-in-error/wrong-patient/wrong-medication/wrong-dose/wrong-route/duplicate/source-evidence cases;
- no update/delete-based revocation semantics.

## Exact-target improvement

The authorization binds a domain-separated digest of the complete public attestation, including `administration_id`. A verifier therefore cannot reuse one short-lived authorization to publish the same private receipt lineage under arbitrarily changed public IDs.

## Privacy

The DHT attestation does not require patient identity, medication name, dose, route, site, diagnosis, notes, or narrative rationale. Those remain protected. The public layer carries evidence identities and the administrator principal binding.

## Corrections

Qualified administration is immutable. Corrections are separate append-only records and links. The original claim remains auditable; later read models must derive current interpretation from publication + correction lineage rather than mutable `performed=true` state.

## Non-claims

- no claim that DHT publication proves the physical act occurred;
- no claim that a patient-binding adapter is institutionally trustworthy by type alone;
- no clinical re-reasoning inside the integrity zome;
- no global read completeness claim;
- no regulatory/clinical qualification until exact-head CI and conductor/adversarial evidence pass.

## Qualification

See:

- `docs/security/MEDICATION_ADMINISTRATION_ATTESTATION_V1.md`
- `docs/security/MEDICATION_ADMINISTRATION_ATTESTATION_QUALIFICATION_CHECKLIST.md`

The repository ships with administration roots empty, so this path is disabled until a deployment explicitly repacks the DNA with trusted root AgentPubKeys.