### PR TITLE
security(admin): add DNA-rooted occurrence binding attestations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ members = [
     "zomes/medication_dispense/coordinator",
     "zomes/medication_administration/integrity",
     "zomes/medication_administration/coordinator",
+    "zomes/medication_administration_occurrence/integrity",
+    "zomes/medication_administration_occurrence/coordinator",
     "zomes/consent/integrity",
     "zomes/consent/coordinator",
     "zomes/bridge/integrity",

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -56,6 +56,7 @@ pub enum DigestDomain {
     MedicationAdministrationPrnIntent,
     MedicationAdministrationOccurrence,
     MedicationAdministrationOccurrenceBinding,
+    MedicationAdministrationOccurrenceAttestation,
     QuarantineEvent,
     QuarantineDecision,
     AuthorityPolicy,
@@ -106,6 +107,7 @@ impl DigestDomain {
             Self::MedicationAdministrationPrnIntent => b"medication-administration-prn-intent",
             Self::MedicationAdministrationOccurrence => b"medication-administration-occurrence",
             Self::MedicationAdministrationOccurrenceBinding => b"medication-administration-occurrence-binding",
+            Self::MedicationAdministrationOccurrenceAttestation => b"medication-administration-occurrence-attestation",
             Self::QuarantineEvent => b"quarantine-event",
             Self::QuarantineDecision => b"quarantine-decision",
             Self::AuthorityPolicy => b"authority-policy",
@@ -118,7 +120,6 @@ impl DigestDomain {
     }
 }
 
-/// Serializable digest claim. Deserialization does not confer verification.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct StoredDigest {
     pub algorithm: DigestAlgorithm,
@@ -135,8 +136,6 @@ impl StoredDigest {
     }
 }
 
-/// In-process proof that exact canonical bytes were hashed under the stated v1
-/// algorithm/domain contract. Intentionally not serializable/deserializable.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct VerifiedDigest {
     stored: StoredDigest,
@@ -166,7 +165,6 @@ impl VerifiedDigest {
     }
 }
 
