### PR TITLE
feat(admin): add conflict-preserving administration state reducer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ members = [
     "crates/medication-dispensing",
     "crates/medication-dispense-state",
     "crates/medication-administration",
+    "crates/medication-administration-state",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/medication-administration-state/Cargo.toml
+++ b/crates/medication-administration-state/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mycelix-medication-administration-state"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Conflict-preserving qualified medication administration read model for Mycelix-Health"
+
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }
+holo_hash = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
+medication_administration_integrity = { path = "../../zomes/medication_administration/integrity" }
+
+[dev-dependencies]
+hdi = { workspace = true }

--- a/crates/medication-administration-state/Cargo.toml
+++ b/crates/medication-administration-state/Cargo.toml
@@ -11,6 +11,3 @@ thiserror = { workspace = true }
 holo_hash = { workspace = true }
 mycelix-clinical-integrity = { path = "../clinical-integrity" }
 medication_administration_integrity = { path = "../../zomes/medication_administration/integrity" }
-
-[dev-dependencies]
-hdi = { workspace = true }

--- a/crates/medication-administration-state/README.md
+++ b/crates/medication-administration-state/README.md
@@ -1,0 +1,9 @@
+# Mycelix Medication Administration State
+
+Conflict-preserving read model for qualified clinician medication-administration attestations and append-only corrections.
+
+This crate deliberately exposes `None`, `One`, or `Conflict` per v1 logical administration occurrence. It never derives a bare `performed: bool`, never chooses a winner by timestamp, and never upgrades legacy `MedicationAdherence` records into qualified administration.
+
+`DuplicateDocumentation` suppresses only the targeted publication action. Other v1 correction reasons invalidate the semantic administration-receipt lineage. All correction provenance remains visible.
+
+The caller must provide a complete-for-purpose set of already DHT-valid records. The reducer does not prove global query completeness. V1 uses `administration_id` as a logical occurrence key; P0 #67 tracks replacement with a computable clinical occurrence identity before scheduled-dose uniqueness may be claimed.

--- a/crates/medication-administration-state/src/lib.rs
+++ b/crates/medication-administration-state/src/lib.rs
@@ -2,13 +2,17 @@
 //! Conflict-preserving qualified medication administration read model.
 //!
 //! This crate reduces already DHT-valid administration publications and corrections.
-//! It does not query the DHT and never interprets missing data as proof of global absence.
-//! There is deliberately no `performed: bool` or last-write-wins rule.
+//! It does not query the DHT and never interprets missing data as proof of global
+//! absence. There is deliberately no `performed: bool` or last-write-wins rule.
+//!
+//! V1 groups competing semantic receipts by `administration_id`. That is an explicit
+//! temporary logical key, not proof of a unique real-world scheduled dose. P0 #67
+//! tracks replacement with a computable administration-occurrence identity.
 
 use holo_hash::ActionHash;
 use medication_administration_integrity::{
-    AdministrationCorrectionReason, MedicationAdministrationCorrection,
-    MedicationAdministrationAttestationV1, QualifiedMedicationAdministration,
+    AdministrationCorrectionReason, MedicationAdministrationAttestationV1,
+    MedicationAdministrationCorrection, QualifiedMedicationAdministration,
 };
 use mycelix_clinical_integrity::{DigestDomain, StoredDigest};
 use serde::Serialize;