-/// Hash bytes that are already in the owning artifact's canonical serialization.
 pub fn hash_canonical_bytes(
     domain: DigestDomain,
     canonical_bytes: &[u8],
@@ -292,6 +290,7 @@ mod tests {
             DigestDomain::MedicationAdministrationPrnIntent,
             DigestDomain::MedicationAdministrationOccurrence,
             DigestDomain::MedicationAdministrationOccurrenceBinding,
+            DigestDomain::MedicationAdministrationOccurrenceAttestation,
             DigestDomain::AuthorityPolicy,
         ];
         let values: Vec<[u8; 32]> = domains

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -41,6 +41,15 @@ integrity:
       # Exact receipt + attestation verifier authorizations are short-lived and
       # hard-capped by the integrity zome at 15 minutes. Deployments may choose less.
       max_verifier_authorization_duration_micros: 900000000
+    medication_administration_occurrence:
+      schema_version: 1
+      # Occurrence-classification trust is separate from administration publication
+      # trust. Empty by default: no administration->occurrence binding can validate
+      # until a deployment explicitly pins root AgentPubKeys and repacks the DNA.
+      root_authorities: []
+      # Exact occurrence-binding authorizations are short-lived and hard-capped by
+      # the integrity zome at 15 minutes. Deployments may choose a shorter window.
+      max_verifier_authorization_duration_micros: 900000000
   zomes:
     # Tier 1: MVP Core
     - name: patient_integrity
@@ -59,6 +68,8 @@ integrity:
       path: ../target/wasm32-unknown-unknown/release/medication_dispense_integrity.wasm
     - name: medication_administration_integrity
       path: ../target/wasm32-unknown-unknown/release/medication_administration_integrity.wasm
+    - name: medication_administration_occurrence_integrity
+      path: ../target/wasm32-unknown-unknown/release/medication_administration_occurrence_integrity.wasm
     - name: consent_integrity
       path: ../target/wasm32-unknown-unknown/release/consent_integrity.wasm
     - name: bridge_integrity
@@ -101,6 +112,10 @@ coordinator:
       path: ../target/wasm32-unknown-unknown/release/medication_administration.wasm
       dependencies:
         - name: medication_administration_integrity
+    - name: medication_administration_occurrence
+      path: ../target/wasm32-unknown-unknown/release/medication_administration_occurrence.wasm
+      dependencies:
+        - name: medication_administration_occurrence_integrity
     - name: consent
       path: ../target/wasm32-unknown-unknown/release/consent.wasm
       dependencies:

--- a/docs/security/MEDICATION_ADMINISTRATION_OCCURRENCE_ATTESTATION_V1.md
+++ b/docs/security/MEDICATION_ADMINISTRATION_OCCURRENCE_ATTESTATION_V1.md
@@ -1,0 +1,103 @@
+# Medication Administration Occurrence Binding Attestation v1
+
+Status: **experimental / qualification-required**.
+
+This tranche admits the private occurrence-binding artifact from PR #69 into a DHT-valid, privacy-minimized network fact.
+
+## Threat model
+
+A serialized occurrence or occurrence-binding digest is not automatically trustworthy. A modified ordinary coordinator must not be able to declare that an administration receipt belongs to an arbitrary occurrence.
+
+The integrity zome therefore requires:
+
+1. a DHT-valid `QualifiedMedicationAdministration` action;
+2. a privacy-minimized occurrence-binding attestation that exactly matches that administration's receipt/event/medication digests;
+3. a DNA-pinned root authority to issue a short-lived authorization for one exact verifier;
+4. the authorization to bind one exact public attestation digest and one exact private binding digest;
+5. the named verifier to publish inside the authorization window.
+
+## Fail-closed deployment
+
+DNA properties ship with:
+
+```yaml
+medication_administration_occurrence:
+  schema_version: 1
+  root_authorities: []
+  max_verifier_authorization_duration_micros: 900000000
+```
+
+With an empty root list, no occurrence verifier authorization can validate. A deployment must intentionally repack the DNA with trusted root AgentPubKeys.
+
+## Public payload
+
+The public attestation contains only:
+
+- referenced qualified-administration action hash;
+- occurrence-binding digest;
+- administration receipt digest;
+- administration event digest;
+- administration occurrence digest;
+- medication artifact digest;
+- dosage index.
+
+It does not require the patient identity, dose amount, route/site, schedule windows, PRN nonce, clinical notes, or resolver provenance to be public.
+
+## Exact source binding
+
+Integrity validation fetches the referenced qualified-administration record with `must_get_valid_record` and requires its receipt/event/medication digests to exactly match the occurrence attestation. An occurrence binding therefore cannot float free of the DHT administration publication it classifies.
+
+## Exact-target verifier authorization
+
+A DNA-rooted authorization is bound to:
+
+- exact administration action;
+- exact attestation digest;
+- exact private occurrence-binding digest;
+- exact administration receipt/event/occurrence/medication digests;
+- exact dosage index;
+- exact verifier;
+- short validity interval.
+
+The maximum v1 interval is 15 minutes and deployments may choose less.
+
+## Corrections
+
+Occurrence bindings are append-only. Updates/deletes are rejected. Corrections are separate records with typed reasons:
+
+- `EnteredInError`;
+- `WrongOccurrence`;
+- `SourceEvidenceRevoked`;
+- `DuplicateDocumentation`;
+- `Other` with protected rationale commitment.
+
+A future occurrence-aware reducer must preserve the same distinction used elsewhere: duplicate-documentation is publication-scoped; semantic correction invalidates the binding lineage.
+
+## Non-claims
+
+This zome does not prove:
+
+- the physical medication administration occurred;
+- the private occurrence-binding bytes from their digest alone;
+- institutional trust in a schedule resolver by itself;
+- global query completeness;
+- causal effect of administration on later observations.
+
+The DNA-rooted verifier is explicitly attesting that it revalidated the protected binding/evidence before requesting authorization.
+
+## Qualification gates
+
+Before promotion require:
+
+- exact-head native workspace build/test/fmt/clippy;
+- WASM build of both occurrence zomes;
+- empty-root fail-closed conductor test;
+- non-root authorization rejection;
+- wrong verifier rejection;
+- expired/future authorization rejection;
+- changed attestation/receipt/event/occurrence/medication/dosage rejection;
+- wrong referenced administration rejection;
+- update/delete rejection;
+- correction-authority and cross-lineage link rejection;
+- modified-coordinator adversarial test;
+- reducer tests proving caller-selected `administration_id` no longer controls occurrence conflict grouping.

--- a/zomes/medication_administration_occurrence/coordinator/Cargo.toml
+++ b/zomes/medication_administration_occurrence/coordinator/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "medication_administration_occurrence"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Coordinator for DNA-rooted medication administration occurrence bindings"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { workspace = true }
+medication_administration_occurrence_integrity = { path = "../integrity" }
+
+[features]
+default = []

--- a/zomes/medication_administration_occurrence/coordinator/src/lib.rs
+++ b/zomes/medication_administration_occurrence/coordinator/src/lib.rs
@@ -1,0 +1,57 @@
+#![deny(unsafe_code)]
+//! Thin coordinator for DNA-rooted administration occurrence bindings.
+//!
+//! Trust and exact-target enforcement live in the integrity zome. This coordinator
+//! only commits exact entries/links so a modified coordinator cannot bypass admission.
+
+use hdk::prelude::*;
+use medication_administration_occurrence_integrity::{
+    EntryTypes, LinkTypes, MedicationAdministrationOccurrenceBindingCorrection,
+    MedicationAdministrationOccurrenceVerifierAuthorization,
+    QualifiedMedicationAdministrationOccurrenceBinding,
+};
+
+#[hdk_extern]
+pub fn create_occurrence_verifier_authorization(
+    authorization: MedicationAdministrationOccurrenceVerifierAuthorization,
+) -> ExternResult<Record> {
+    let hash = create_entry(
+        EntryTypes::MedicationAdministrationOccurrenceVerifierAuthorization(authorization),
+    )?;
+    get(hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed administration occurrence verifier authorization could not be read back"
+            .to_string()
+    )))
+}
+
+#[hdk_extern]
+pub fn publish_qualified_occurrence_binding(
+    binding: QualifiedMedicationAdministrationOccurrenceBinding,
+) -> ExternResult<Record> {
+    let hash = create_entry(EntryTypes::QualifiedMedicationAdministrationOccurrenceBinding(
+        binding,
+    ))?;
+    get(hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed qualified administration occurrence binding could not be read back".to_string()
+    )))
+}
+
+#[hdk_extern]
+pub fn append_occurrence_binding_correction(
+    correction: MedicationAdministrationOccurrenceBindingCorrection,
+) -> ExternResult<Record> {
+    let binding_hash = correction.binding_hash.clone();
+    let correction_hash = create_entry(
+        EntryTypes::MedicationAdministrationOccurrenceBindingCorrection(correction),
+    )?;
+    create_link(
+        binding_hash,
+        correction_hash.clone(),
+        LinkTypes::BindingToCorrections,
+        (),
+    )?;
+    get(correction_hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed administration occurrence binding correction could not be read back"
+            .to_string()
+    )))
+}