@@ -27,7 +31,7 @@ pub struct AdministrationCorrectionRecord {
     pub correction: MedicationAdministrationCorrection,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct AdministrationCorrectionView {
     pub correction_action_hash: ActionHash,
     pub target_publication_action_hash: ActionHash,
@@ -35,7 +39,7 @@ pub struct AdministrationCorrectionView {
     pub rationale_commitment: Option<[u8; 32]>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub enum AdministrationLineageLifecycle {
     /// At least one unsuppressed publication remains and no semantic-invalidating
     /// correction is known in the supplied complete-for-purpose read set.
@@ -44,14 +48,14 @@ pub enum AdministrationLineageLifecycle {
     Corrected {
         semantic_corrections: Vec<AdministrationCorrectionView>,
     },
-    /// Every publication of this semantic receipt has been marked duplicate
-    /// documentation, while no semantic-invalidating correction exists.
+    /// Every publication of this semantic receipt is explicitly classified as
+    /// duplicate documentation, with no semantic-invalidating correction.
     PublicationSuppressed {
         duplicate_corrections: Vec<AdministrationCorrectionView>,
     },
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct AdministrationLineageView {
     pub administration_id: String,
     pub administration_receipt_digest: StoredDigest,
@@ -64,10 +68,9 @@ pub struct AdministrationLineageView {
     pub administration_policy_digest: StoredDigest,
     /// All equivalent DHT publications of this exact semantic receipt.
     pub publication_action_hashes: Vec<ActionHash>,
-    /// Publications not individually suppressed as duplicate documentation.
+    /// Publications not individually suppressed by `DuplicateDocumentation`.
     pub effective_publication_action_hashes: Vec<ActionHash>,
-    /// Complete correction provenance, regardless of whether each correction is
-    /// publication-scoped or semantic-receipt-scoped.
+    /// Complete correction provenance, regardless of correction effect.
     pub corrections: Vec<AdministrationCorrectionView>,
     pub lifecycle: AdministrationLineageLifecycle,
 }
@@ -83,17 +86,16 @@ pub enum AdministrationCurrentState {
     },
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct AdministrationOccurrenceView {
-    /// V1 logical occurrence key. The verifier is responsible for ensuring this ID is
-    /// stable for the intended administration occurrence. A future computable schedule
-    /// occurrence digest should replace reliance on caller-selected IDs.
+    /// V1 logical grouping key. See P0 #67 before treating this as a globally unique
+    /// intended-dose occurrence identity.
     pub administration_id: String,
     pub current: AdministrationCurrentState,
     pub lineages: Vec<AdministrationLineageView>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct MedicationAdministrationView {
     pub occurrences: Vec<AdministrationOccurrenceView>,
 }
@@ -109,9 +111,9 @@ struct PublicationGroup {
 
 /// Reduce a complete-for-purpose set of already DHT-valid administration records.
 ///
-/// The caller must supply all relevant publications and correction records for the
-/// scope it wishes to interpret. The reducer can prove reference closure inside that
-/// set, but it cannot prove that an omitted correction does not exist elsewhere.
+/// The caller must materialize all relevant publications and correction records for
+/// the scope it wants to interpret. Reference closure is checked inside the supplied
+/// set, but this function cannot prove an omitted correction does not exist elsewhere.
 pub fn reduce_administration_state(
     publications: &[AdministrationPublicationRecord],
     corrections: &[AdministrationCorrectionRecord],
@@ -124,8 +126,8 @@ pub fn reduce_administration_state(
     let mut groups: HashMap<StoredDigest, PublicationGroup> = HashMap::new();
 
     for record in publications {
-        validate_attestation_shape(&record.administration.attestation)?;
         let attestation = &record.administration.attestation;
+        validate_attestation_shape(attestation)?;
         let receipt = attestation.administration_receipt_digest;
 
         if let Some(existing) = publication_payload_by_action.get(&record.action_hash) {
@@ -160,17 +162,33 @@ pub fn reduce_administration_state(
         }
     }
 
-    let mut seen_correction_actions: HashMap<ActionHash, MedicationAdministrationCorrection> =
+    let mut correction_payload_by_action: HashMap<ActionHash, MedicationAdministrationCorrection> =
         HashMap::new();
+    let mut correction_id_owner: HashMap<String, ActionHash> = HashMap::new();
+
     for record in corrections {
         validate_correction_shape(&record.correction)?;
-        if let Some(existing) = seen_correction_actions.get(&record.action_hash) {
+
+        if let Some(existing) = correction_payload_by_action.get(&record.action_hash) {
             if existing != &record.correction {
                 return Err(AdministrationStateError::CorrectionActionHashPayloadConflict);
             }
             continue;
         }
-        seen_correction_actions.insert(record.action_hash.clone(), record.correction.clone());
+        correction_payload_by_action.insert(record.action_hash.clone(), record.correction.clone());
+
+        match correction_id_owner.get(&record.correction.correction_id) {
+            Some(existing_action) if existing_action != &record.action_hash => {
+                return Err(AdministrationStateError::DuplicateCorrectionId);
+            }
+            Some(_) => {}
+            None => {
+                correction_id_owner.insert(
+                    record.correction.correction_id.clone(),
+                    record.action_hash.clone(),
+                );
+            }
+        }
 
         let target_receipt = publication_by_action
             .get(&record.correction.administration_hash)
@@ -182,27 +200,25 @@ pub fn reduce_administration_state(
         let group = groups
             .get_mut(target_receipt)
             .ok_or(AdministrationStateError::OrphanCorrection)?;
-        let view = AdministrationCorrectionView {
+        let correction_view = AdministrationCorrectionView {
             correction_action_hash: record.action_hash.clone(),
             target_publication_action_hash: record.correction.administration_hash.clone(),
-            reason: record.correction.reason.clone(),
+            reason: record.correction.reason,
             rationale_commitment: record.correction.rationale_commitment,
         };
 
-        if matches!(
-            record.correction.reason,
-            AdministrationCorrectionReason::DuplicateDocumentation
-        ) {
+        if record.correction.reason == AdministrationCorrectionReason::DuplicateDocumentation {
             group
                 .duplicate_suppressed_actions
                 .insert(record.correction.administration_hash.clone());
-            group.duplicate_corrections.push(view);
+            group.duplicate_corrections.push(correction_view);
         } else {
-            group.semantic_corrections.push(view);
+            group.semantic_corrections.push(correction_view);
         }
     }
 
     let mut by_occurrence: HashMap<String, Vec<AdministrationLineageView>> = HashMap::new();
+
     for (_, mut group) in groups {
         group.publication_action_hashes.sort_by(action_hash_order);
         group.duplicate_corrections.sort_by(correction_order);
@@ -349,7 +365,7 @@ fn validate_correction_shape(
     {
         return Err(AdministrationStateError::MalformedCorrection);
     }
-    if matches!(correction.reason, AdministrationCorrectionReason::Other)
+    if correction.reason == AdministrationCorrectionReason::Other
         && correction.rationale_commitment.is_none()
     {
         return Err(AdministrationStateError::MalformedCorrection);
@@ -404,6 +420,12 @@ fn correction_order(
     action_hash_order(&left.correction_action_hash, &right.correction_action_hash)
 }
 
+fn digest_order(left: &StoredDigest, right: &StoredDigest) -> std::cmp::Ordering {
+    digest_domain_rank(left.domain)
+        .cmp(&digest_domain_rank(right.domain))
+        .then_with(|| left.value.cmp(&right.value))
+}
+
 fn digest_domain_rank(domain: DigestDomain) -> u16 {
     match domain {
         DigestDomain::MedicationAdministrationReceipt => 0,
@@ -411,12 +433,6 @@ fn digest_domain_rank(domain: DigestDomain) -> u16 {
         DigestDomain::EmergencyMedicationOverrideReceipt => 2,
         _ => 100,
     }
-}
-
-fn digest_order(left: &StoredDigest, right: &StoredDigest) -> std::cmp::Ordering {
-    digest_domain_rank(left.domain)
-        .cmp(&digest_domain_rank(right.domain))
-        .then_with(|| left.value.cmp(&right.value))
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
@@ -438,6 +454,8 @@ pub enum AdministrationStateError {
     ActionHashPayloadConflict,
     #[error("same correction action hash was supplied with conflicting payloads")]
     CorrectionActionHashPayloadConflict,
+    #[error("correction_id is reused by multiple correction actions")]
+    DuplicateCorrectionId,
     #[error("same semantic administration receipt is paired with changed attestation fields")]
     ConflictingSemanticReceiptDuplicate,
     #[error("administration correction target publication is missing from supplied read set")]
@@ -536,7 +554,7 @@ mod tests {
             2
         );
         assert!(matches!(
-            view.occurrences[0].current,
+            &view.occurrences[0].current,
             AdministrationCurrentState::One { .. }
         ));
     }
@@ -577,7 +595,7 @@ mod tests {
         let c = correction(3, &b, AdministrationCorrectionReason::DuplicateDocumentation);
         let view = reduce_administration_state(&[a, b], &[c]).unwrap();
         assert!(matches!(
-            view.occurrences[0].current,
+            &view.occurrences[0].current,
             AdministrationCurrentState::One { .. }
         ));
         assert_eq!(
@@ -609,7 +627,10 @@ mod tests {
         let a = publication(1, "dose-a", 20);
         let c = correction(2, &a, AdministrationCorrectionReason::DuplicateDocumentation);
         let view = reduce_administration_state(&[a], &[c]).unwrap();
-        assert_eq!(view.occurrences[0].current, AdministrationCurrentState::None);
+        assert_eq!(
+            &view.occurrences[0].current,
+            &AdministrationCurrentState::None
+        );
         assert!(matches!(
             &view.occurrences[0].lineages[0].lifecycle,
             AdministrationLineageLifecycle::PublicationSuppressed { .. }
@@ -634,6 +655,19 @@ mod tests {
         assert_eq!(
             reduce_administration_state(&[], &[fake]),
             Err(AdministrationStateError::OrphanCorrection)
+        );
+    }
+
+    #[test]
+    fn duplicate_correction_id_fails_closed() {
+        let a = publication(1, "dose-a", 20);
+        let mut first = correction(2, &a, AdministrationCorrectionReason::DuplicateDocumentation);
+        let mut second = correction(3, &a, AdministrationCorrectionReason::WrongDose);
+        first.correction.correction_id = "same-id".into();
+        second.correction.correction_id = "same-id".into();
+        assert_eq!(
+            reduce_administration_state(&[a], &[first, second]),
+            Err(AdministrationStateError::DuplicateCorrectionId)
         );
     }
 

--- a/crates/medication-administration-state/src/lib.rs
+++ b/crates/medication-administration-state/src/lib.rs
@@ -1,0 +1,617 @@
+#![deny(unsafe_code)]
+//! Conflict-preserving qualified medication administration read model.
+//!
+//! This crate reduces already DHT-valid administration publications and corrections.
+//! It does not query the DHT and never interprets missing data as proof of global absence.
+//! There is deliberately no `performed: bool` or last-write-wins rule.
+
+use holo_hash::ActionHash;
+use medication_administration_integrity::{
+    AdministrationCorrectionReason, MedicationAdministrationCorrection,
+    MedicationAdministrationAttestationV1, QualifiedMedicationAdministration,
+};
+use mycelix_clinical_integrity::{DigestDomain, StoredDigest};
+use serde::Serialize;
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
+
+#[derive(Clone)]
+pub struct AdministrationPublicationRecord {
+    pub action_hash: ActionHash,
+    pub administration: QualifiedMedicationAdministration,
+}
+
+#[derive(Clone)]
+pub struct AdministrationCorrectionRecord {
+    pub action_hash: ActionHash,
+    pub correction: MedicationAdministrationCorrection,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct AdministrationCorrectionView {
+    pub correction_action_hash: ActionHash,
+    pub target_publication_action_hash: ActionHash,
+    pub reason: AdministrationCorrectionReason,
+    pub rationale_commitment: Option<[u8; 32]>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub enum AdministrationLineageLifecycle {
+    /// At least one unsuppressed publication remains and no semantic-invalidating
+    /// correction is known in the supplied complete-for-purpose read set.
+    Current,
+    /// One or more corrections invalidate the semantic administration receipt.
+    Corrected {
+        corrections: Vec<AdministrationCorrectionView>,
+    },
+    /// Every publication of this semantic receipt has been marked duplicate
+    /// documentation, while no semantic-invalidating correction exists.
+    PublicationSuppressed {
+        corrections: Vec<AdministrationCorrectionView>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct AdministrationLineageView {
+    pub administration_id: String,
+    pub administration_receipt_digest: StoredDigest,
+    pub event_digest: StoredDigest,
+    pub medication_artifact_digest: StoredDigest,
+    pub activation_semantic_receipt_digest: StoredDigest,
+    pub finalized_dispense_receipt_digest: StoredDigest,
+    pub administrator_principal_binding: [u8; 32],
+    pub authority_policy_digest: StoredDigest,
+    pub administration_policy_digest: StoredDigest,
+    /// All equivalent DHT publications of this exact semantic receipt.
+    pub publication_action_hashes: Vec<ActionHash>,
+    /// Publications not individually suppressed as duplicate documentation.
+    pub effective_publication_action_hashes: Vec<ActionHash>,
+    pub lifecycle: AdministrationLineageLifecycle,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub enum AdministrationCurrentState {
+    None,
+    One {
+        administration_receipt_digest: StoredDigest,
+    },
+    Conflict {
+        administration_receipt_digests: Vec<StoredDigest>,
+    },
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct AdministrationOccurrenceView {
+    /// V1 logical occurrence key. The verifier is responsible for ensuring this ID is
+    /// stable for the intended administration occurrence. A future computable schedule
+    /// occurrence digest should replace reliance on caller-selected IDs.
+    pub administration_id: String,
+    pub current: AdministrationCurrentState,
+    pub lineages: Vec<AdministrationLineageView>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct MedicationAdministrationView {
+    pub occurrences: Vec<AdministrationOccurrenceView>,
+}
+
+#[derive(Clone)]
+struct PublicationGroup {
+    attestation: MedicationAdministrationAttestationV1,
+    publication_action_hashes: Vec<ActionHash>,
+    duplicate_suppressed_actions: HashSet<ActionHash>,
+    duplicate_corrections: Vec<AdministrationCorrectionView>,
+    semantic_corrections: Vec<AdministrationCorrectionView>,
+}
+
+/// Reduce a complete-for-purpose set of already DHT-valid administration records.
+///
+/// The caller must supply all relevant publications and correction records for the
+/// scope it wishes to interpret. The reducer can prove reference closure inside that
+/// set, but it cannot prove that an omitted correction does not exist elsewhere.
+pub fn reduce_administration_state(
+    publications: &[AdministrationPublicationRecord],
+    corrections: &[AdministrationCorrectionRecord],
+) -> Result<MedicationAdministrationView, AdministrationStateError> {
+    let mut publication_by_action: HashMap<ActionHash, (String, StoredDigest)> = HashMap::new();
+    let mut publication_payload_by_action: HashMap<ActionHash, MedicationAdministrationAttestationV1> =
+        HashMap::new();
+    let mut groups: HashMap<StoredDigest, PublicationGroup> = HashMap::new();
+
+    for record in publications {
+        validate_attestation_shape(&record.administration.attestation)?;
+        let attestation = &record.administration.attestation;
+        let receipt = attestation.administration_receipt_digest;
+
+        if let Some(existing) = publication_payload_by_action.get(&record.action_hash) {
+            if existing != attestation {
+                return Err(AdministrationStateError::ActionHashPayloadConflict);
+            }
+            continue;
+        }
+
+        publication_payload_by_action.insert(record.action_hash.clone(), attestation.clone());
+        publication_by_action.insert(
+            record.action_hash.clone(),
+            (attestation.administration_id.clone(), receipt),
+        );
+
+        match groups.get_mut(&receipt) {
+            Some(group) => {
+                if group.attestation != *attestation {
+                    return Err(AdministrationStateError::ConflictingSemanticReceiptDuplicate);
+                }
+                push_unique(&mut group.publication_action_hashes, record.action_hash.clone());
+            }
+            None => {
+                groups.insert(
+                    receipt,
+                    PublicationGroup {
+                        attestation: attestation.clone(),
+                        publication_action_hashes: vec![record.action_hash.clone()],
+                        duplicate_suppressed_actions: HashSet::new(),
+                        duplicate_corrections: Vec::new(),
+                        semantic_corrections: Vec::new(),
+                    },
+                );
+            }
+        }
+    }
+
+    let mut seen_correction_actions: HashMap<ActionHash, MedicationAdministrationCorrection> =
+        HashMap::new();
+    for record in corrections {
+        validate_correction_shape(&record.correction)?;
+        if let Some(existing) = seen_correction_actions.get(&record.action_hash) {
+            if existing != &record.correction {
+                return Err(AdministrationStateError::CorrectionActionHashPayloadConflict);
+            }
+            continue;
+        }
+        seen_correction_actions.insert(record.action_hash.clone(), record.correction.clone());
+
+        let (_, target_receipt) = publication_by_action
+            .get(&record.correction.administration_hash)
+            .ok_or(AdministrationStateError::OrphanCorrection)?;
+        if *target_receipt != record.correction.administration_receipt_digest {
+            return Err(AdministrationStateError::CorrectionReceiptMismatch);
+        }
+
+        let group = groups
+            .get_mut(target_receipt)
+            .ok_or(AdministrationStateError::OrphanCorrection)?;
+        let view = AdministrationCorrectionView {
+            correction_action_hash: record.action_hash.clone(),
+            target_publication_action_hash: record.correction.administration_hash.clone(),
+            reason: record.correction.reason.clone(),
+            rationale_commitment: record.correction.rationale_commitment,
+        };
+
+        if matches!(record.correction.reason, AdministrationCorrectionReason::DuplicateDocumentation)
+        {
+            group
+                .duplicate_suppressed_actions
+                .insert(record.correction.administration_hash.clone());
+            group.duplicate_corrections.push(view);
+        } else {
+            group.semantic_corrections.push(view);
+        }
+    }
+
+    let mut by_occurrence: HashMap<String, Vec<AdministrationLineageView>> = HashMap::new();
+    for (_, mut group) in groups {
+        group.publication_action_hashes.sort_by(action_hash_order);
+        group.duplicate_corrections.sort_by(correction_order);
+        group.semantic_corrections.sort_by(correction_order);
+
+        let effective_publication_action_hashes: Vec<ActionHash> = group
+            .publication_action_hashes
+            .iter()
+            .filter(|hash| !group.duplicate_suppressed_actions.contains(*hash))
+            .cloned()
+            .collect();
+
+        let lifecycle = if !group.semantic_corrections.is_empty() {
+            AdministrationLineageLifecycle::Corrected {
+                corrections: group.semantic_corrections.clone(),
+            }
+        } else if effective_publication_action_hashes.is_empty() {
+            AdministrationLineageLifecycle::PublicationSuppressed {
+                corrections: group.duplicate_corrections.clone(),
+            }
+        } else {
+            AdministrationLineageLifecycle::Current
+        };
+
+        let attestation = group.attestation;
+        let view = AdministrationLineageView {
+            administration_id: attestation.administration_id.clone(),
+            administration_receipt_digest: attestation.administration_receipt_digest,
+            event_digest: attestation.event_digest,
+            medication_artifact_digest: attestation.medication_artifact_digest,
+            activation_semantic_receipt_digest: attestation.activation_semantic_receipt_digest,
+            finalized_dispense_receipt_digest: attestation.finalized_dispense_receipt_digest,
+            administrator_principal_binding: attestation.administrator_principal_binding,
+            authority_policy_digest: attestation.authority_policy_digest,
+            administration_policy_digest: attestation.administration_policy_digest,
+            publication_action_hashes: group.publication_action_hashes,
+            effective_publication_action_hashes,
+            lifecycle,
+        };
+        by_occurrence
+            .entry(view.administration_id.clone())
+            .or_default()
+            .push(view);
+    }
+
+    let mut occurrences = Vec::with_capacity(by_occurrence.len());
+    for (administration_id, mut lineages) in by_occurrence {
+        lineages.sort_by(|left, right| digest_order(
+            &left.administration_receipt_digest,
+            &right.administration_receipt_digest,
+        ));
+
+        let mut current_receipts: Vec<StoredDigest> = lineages
+            .iter()
+            .filter(|lineage| matches!(&lineage.lifecycle, AdministrationLineageLifecycle::Current))
+            .map(|lineage| lineage.administration_receipt_digest)
+            .collect();
+        current_receipts.sort_by(digest_order);
+        current_receipts.dedup();
+
+        let current = match current_receipts.as_slice() {
+            [] => AdministrationCurrentState::None,
+            [one] => AdministrationCurrentState::One {
+                administration_receipt_digest: *one,
+            },
+            _ => AdministrationCurrentState::Conflict {
+                administration_receipt_digests: current_receipts,
+            },
+        };
+
+        occurrences.push(AdministrationOccurrenceView {
+            administration_id,
+            current,
+            lineages,
+        });
+    }
+    occurrences.sort_by(|left, right| left.administration_id.cmp(&right.administration_id));
+
+    Ok(MedicationAdministrationView { occurrences })
+}
+
+fn validate_attestation_shape(
+    attestation: &MedicationAdministrationAttestationV1,
+) -> Result<(), AdministrationStateError> {
+    if attestation.schema_version != 1 || attestation.administration_id.trim().is_empty() {
+        return Err(AdministrationStateError::MalformedAdministration);
+    }
+    if attestation.administrator_principal_binding == [0u8; 32] {
+        return Err(AdministrationStateError::MalformedAdministration);
+    }
+    require_domain(
+        attestation.administration_receipt_digest,
+        DigestDomain::MedicationAdministrationReceipt,
+    )?;
+    require_domain(
+        attestation.event_digest,
+        DigestDomain::MedicationAdministrationEvent,
+    )?;
+    require_domain(
+        attestation.medication_artifact_digest,
+        DigestDomain::MedicationRequestArtifact,
+    )?;
+    require_activation_receipt_domain(attestation.activation_semantic_receipt_digest)?;
+    require_domain(
+        attestation.finalized_dispense_receipt_digest,
+        DigestDomain::MedicationDispenseReceipt,
+    )?;
+    require_domain(attestation.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+    require_domain(
+        attestation.administration_policy_digest,
+        DigestDomain::MedicationAdministrationPolicy,
+    )?;
+    Ok(())
+}
+
+fn validate_correction_shape(
+    correction: &MedicationAdministrationCorrection,
+) -> Result<(), AdministrationStateError> {
+    if correction.correction_id.trim().is_empty() {
+        return Err(AdministrationStateError::MalformedCorrection);
+    }
+    require_domain(
+        correction.administration_receipt_digest,
+        DigestDomain::MedicationAdministrationReceipt,
+    )?;
+    if correction
+        .rationale_commitment
+        .is_some_and(|commitment| commitment == [0u8; 32])
+    {
+        return Err(AdministrationStateError::MalformedCorrection);
+    }
+    if matches!(correction.reason, AdministrationCorrectionReason::Other)
+        && correction.rationale_commitment.is_none()
+    {
+        return Err(AdministrationStateError::MalformedCorrection);
+    }
+    Ok(())
+}
+
+fn require_activation_receipt_domain(digest: StoredDigest) -> Result<(), AdministrationStateError> {
+    digest
+        .validate_shape()
+        .map_err(|_| AdministrationStateError::InvalidDigest)?;
+    if !matches!(
+        digest.domain,
+        DigestDomain::MedicationActivationReceipt
+            | DigestDomain::EmergencyMedicationOverrideReceipt
+    ) {
+        return Err(AdministrationStateError::WrongActivationReceiptDomain);
+    }
+    Ok(())
+}
+
+fn require_domain(
+    digest: StoredDigest,
+    expected: DigestDomain,
+) -> Result<(), AdministrationStateError> {
+    digest
+        .validate_shape()
+        .map_err(|_| AdministrationStateError::InvalidDigest)?;
+    if digest.domain != expected {
+        return Err(AdministrationStateError::WrongDigestDomain {
+            expected,
+            actual: digest.domain,
+        });
+    }
+    Ok(())
+}
+
+fn push_unique<T: PartialEq>(values: &mut Vec<T>, value: T) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
+fn action_hash_order(left: &ActionHash, right: &ActionHash) -> std::cmp::Ordering {
+    left.get_raw_36().cmp(right.get_raw_36())
+}
+
+fn correction_order(
+    left: &AdministrationCorrectionView,
+    right: &AdministrationCorrectionView,
+) -> std::cmp::Ordering {
+    action_hash_order(&left.correction_action_hash, &right.correction_action_hash)
+}
+
+fn digest_domain_rank(domain: DigestDomain) -> u16 {
+    match domain {
+        DigestDomain::MedicationAdministrationReceipt => 0,
+        DigestDomain::MedicationActivationReceipt => 1,
+        DigestDomain::EmergencyMedicationOverrideReceipt => 2,
+        _ => 100,
+    }
+}
+
+fn digest_order(left: &StoredDigest, right: &StoredDigest) -> std::cmp::Ordering {
+    digest_domain_rank(left.domain)
+        .cmp(&digest_domain_rank(right.domain))
+        .then_with(|| left.value.cmp(&right.value))
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum AdministrationStateError {
+    #[error("qualified medication administration is malformed")]
+    MalformedAdministration,
+    #[error("medication administration correction is malformed")]
+    MalformedCorrection,
+    #[error("stored digest is invalid")]
+    InvalidDigest,
+    #[error("digest domain mismatch: expected {expected:?}, got {actual:?}")]
+    WrongDigestDomain {
+        expected: DigestDomain,
+        actual: DigestDomain,
+    },
+    #[error("activation semantic receipt has invalid digest domain")]
+    WrongActivationReceiptDomain,
+    #[error("same publication action hash was supplied with conflicting payloads")]
+    ActionHashPayloadConflict,
+    #[error("same correction action hash was supplied with conflicting payloads")]
+    CorrectionActionHashPayloadConflict,
+    #[error("same semantic administration receipt is paired with changed attestation fields")]
+    ConflictingSemanticReceiptDuplicate,
+    #[error("administration correction target publication is missing from supplied read set")]
+    OrphanCorrection,
+    #[error("administration correction receipt does not match target publication")]
+    CorrectionReceiptMismatch,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use holo_hash::AgentPubKey;
+    use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain};
+
+    fn stored(domain: DigestDomain, seed: u8) -> StoredDigest {
+        StoredDigest {
+            algorithm: DigestAlgorithm::Blake3_256,
+            domain,
+            value: [seed; 32],
+        }
+    }
+
+    fn action(seed: u8) -> ActionHash {
+        ActionHash::from_raw_36(vec![seed; 36])
+    }
+
+    fn attestation(id: &str, receipt_seed: u8) -> MedicationAdministrationAttestationV1 {
+        MedicationAdministrationAttestationV1 {
+            schema_version: 1,
+            administration_id: id.into(),
+            administration_receipt_digest: stored(
+                DigestDomain::MedicationAdministrationReceipt,
+                receipt_seed,
+            ),
+            event_digest: stored(DigestDomain::MedicationAdministrationEvent, receipt_seed + 1),
+            medication_artifact_digest: stored(DigestDomain::MedicationRequestArtifact, 10),
+            activation_semantic_receipt_digest: stored(DigestDomain::MedicationActivationReceipt, 11),
+            finalized_dispense_receipt_digest: stored(DigestDomain::MedicationDispenseReceipt, 12),
+            administrator_principal_binding: [13; 32],
+            authority_policy_digest: stored(DigestDomain::AuthorityPolicy, 14),
+            administration_policy_digest: stored(DigestDomain::MedicationAdministrationPolicy, 15),
+        }
+    }
+
+    fn publication(action_seed: u8, id: &str, receipt_seed: u8) -> AdministrationPublicationRecord {
+        AdministrationPublicationRecord {
+            action_hash: action(action_seed),
+            administration: QualifiedMedicationAdministration {
+                attestation: attestation(id, receipt_seed),
+                verifier_authorization_hash: action(200),
+            },
+        }
+    }
+
+    fn correction(
+        action_seed: u8,
+        target: &AdministrationPublicationRecord,
+        reason: AdministrationCorrectionReason,
+    ) -> AdministrationCorrectionRecord {
+        AdministrationCorrectionRecord {
+            action_hash: action(action_seed),
+            correction: MedicationAdministrationCorrection {
+                correction_id: format!("correction-{action_seed}"),
+                administration_hash: target.action_hash.clone(),
+                administration_receipt_digest: target
+                    .administration
+                    .attestation
+                    .administration_receipt_digest,
+                reason,
+                rationale_commitment: None,
+            },
+        }
+    }
+
+    #[test]
+    fn duplicate_publications_of_same_receipt_are_idempotent() {
+        let a = publication(1, "dose-a", 20);
+        let mut b = publication(2, "dose-a", 20);
+        b.administration.attestation = a.administration.attestation.clone();
+        let view = reduce_administration_state(&[a, b], &[]).unwrap();
+        assert_eq!(view.occurrences.len(), 1);
+        assert_eq!(view.occurrences[0].lineages.len(), 1);
+        assert_eq!(view.occurrences[0].lineages[0].publication_action_hashes.len(), 2);
+        assert!(matches!(
+            view.occurrences[0].current,
+            AdministrationCurrentState::One { .. }
+        ));
+    }
+
+    #[test]
+    fn distinct_current_receipts_for_same_administration_id_are_conflict() {
+        let a = publication(1, "dose-a", 20);
+        let b = publication(2, "dose-a", 30);
+        let view = reduce_administration_state(&[a, b], &[]).unwrap();
+        assert!(matches!(
+            &view.occurrences[0].current,
+            AdministrationCurrentState::Conflict { .. }
+        ));
+    }
+
+    #[test]
+    fn semantic_correction_can_resolve_conflict_without_last_write_wins() {
+        let a = publication(1, "dose-a", 20);
+        let b = publication(2, "dose-a", 30);
+        let c = correction(3, &b, AdministrationCorrectionReason::WrongDose);
+        let view = reduce_administration_state(&[a, b], &[c]).unwrap();
+        match &view.occurrences[0].current {
+            AdministrationCurrentState::One {
+                administration_receipt_digest,
+            } => assert_eq!(*administration_receipt_digest, stored(DigestDomain::MedicationAdministrationReceipt, 20)),
+            _ => panic!("explicit semantic correction should leave one current receipt"),
+        }
+    }
+
+    #[test]
+    fn duplicate_documentation_suppresses_only_target_publication() {
+        let a = publication(1, "dose-a", 20);
+        let mut b = publication(2, "dose-a", 20);
+        b.administration.attestation = a.administration.attestation.clone();
+        let c = correction(3, &b, AdministrationCorrectionReason::DuplicateDocumentation);
+        let view = reduce_administration_state(&[a, b], &[c]).unwrap();
+        assert!(matches!(
+            view.occurrences[0].current,
+            AdministrationCurrentState::One { .. }
+        ));
+        assert_eq!(
+            view.occurrences[0].lineages[0].effective_publication_action_hashes.len(),
+            1
+        );
+    }
+
+    #[test]
+    fn suppressing_only_publication_leaves_no_current_claim() {
+        let a = publication(1, "dose-a", 20);
+        let c = correction(2, &a, AdministrationCorrectionReason::DuplicateDocumentation);
+        let view = reduce_administration_state(&[a], &[c]).unwrap();
+        assert_eq!(view.occurrences[0].current, AdministrationCurrentState::None);
+        assert!(matches!(
+            &view.occurrences[0].lineages[0].lifecycle,
+            AdministrationLineageLifecycle::PublicationSuppressed { .. }
+        ));
+    }
+
+    #[test]
+    fn orphan_correction_fails_closed() {
+        let fake = AdministrationCorrectionRecord {
+            action_hash: action(2),
+            correction: MedicationAdministrationCorrection {
+                correction_id: "orphan".into(),
+                administration_hash: action(99),
+                administration_receipt_digest: stored(
+                    DigestDomain::MedicationAdministrationReceipt,
+                    20,
+                ),
+                reason: AdministrationCorrectionReason::WrongPatient,
+                rationale_commitment: None,
+            },
+        };
+        assert_eq!(
+            reduce_administration_state(&[], &[fake]),
+            Err(AdministrationStateError::OrphanCorrection)
+        );
+    }
+
+    #[test]
+    fn input_order_does_not_change_state() {
+        let a = publication(1, "dose-a", 20);
+        let b = publication(2, "dose-a", 30);
+        let c = correction(3, &b, AdministrationCorrectionReason::WrongDose);
+        let forward = reduce_administration_state(&[a.clone(), b.clone()], &[c.clone()]).unwrap();
+        let reverse = reduce_administration_state(&[b, a], &[c]).unwrap();
+        assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn emergency_activation_domain_is_preserved() {
+        let mut a = publication(1, "dose-a", 20);
+        a.administration.attestation.activation_semantic_receipt_digest = stored(
+            DigestDomain::EmergencyMedicationOverrideReceipt,
+            11,
+        );
+        let view = reduce_administration_state(&[a], &[]).unwrap();
+        assert_eq!(
+            view.occurrences[0].lineages[0]
+                .activation_semantic_receipt_digest
+                .domain,
+            DigestDomain::EmergencyMedicationOverrideReceipt
+        );
+    }
+
+    #[test]
+    fn action_hash_constructor_fixture_is_valid() {
+        let _ = AgentPubKey::from_raw_36(vec![1; 36]);
+        assert_eq!(action(1).get_raw_36().len(), 36);
+    }
+}

--- a/crates/medication-administration-state/src/lib.rs
+++ b/crates/medication-administration-state/src/lib.rs
@@ -42,12 +42,12 @@ pub enum AdministrationLineageLifecycle {
     Current,
     /// One or more corrections invalidate the semantic administration receipt.
     Corrected {
-        corrections: Vec<AdministrationCorrectionView>,
+        semantic_corrections: Vec<AdministrationCorrectionView>,
     },
     /// Every publication of this semantic receipt has been marked duplicate
     /// documentation, while no semantic-invalidating correction exists.
     PublicationSuppressed {
-        corrections: Vec<AdministrationCorrectionView>,
+        duplicate_corrections: Vec<AdministrationCorrectionView>,
     },
 }
 
@@ -66,6 +66,9 @@ pub struct AdministrationLineageView {
     pub publication_action_hashes: Vec<ActionHash>,
     /// Publications not individually suppressed as duplicate documentation.
     pub effective_publication_action_hashes: Vec<ActionHash>,
+    /// Complete correction provenance, regardless of whether each correction is
+    /// publication-scoped or semantic-receipt-scoped.
+    pub corrections: Vec<AdministrationCorrectionView>,
     pub lifecycle: AdministrationLineageLifecycle,
 }
 
@@ -113,9 +116,11 @@ pub fn reduce_administration_state(
     publications: &[AdministrationPublicationRecord],
     corrections: &[AdministrationCorrectionRecord],
 ) -> Result<MedicationAdministrationView, AdministrationStateError> {
-    let mut publication_by_action: HashMap<ActionHash, (String, StoredDigest)> = HashMap::new();
-    let mut publication_payload_by_action: HashMap<ActionHash, MedicationAdministrationAttestationV1> =
-        HashMap::new();
+    let mut publication_by_action: HashMap<ActionHash, StoredDigest> = HashMap::new();
+    let mut publication_payload_by_action: HashMap<
+        ActionHash,
+        MedicationAdministrationAttestationV1,
+    > = HashMap::new();
     let mut groups: HashMap<StoredDigest, PublicationGroup> = HashMap::new();
 
     for record in publications {
@@ -131,10 +136,7 @@ pub fn reduce_administration_state(
         }
 
         publication_payload_by_action.insert(record.action_hash.clone(), attestation.clone());
-        publication_by_action.insert(
-            record.action_hash.clone(),
-            (attestation.administration_id.clone(), receipt),
-        );
+        publication_by_action.insert(record.action_hash.clone(), receipt);
 
         match groups.get_mut(&receipt) {
             Some(group) => {
@@ -170,7 +172,7 @@ pub fn reduce_administration_state(
         }
         seen_correction_actions.insert(record.action_hash.clone(), record.correction.clone());
 
-        let (_, target_receipt) = publication_by_action
+        let target_receipt = publication_by_action
             .get(&record.correction.administration_hash)
             .ok_or(AdministrationStateError::OrphanCorrection)?;
         if *target_receipt != record.correction.administration_receipt_digest {
@@ -187,8 +189,10 @@ pub fn reduce_administration_state(
             rationale_commitment: record.correction.rationale_commitment,
         };
 
-        if matches!(record.correction.reason, AdministrationCorrectionReason::DuplicateDocumentation)
-        {
+        if matches!(
+            record.correction.reason,
+            AdministrationCorrectionReason::DuplicateDocumentation
+        ) {
             group
                 .duplicate_suppressed_actions
                 .insert(record.correction.administration_hash.clone());
@@ -211,13 +215,17 @@ pub fn reduce_administration_state(
             .cloned()
             .collect();
 
+        let mut all_corrections = group.duplicate_corrections.clone();
+        all_corrections.extend(group.semantic_corrections.iter().cloned());
+        all_corrections.sort_by(correction_order);
+
         let lifecycle = if !group.semantic_corrections.is_empty() {
             AdministrationLineageLifecycle::Corrected {
-                corrections: group.semantic_corrections.clone(),
+                semantic_corrections: group.semantic_corrections.clone(),
             }
         } else if effective_publication_action_hashes.is_empty() {
             AdministrationLineageLifecycle::PublicationSuppressed {
-                corrections: group.duplicate_corrections.clone(),
+                duplicate_corrections: group.duplicate_corrections.clone(),
             }
         } else {
             AdministrationLineageLifecycle::Current
@@ -236,6 +244,7 @@ pub fn reduce_administration_state(
             administration_policy_digest: attestation.administration_policy_digest,
             publication_action_hashes: group.publication_action_hashes,
             effective_publication_action_hashes,
+            corrections: all_corrections,
             lifecycle,
         };
         by_occurrence
@@ -246,14 +255,21 @@ pub fn reduce_administration_state(
 
     let mut occurrences = Vec::with_capacity(by_occurrence.len());
     for (administration_id, mut lineages) in by_occurrence {
-        lineages.sort_by(|left, right| digest_order(
-            &left.administration_receipt_digest,
-            &right.administration_receipt_digest,
-        ));
+        lineages.sort_by(|left, right| {
+            digest_order(
+                &left.administration_receipt_digest,
+                &right.administration_receipt_digest,
+            )
+        });
 
         let mut current_receipts: Vec<StoredDigest> = lineages
             .iter()
-            .filter(|lineage| matches!(&lineage.lifecycle, AdministrationLineageLifecycle::Current))
+            .filter(|lineage| {
+                matches!(
+                    &lineage.lifecycle,
+                    AdministrationLineageLifecycle::Current
+                )
+            })
             .map(|lineage| lineage.administration_receipt_digest)
             .collect();
         current_receipts.sort_by(digest_order);
@@ -306,7 +322,10 @@ fn validate_attestation_shape(
         attestation.finalized_dispense_receipt_digest,
         DigestDomain::MedicationDispenseReceipt,
     )?;
-    require_domain(attestation.authority_policy_digest, DigestDomain::AuthorityPolicy)?;
+    require_domain(
+        attestation.authority_policy_digest,
+        DigestDomain::AuthorityPolicy,
+    )?;
     require_domain(
         attestation.administration_policy_digest,
         DigestDomain::MedicationAdministrationPolicy,
@@ -430,7 +449,6 @@ pub enum AdministrationStateError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use holo_hash::AgentPubKey;
     use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain};
 
     fn stored(domain: DigestDomain, seed: u8) -> StoredDigest {
@@ -453,9 +471,15 @@ mod tests {
                 DigestDomain::MedicationAdministrationReceipt,
                 receipt_seed,
             ),
-            event_digest: stored(DigestDomain::MedicationAdministrationEvent, receipt_seed + 1),
+            event_digest: stored(
+                DigestDomain::MedicationAdministrationEvent,
+                receipt_seed.wrapping_add(1),
+            ),
             medication_artifact_digest: stored(DigestDomain::MedicationRequestArtifact, 10),
-            activation_semantic_receipt_digest: stored(DigestDomain::MedicationActivationReceipt, 11),
+            activation_semantic_receipt_digest: stored(
+                DigestDomain::MedicationActivationReceipt,
+                11,
+            ),
             finalized_dispense_receipt_digest: stored(DigestDomain::MedicationDispenseReceipt, 12),
             administrator_principal_binding: [13; 32],
             authority_policy_digest: stored(DigestDomain::AuthorityPolicy, 14),
@@ -463,7 +487,11 @@ mod tests {
         }
     }
 
-    fn publication(action_seed: u8, id: &str, receipt_seed: u8) -> AdministrationPublicationRecord {
+    fn publication(
+        action_seed: u8,
+        id: &str,
+        receipt_seed: u8,
+    ) -> AdministrationPublicationRecord {
         AdministrationPublicationRecord {
             action_hash: action(action_seed),
             administration: QualifiedMedicationAdministration {
@@ -501,7 +529,12 @@ mod tests {
         let view = reduce_administration_state(&[a, b], &[]).unwrap();
         assert_eq!(view.occurrences.len(), 1);
         assert_eq!(view.occurrences[0].lineages.len(), 1);
-        assert_eq!(view.occurrences[0].lineages[0].publication_action_hashes.len(), 2);
+        assert_eq!(
+            view.occurrences[0].lineages[0]
+                .publication_action_hashes
+                .len(),
+            2
+        );
         assert!(matches!(
             view.occurrences[0].current,
             AdministrationCurrentState::One { .. }
@@ -528,7 +561,10 @@ mod tests {
         match &view.occurrences[0].current {
             AdministrationCurrentState::One {
                 administration_receipt_digest,
-            } => assert_eq!(*administration_receipt_digest, stored(DigestDomain::MedicationAdministrationReceipt, 20)),
+            } => assert_eq!(
+                *administration_receipt_digest,
+                stored(DigestDomain::MedicationAdministrationReceipt, 20)
+            ),
             _ => panic!("explicit semantic correction should leave one current receipt"),
         }
     }
@@ -545,9 +581,27 @@ mod tests {
             AdministrationCurrentState::One { .. }
         ));
         assert_eq!(
-            view.occurrences[0].lineages[0].effective_publication_action_hashes.len(),
+            view.occurrences[0].lineages[0]
+                .effective_publication_action_hashes
+                .len(),
             1
         );
+        assert_eq!(view.occurrences[0].lineages[0].corrections.len(), 1);
+    }
+
+    #[test]
+    fn semantic_and_duplicate_corrections_are_both_preserved() {
+        let a = publication(1, "dose-a", 20);
+        let mut b = publication(2, "dose-a", 20);
+        b.administration.attestation = a.administration.attestation.clone();
+        let duplicate = correction(3, &b, AdministrationCorrectionReason::DuplicateDocumentation);
+        let wrong_dose = correction(4, &a, AdministrationCorrectionReason::WrongDose);
+        let view = reduce_administration_state(&[a, b], &[duplicate, wrong_dose]).unwrap();
+        assert_eq!(view.occurrences[0].lineages[0].corrections.len(), 2);
+        assert!(matches!(
+            &view.occurrences[0].lineages[0].lifecycle,
+            AdministrationLineageLifecycle::Corrected { .. }
+        ));
     }
 
     #[test]
@@ -588,7 +642,8 @@ mod tests {
         let a = publication(1, "dose-a", 20);
         let b = publication(2, "dose-a", 30);
         let c = correction(3, &b, AdministrationCorrectionReason::WrongDose);
-        let forward = reduce_administration_state(&[a.clone(), b.clone()], &[c.clone()]).unwrap();
+        let forward =
+            reduce_administration_state(&[a.clone(), b.clone()], &[c.clone()]).unwrap();
         let reverse = reduce_administration_state(&[b, a], &[c]).unwrap();
         assert_eq!(forward, reverse);
     }
@@ -596,7 +651,9 @@ mod tests {
     #[test]
     fn emergency_activation_domain_is_preserved() {
         let mut a = publication(1, "dose-a", 20);
-        a.administration.attestation.activation_semantic_receipt_digest = stored(
+        a.administration
+            .attestation
+            .activation_semantic_receipt_digest = stored(
             DigestDomain::EmergencyMedicationOverrideReceipt,
             11,
         );
@@ -607,11 +664,5 @@ mod tests {
                 .domain,
             DigestDomain::EmergencyMedicationOverrideReceipt
         );
-    }
-
-    #[test]
-    fn action_hash_constructor_fixture_is_valid() {
-        let _ = AgentPubKey::from_raw_36(vec![1; 36]);
-        assert_eq!(action(1).get_raw_36().len(), 36);
     }
 }

--- a/docs/security/MEDICATION_ADMINISTRATION_STATE_V1.md
+++ b/docs/security/MEDICATION_ADMINISTRATION_STATE_V1.md
@@ -1,0 +1,90 @@
+# Medication Administration State v1
+
+Status: experimental / draft qualification
+
+## Purpose
+
+This reducer derives a deterministic current interpretation from already DHT-valid `QualifiedMedicationAdministration` publications plus append-only `MedicationAdministrationCorrection` records.
+
+It exists so downstream care, CDS, research, and Symthaea cannot collapse administration provenance into `performed = true`.
+
+## State model
+
+For each v1 logical occurrence key (`administration_id`), current state is exactly one of:
+
+- `None`
+- `One { administration_receipt_digest }`
+- `Conflict { administration_receipt_digests }`
+
+There is no timestamp winner and no arrival-order winner.
+
+Each semantic receipt lineage is separately classified as:
+
+- `Current`
+- `Corrected`
+- `PublicationSuppressed`
+
+## Duplicate publication vs semantic correction
+
+Multiple DHT actions carrying the exact same semantic administration receipt are idempotent publication provenance, not multiple clinical administrations.
+
+`DuplicateDocumentation` is publication-scoped: it suppresses only the exact publication action it targets. If an equivalent unsuppressed publication remains, the semantic administration receipt remains current.
+
+All other v1 correction reasons are semantic-receipt-scoped. A wrong-patient, wrong-medication, wrong-dose, wrong-route, entered-in-error, or source-evidence-revoked correction invalidates that semantic administration lineage.
+
+All correction evidence remains visible even when one correction determines lifecycle.
+
+## Conflict resolution
+
+Two distinct current semantic administration receipts for the same logical occurrence produce `Conflict`.
+
+Conflict may become `One` only when explicit correction evidence invalidates/suppresses enough competing lineages. Time, action order, agent trust score, or query order cannot choose a winner.
+
+## Read-set closure
+
+The reducer does not query Holochain and cannot prove global absence. A correction whose target publication is absent from the supplied set fails with `OrphanCorrection`; a mismatched semantic receipt fails closed.
+
+Callers must materialize a complete-for-purpose publication/correction set before interpreting the result.
+
+## Identity limitation — P0 #67
+
+V1 groups by `administration_id`, which is root/verifier-authorized but still a caller-selected logical identifier. It does not prove that two different IDs cannot refer to the same intended scheduled dose.
+
+P0 #67 must replace this grouping boundary with a versioned, domain-separated computable administration-occurrence identity derived from exact clinical intent before the system claims unique scheduled-dose occurrence semantics.
+
+Until then this reducer is suitable for exact receipt/correction interpretation, not proof of global scheduled-dose uniqueness.
+
+## Privacy
+
+The reducer uses the privacy-minimized DHT attestation and does not require patient identity, medication name, dose, route, site, diagnosis, or narrative rationale.
+
+Those details remain in protected event/receipt evidence and may be joined only through an authorized clinical workflow.
+
+## Non-claims
+
+This reducer does not prove:
+
+- physical administration occurred;
+- global query completeness;
+- `administration_id` uniquely identifies a real-world dose occurrence;
+- an omitted correction does not exist;
+- later symptoms/labs were caused by the administration;
+- legacy `MedicationAdherence` is qualified administration;
+- regulatory or clinical qualification.
+
+## Qualification targets
+
+Before promotion:
+
+- exact-head format/clippy/build/test must pass;
+- duplicate publication must be idempotent;
+- same-receipt changed attestation must fail;
+- conflicting current receipts must remain conflict independent of input order;
+- explicit semantic correction must resolve only the corrected lineage;
+- duplicate-documentation correction must suppress only its target publication;
+- mixed duplicate + semantic corrections must preserve both provenance classes;
+- correction ID/action reuse attacks must fail closed;
+- orphan and wrong-receipt corrections must fail closed;
+- emergency activation receipt domain must survive reduction;
+- conductor tests must prove only DHT-valid publication/correction records reach the reducer adapter;
+- P0 #67 must be satisfied before unique scheduled-dose occurrence claims.

--- a/zomes/medication_administration/integrity/src/lib.rs
+++ b/zomes/medication_administration/integrity/src/lib.rs
@@ -124,7 +124,7 @@ pub struct QualifiedMedicationAdministration {
     pub verifier_authorization_hash: ActionHash,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum AdministrationCorrectionReason {
     EnteredInError,
     WrongPatient,


### PR DESCRIPTION
## Stack

Depends on #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

Advances P0 #63 and explicitly gates unique scheduled-dose claims on P0 #67.

## Why

After qualified administration becomes an append-only DHT attestation with append-only corrections, downstream code still needs a canonical read model that cannot flatten duplicate publication, wrong-patient/wrong-dose correction, or competing administration receipts into `performed = true`.

## Model

Adds `mycelix-medication-administration-state`.

For each v1 logical occurrence key, current state is exactly:

- `None`;
- `One { administration_receipt_digest }`;
- `Conflict { administration_receipt_digests }`.

There is deliberately no timestamp winner, arrival-order winner, or trust-score winner.

## Correction semantics

- exact duplicate publications of the same semantic receipt are idempotent;
- `DuplicateDocumentation` suppresses only the exact publication action it targets;
- if another equivalent publication remains, the receipt remains current;
- other v1 correction reasons invalidate the semantic receipt lineage;
- all correction provenance is retained even when lifecycle is determined by a semantic correction;
- explicit correction may resolve a conflict; ordering may not;
- orphan/wrong-receipt correction fails closed;
- correction IDs cannot be silently reused by multiple correction actions.

## Emergency provenance

Qualified and emergency activation receipt domains remain distinct in every administration lineage.

## Complete-for-purpose read set

The reducer does not query Holochain and cannot prove global absence. Callers must materialize a complete-for-purpose set of already DHT-valid administration publications and corrections. Missing referenced publication evidence fails closed.

## P0 #67 limitation

V1 groups by root/verifier-authorized `administration_id`. That is a logical audit key, not proof that two differently named records are different real-world scheduled-dose occurrences.

P0 #67 introduces a versioned computable administration-occurrence identity derived from exact clinical intent. Until that lands, this reducer must not be represented as proving unique scheduled-dose occurrence semantics.

## Non-claims

- no proof the physical act occurred;
- no global query completeness claim;
- no upgrade of legacy `MedicationAdherence` into qualified administration;
- no causal attribution to later outcomes;
- no regulatory/clinical qualification until exact-head CI and conductor evidence pass.

See `docs/security/MEDICATION_ADMINISTRATION_STATE_V1.md`.