--- a/zomes/medication_administration_occurrence/integrity/Cargo.toml
+++ b/zomes/medication_administration_occurrence/integrity/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "medication_administration_occurrence_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "DNA-rooted medication administration occurrence-binding attestation integrity zome"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+mycelix-clinical-integrity = { path = "../../../crates/clinical-integrity" }
+medication_administration_integrity = { path = "../../medication_administration/integrity" }
+
+[features]
+default = []

--- a/zomes/medication_administration_occurrence/integrity/src/lib.rs
+++ b/zomes/medication_administration_occurrence/integrity/src/lib.rs
@@ -10,7 +10,7 @@ use medication_administration_integrity::QualifiedMedicationAdministration;
 use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, StoredDigest};
 
 const CONFIG_VERSION: u16 = 1;
-const ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS: i64 = 900_000_000; // 15 min
+const ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS: i64 = 900_000_000;
 const ATTESTATION_TAG: &[u8] =
     b"mycelix-health/medication-administration-occurrence-attestation-v1";
 
@@ -76,7 +76,7 @@ impl MedicationAdministrationOccurrenceAttestationV1 {
         framed.push(0);
         framed.extend_from_slice(&encoded);
         Ok(hash_canonical_bytes(
-            DigestDomain::MedicationAdministrationOccurrenceBinding,
+            DigestDomain::MedicationAdministrationOccurrenceAttestation,
             &framed,
         )
         .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
@@ -225,7 +225,7 @@ fn validate_authorization_shape(
     }
     require_digest_domain(
         authorization.occurrence_attestation_digest,
-        DigestDomain::MedicationAdministrationOccurrenceBinding,
+        DigestDomain::MedicationAdministrationOccurrenceAttestation,
     )?;
     require_digest_domain(
         authorization.occurrence_binding_digest,
@@ -383,7 +383,8 @@ fn validate_create_link(
     match link_type {
         LinkTypes::BindingToCorrections => {
             let binding_hash = require_action_hash(base_address, "occurrence binding link base")?;
-            let correction_hash = require_action_hash(target_address, "occurrence correction target")?;
+            let correction_hash =
+                require_action_hash(target_address, "occurrence correction target")?;
             let binding_record = must_get_valid_record(binding_hash.clone())?;
             let binding: QualifiedMedicationAdministrationOccurrenceBinding =
                 decode_entry(&binding_record, "qualified administration occurrence binding")?;
@@ -398,7 +399,9 @@ fn validate_create_link(
                 return invalid("Occurrence-binding correction link crosses lineage");
             }
             if correction_record.action().author() != &action.author {
-                return invalid("Occurrence-binding correction link must be authored by correction author");
+                return invalid(
+                    "Occurrence-binding correction link must be authored by correction author",
+                );
             }
             Ok(ValidateCallbackResult::Valid)
         }
@@ -528,6 +531,15 @@ mod tests {
             medication_artifact_digest: stored(DigestDomain::MedicationRequestArtifact, 6),
             dosage_index: 0,
         }
+    }
+
+    #[test]
+    fn attestation_digest_is_separate_from_private_binding_domain() {
+        let value = attestation().digest().unwrap();
+        assert_eq!(
+            value.domain,
+            DigestDomain::MedicationAdministrationOccurrenceAttestation
+        );
     }
 
     #[test]

--- a/zomes/medication_administration_occurrence/integrity/src/lib.rs
+++ b/zomes/medication_administration_occurrence/integrity/src/lib.rs
@@ -1,0 +1,557 @@
+#![deny(unsafe_code)]
+//! DNA-rooted admission for medication-administration occurrence bindings.
+//!
+//! The private occurrence-binding artifact remains off-DHT. The DHT stores only a
+//! privacy-minimized projection after a DNA-pinned root authorizes one exact verifier
+//! to publish one exact administration->occurrence binding inside a short window.
+
+use hdi::prelude::*;
+use medication_administration_integrity::QualifiedMedicationAdministration;
+use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, StoredDigest};
+
+const CONFIG_VERSION: u16 = 1;
+const ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS: i64 = 900_000_000; // 15 min
+const ATTESTATION_TAG: &[u8] =
+    b"mycelix-health/medication-administration-occurrence-attestation-v1";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MedicationAdministrationOccurrenceRootConfig {
+    pub schema_version: u16,
+    pub root_authorities: Vec<AgentPubKey>,
+    pub max_verifier_authorization_duration_micros: i64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct MedicationAdministrationOccurrenceAttestationV1 {
+    pub schema_version: u16,
+    pub administration_hash: ActionHash,
+    pub occurrence_binding_digest: StoredDigest,
+    pub administration_receipt_digest: StoredDigest,
+    pub event_digest: StoredDigest,
+    pub occurrence_digest: StoredDigest,
+    pub medication_artifact_digest: StoredDigest,
+    pub dosage_index: u32,
+}
+
+impl MedicationAdministrationOccurrenceAttestationV1 {
+    pub fn validate_shape(&self) -> ExternResult<ValidateCallbackResult> {
+        if self.schema_version != 1 {
+            return invalid("Unsupported administration occurrence attestation version");
+        }
+        require_digest_domain(
+            self.occurrence_binding_digest,
+            DigestDomain::MedicationAdministrationOccurrenceBinding,
+        )?;
+        require_digest_domain(
+            self.administration_receipt_digest,
+            DigestDomain::MedicationAdministrationReceipt,
+        )?;
+        require_digest_domain(self.event_digest, DigestDomain::MedicationAdministrationEvent)?;
+        require_digest_domain(
+            self.occurrence_digest,
+            DigestDomain::MedicationAdministrationOccurrence,
+        )?;
+        require_digest_domain(
+            self.medication_artifact_digest,
+            DigestDomain::MedicationRequestArtifact,
+        )?;
+        Ok(ValidateCallbackResult::Valid)
+    }
+
+    pub fn digest(&self) -> ExternResult<StoredDigest> {
+        let shape = self.validate_shape()?;
+        if !matches!(shape, ValidateCallbackResult::Valid) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Cannot hash invalid administration occurrence attestation".to_string()
+            )));
+        }
+        let encoded = serde_json::to_vec(self).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Failed to serialize administration occurrence attestation: {error}"
+            )))
+        })?;
+        let mut framed = Vec::with_capacity(ATTESTATION_TAG.len() + 1 + encoded.len());
+        framed.extend_from_slice(ATTESTATION_TAG);
+        framed.push(0);
+        framed.extend_from_slice(&encoded);
+        Ok(hash_canonical_bytes(
+            DigestDomain::MedicationAdministrationOccurrenceBinding,
+            &framed,
+        )
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .stored())
+    }
+}
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct MedicationAdministrationOccurrenceVerifierAuthorization {
+    pub authorization_id: String,
+    pub grantee: AgentPubKey,
+    pub administration_hash: ActionHash,
+    pub occurrence_attestation_digest: StoredDigest,
+    pub occurrence_binding_digest: StoredDigest,
+    pub administration_receipt_digest: StoredDigest,
+    pub event_digest: StoredDigest,
+    pub occurrence_digest: StoredDigest,
+    pub medication_artifact_digest: StoredDigest,
+    pub dosage_index: u32,
+    pub valid_from: Timestamp,
+    pub valid_until: Timestamp,
+}
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct QualifiedMedicationAdministrationOccurrenceBinding {
+    pub attestation: MedicationAdministrationOccurrenceAttestationV1,
+    pub verifier_authorization_hash: ActionHash,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OccurrenceBindingCorrectionReason {
+    EnteredInError,
+    WrongOccurrence,
+    SourceEvidenceRevoked,
+    DuplicateDocumentation,
+    Other,
+}
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct MedicationAdministrationOccurrenceBindingCorrection {
+    pub correction_id: String,
+    pub binding_hash: ActionHash,
+    pub occurrence_binding_digest: StoredDigest,
+    pub occurrence_digest: StoredDigest,
+    pub reason: OccurrenceBindingCorrectionReason,
+    pub rationale_commitment: Option<[u8; 32]>,
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    MedicationAdministrationOccurrenceVerifierAuthorization(
+        MedicationAdministrationOccurrenceVerifierAuthorization,
+    ),
+    QualifiedMedicationAdministrationOccurrenceBinding(
+        QualifiedMedicationAdministrationOccurrenceBinding,
+    ),
+    MedicationAdministrationOccurrenceBindingCorrection(
+        MedicationAdministrationOccurrenceBindingCorrection,
+    ),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    BindingToCorrections,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => {
+                validate_create_entry(EntryCreationAction::Create(action), app_entry)
+            }
+            OpEntry::UpdateEntry { .. } => invalid(
+                "Administration occurrence trust/evidence entries are append-only and cannot be updated",
+            ),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterUpdate(_) => invalid(
+            "Administration occurrence trust/evidence entries are append-only and cannot be updated",
+        ),
+        FlatOp::RegisterDelete(_) => invalid(
+            "Administration occurrence trust/evidence entries cannot be deleted; append a correction",
+        ),
+        FlatOp::RegisterCreateLink {
+            link_type,
+            base_address,
+            target_address,
+            action,
+            ..
+        } => validate_create_link(link_type, base_address, target_address, action),
+        FlatOp::RegisterDeleteLink { .. } => invalid(
+            "Administration occurrence correction links are append-only and cannot be deleted",
+        ),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_create_entry(
+    action: EntryCreationAction,
+    entry: EntryTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    match entry {
+        EntryTypes::MedicationAdministrationOccurrenceVerifierAuthorization(authorization) => {
+            let shape = validate_authorization_shape(&authorization)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let config = occurrence_root_config()?;
+            let root = require_root_authority(action.author(), &config)?;
+            if !matches!(root, ValidateCallbackResult::Valid) {
+                return Ok(root);
+            }
+            validate_authorization_window(action.timestamp(), &authorization, &config)
+        }
+        EntryTypes::QualifiedMedicationAdministrationOccurrenceBinding(binding) => {
+            let shape = binding.attestation.validate_shape()?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let source = require_exact_administration_source(&binding.attestation)?;
+            if !matches!(source, ValidateCallbackResult::Valid) {
+                return Ok(source);
+            }
+            require_exact_verifier_authorization(action.author(), action.timestamp(), &binding)
+        }
+        EntryTypes::MedicationAdministrationOccurrenceBindingCorrection(correction) => {
+            let shape = validate_correction_shape(&correction)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            require_correction_authority(action.author(), &correction)
+        }
+    }
+}
+
+fn validate_authorization_shape(
+    authorization: &MedicationAdministrationOccurrenceVerifierAuthorization,
+) -> ExternResult<ValidateCallbackResult> {
+    if authorization.authorization_id.trim().is_empty() {
+        return invalid("Administration occurrence verifier authorization ID is required");
+    }
+    require_digest_domain(
+        authorization.occurrence_attestation_digest,
+        DigestDomain::MedicationAdministrationOccurrenceBinding,
+    )?;
+    require_digest_domain(
+        authorization.occurrence_binding_digest,
+        DigestDomain::MedicationAdministrationOccurrenceBinding,
+    )?;
+    require_digest_domain(
+        authorization.administration_receipt_digest,
+        DigestDomain::MedicationAdministrationReceipt,
+    )?;
+    require_digest_domain(
+        authorization.event_digest,
+        DigestDomain::MedicationAdministrationEvent,
+    )?;
+    require_digest_domain(
+        authorization.occurrence_digest,
+        DigestDomain::MedicationAdministrationOccurrence,
+    )?;
+    require_digest_domain(
+        authorization.medication_artifact_digest,
+        DigestDomain::MedicationRequestArtifact,
+    )?;
+    if authorization.valid_until <= authorization.valid_from {
+        return invalid("Administration occurrence authorization validity window is invalid");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_authorization_window(
+    action_timestamp: Timestamp,
+    authorization: &MedicationAdministrationOccurrenceVerifierAuthorization,
+    config: &MedicationAdministrationOccurrenceRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    let duration = authorization.valid_until.as_micros() as i128
+        - authorization.valid_from.as_micros() as i128;
+    if duration <= 0
+        || duration > config.max_verifier_authorization_duration_micros as i128
+        || duration > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS as i128
+    {
+        return invalid(
+            "Administration occurrence authorization duration exceeds configured/hard limit",
+        );
+    }
+    if action_timestamp > authorization.valid_until {
+        return invalid("Administration occurrence authorization was expired when created");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_exact_administration_source(
+    attestation: &MedicationAdministrationOccurrenceAttestationV1,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(attestation.administration_hash.clone())?;
+    let administration: QualifiedMedicationAdministration =
+        decode_entry(&record, "qualified medication administration")?;
+    if administration.attestation.administration_receipt_digest
+        != attestation.administration_receipt_digest
+        || administration.attestation.event_digest != attestation.event_digest
+        || administration.attestation.medication_artifact_digest
+            != attestation.medication_artifact_digest
+    {
+        return invalid(
+            "Administration occurrence binding does not match referenced qualified administration",
+        );
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_exact_verifier_authorization(
+    author: &AgentPubKey,
+    action_timestamp: Timestamp,
+    binding: &QualifiedMedicationAdministrationOccurrenceBinding,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(binding.verifier_authorization_hash.clone())?;
+    let authorization: MedicationAdministrationOccurrenceVerifierAuthorization =
+        decode_entry(&record, "administration occurrence verifier authorization")?;
+    if &authorization.grantee != author {
+        return invalid("Administration occurrence binding author is not authorization grantee");
+    }
+    if action_timestamp < authorization.valid_from || action_timestamp >= authorization.valid_until {
+        return invalid("Administration occurrence binding is outside authorization validity");
+    }
+
+    let attestation = &binding.attestation;
+    let attestation_digest = attestation.digest()?;
+    if authorization.administration_hash != attestation.administration_hash
+        || authorization.occurrence_attestation_digest != attestation_digest
+        || authorization.occurrence_binding_digest != attestation.occurrence_binding_digest
+        || authorization.administration_receipt_digest
+            != attestation.administration_receipt_digest
+        || authorization.event_digest != attestation.event_digest
+        || authorization.occurrence_digest != attestation.occurrence_digest
+        || authorization.medication_artifact_digest != attestation.medication_artifact_digest
+        || authorization.dosage_index != attestation.dosage_index
+    {
+        return invalid(
+            "Administration occurrence attestation does not exactly match root authorization",
+        );
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_correction_shape(
+    correction: &MedicationAdministrationOccurrenceBindingCorrection,
+) -> ExternResult<ValidateCallbackResult> {
+    if correction.correction_id.trim().is_empty() {
+        return invalid("Administration occurrence binding correction ID is required");
+    }
+    require_digest_domain(
+        correction.occurrence_binding_digest,
+        DigestDomain::MedicationAdministrationOccurrenceBinding,
+    )?;
+    require_digest_domain(
+        correction.occurrence_digest,
+        DigestDomain::MedicationAdministrationOccurrence,
+    )?;
+    if correction
+        .rationale_commitment
+        .is_some_and(|commitment| commitment == [0u8; 32])
+    {
+        return invalid("Occurrence-binding correction rationale commitment cannot be zero");
+    }
+    if matches!(correction.reason, OccurrenceBindingCorrectionReason::Other)
+        && correction.rationale_commitment.is_none()
+    {
+        return invalid("Other occurrence-binding correction requires rationale commitment");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_correction_authority(
+    author: &AgentPubKey,
+    correction: &MedicationAdministrationOccurrenceBindingCorrection,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(correction.binding_hash.clone())?;
+    let binding: QualifiedMedicationAdministrationOccurrenceBinding =
+        decode_entry(&record, "qualified administration occurrence binding")?;
+    if binding.attestation.occurrence_binding_digest != correction.occurrence_binding_digest
+        || binding.attestation.occurrence_digest != correction.occurrence_digest
+    {
+        return invalid("Occurrence-binding correction does not match target lineage");
+    }
+    if record.action().author() == author {
+        return Ok(ValidateCallbackResult::Valid);
+    }
+    let config = occurrence_root_config()?;
+    require_root_authority(author, &config)
+}
+
+fn validate_create_link(
+    link_type: LinkTypes,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    action: CreateLink,
+) -> ExternResult<ValidateCallbackResult> {
+    match link_type {
+        LinkTypes::BindingToCorrections => {
+            let binding_hash = require_action_hash(base_address, "occurrence binding link base")?;
+            let correction_hash = require_action_hash(target_address, "occurrence correction target")?;
+            let binding_record = must_get_valid_record(binding_hash.clone())?;
+            let binding: QualifiedMedicationAdministrationOccurrenceBinding =
+                decode_entry(&binding_record, "qualified administration occurrence binding")?;
+            let correction_record = must_get_valid_record(correction_hash)?;
+            let correction: MedicationAdministrationOccurrenceBindingCorrection =
+                decode_entry(&correction_record, "administration occurrence binding correction")?;
+            if correction.binding_hash != binding_hash
+                || correction.occurrence_binding_digest
+                    != binding.attestation.occurrence_binding_digest
+                || correction.occurrence_digest != binding.attestation.occurrence_digest
+            {
+                return invalid("Occurrence-binding correction link crosses lineage");
+            }
+            if correction_record.action().author() != &action.author {
+                return invalid("Occurrence-binding correction link must be authored by correction author");
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+    }
+}
+
+fn occurrence_root_config() -> ExternResult<MedicationAdministrationOccurrenceRootConfig> {
+    let info = dna_info()?;
+    let properties: serde_json::Value = serde_json::from_slice(info.modifiers.properties.bytes())
+        .map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "DNA properties are not valid JSON for medication administration occurrence: {error}"
+            )))
+        })?;
+    let value = properties
+        .get("medication_administration_occurrence")
+        .ok_or(wasm_error!(WasmErrorInner::Guest(
+            "DNA properties do not configure medication_administration_occurrence trust roots"
+                .to_string()
+        )))?;
+    let config: MedicationAdministrationOccurrenceRootConfig =
+        serde_json::from_value(value.clone()).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Invalid medication_administration_occurrence DNA properties: {error}"
+            )))
+        })?;
+    if config.schema_version != CONFIG_VERSION {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Unsupported medication_administration_occurrence root config version {}",
+            config.schema_version
+        ))));
+    }
+    if config.max_verifier_authorization_duration_micros <= 0
+        || config.max_verifier_authorization_duration_micros
+            > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS
+    {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Administration occurrence authorization duration must be > 0 and <= 15 minutes"
+                .to_string()
+        )));
+    }
+    for (index, root) in config.root_authorities.iter().enumerate() {
+        if config.root_authorities[..index].contains(root) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Administration occurrence root list contains duplicate AgentPubKeys".to_string()
+            )));
+        }
+    }
+    Ok(config)
+}
+
+fn require_root_authority(
+    author: &AgentPubKey,
+    config: &MedicationAdministrationOccurrenceRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    if !config.root_authorities.contains(author) {
+        return invalid(
+            "Administration occurrence verifier authorization requires a DNA-pinned root authority",
+        );
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_digest_domain(digest: StoredDigest, expected: DigestDomain) -> ExternResult<()> {
+    digest
+        .validate_shape()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+    if digest.domain != expected {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Administration occurrence digest domain mismatch: expected {expected:?}, got {:?}",
+            digest.domain
+        ))));
+    }
+    Ok(())
+}
+
+fn require_action_hash(hash: AnyLinkableHash, field: &'static str) -> ExternResult<ActionHash> {
+    hash.into_action_hash().ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+        "{field} must be an ActionHash"
+    ))))
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain};
+
+    fn stored(domain: DigestDomain, seed: u8) -> StoredDigest {
+        StoredDigest {
+            algorithm: DigestAlgorithm::Blake3_256,
+            domain,
+            value: [seed; 32],
+        }
+    }
+
+    fn attestation() -> MedicationAdministrationOccurrenceAttestationV1 {
+        MedicationAdministrationOccurrenceAttestationV1 {
+            schema_version: 1,
+            administration_hash: ActionHash::from_raw_36(vec![1; 36]),
+            occurrence_binding_digest: stored(
+                DigestDomain::MedicationAdministrationOccurrenceBinding,
+                2,
+            ),
+            administration_receipt_digest: stored(
+                DigestDomain::MedicationAdministrationReceipt,
+                3,
+            ),
+            event_digest: stored(DigestDomain::MedicationAdministrationEvent, 4),
+            occurrence_digest: stored(DigestDomain::MedicationAdministrationOccurrence, 5),
+            medication_artifact_digest: stored(DigestDomain::MedicationRequestArtifact, 6),
+            dosage_index: 0,
+        }
+    }
+
+    #[test]
+    fn attestation_digest_changes_with_administration_source() {
+        let first = attestation();
+        let mut second = first.clone();
+        second.administration_hash = ActionHash::from_raw_36(vec![9; 36]);
+        assert_ne!(first.digest().unwrap(), second.digest().unwrap());
+    }
+
+    #[test]
+    fn correction_other_requires_rationale_commitment() {
+        let correction = MedicationAdministrationOccurrenceBindingCorrection {
+            correction_id: "correction-a".into(),
+            binding_hash: ActionHash::from_raw_36(vec![2; 36]),
+            occurrence_binding_digest: stored(
+                DigestDomain::MedicationAdministrationOccurrenceBinding,
+                3,
+            ),
+            occurrence_digest: stored(DigestDomain::MedicationAdministrationOccurrence, 4),
+            reason: OccurrenceBindingCorrectionReason::Other,
+            rationale_commitment: None,
+        };
+        let result = validate_correction_shape(&correction).unwrap();
+        assert!(matches!(result, ValidateCallbackResult::Invalid(_)));
+    }
+}


### PR DESCRIPTION
## Stack

Depends on #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

Adds the runtime/DHT admission boundary for P0 #67 occurrence identity.

## Why

The pure occurrence + binding crates establish exact semantics in-process, but a serialized binding is not a DHT-valid fact. A modified coordinator must not be able to classify a qualified administration under an arbitrary occurrence digest.

## Model

Adds `medication_administration_occurrence_integrity` and a thin coordinator.

A valid network binding requires:

- an existing DHT-valid `QualifiedMedicationAdministration` action;
- exact receipt/event/medication lineage matching that administration;
- a privacy-minimized occurrence-binding attestation;
- a DNA-pinned root authority;
- a short-lived authorization for one exact verifier;
- exact binding of administration action, public attestation digest, private binding digest, receipt/event/occurrence/medication digests, dosage index and verifier.

## Digest separation

The protected `MedicationAdministrationOccurrenceBinding` and public `MedicationAdministrationOccurrenceAttestation` use distinct cryptographic domains. Neither can substitute for the other.

## Fail-closed deployment

The DNA ships with:

```yaml
medication_administration_occurrence:
  schema_version: 1
  root_authorities: []
  max_verifier_authorization_duration_micros: 900000000
```

So occurrence-binding admission is disabled until a deployment intentionally pins root AgentPubKeys and repacks the DNA.

## Privacy

The DHT does not require patient identity, dose, route/site, schedule windows, PRN nonce, resolver metadata, clinical notes, or rationale. It carries the minimal digest lineage needed to map one DHT-qualified administration publication to one computable occurrence.

## Corrections

Bindings are append-only. Update/delete are rejected. Corrections are separate typed records (`EnteredInError`, `WrongOccurrence`, `SourceEvidenceRevoked`, `DuplicateDocumentation`, `Other`).

## Non-claims

- no proof the physical administration occurred;
- no global read completeness claim;
- no claim a serialized private binding was verified without the DNA-rooted verifier step;
- no causal-effect claim.

See `docs/security/MEDICATION_ADMINISTRATION_OCCURRENCE_ATTESTATION_V1.md`.