### PR TITLE
feat(causality): preserve legacy trial causality without semantic upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
     "crates/medication-administration-occurrence-binding",
     "crates/medication-administration-occurrence-state",
     "crates/clinical-causality",
+    "crates/clinical-causality-trial-adapter",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-causality-trial-adapter/Cargo.toml
+++ b/crates/clinical-causality-trial-adapter/Cargo.toml
@@ -8,5 +8,6 @@ description = "Lossless legacy trial adverse-event causality migration adapter"
 [dependencies]
 serde = { workspace = true }
 thiserror = { workspace = true }
+holo_hash = { workspace = true }
 mycelix-clinical-causality = { path = "../clinical-causality" }
 trials_integrity = { path = "../../zomes/trials/integrity" }

--- a/crates/clinical-causality-trial-adapter/Cargo.toml
+++ b/crates/clinical-causality-trial-adapter/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mycelix-clinical-causality-trial-adapter"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Lossless legacy trial adverse-event causality migration adapter"
+
+[dependencies]
+serde = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-causality = { path = "../clinical-causality" }
+trials_integrity = { path = "../../zomes/trials/integrity" }

--- a/crates/clinical-causality-trial-adapter/src/lib.rs
+++ b/crates/clinical-causality-trial-adapter/src/lib.rs
@@ -1,0 +1,119 @@
+#![deny(unsafe_code)]
+//! Migration adapter for the legacy trials `AdverseEvent::causality` field.
+//!
+//! The old causality enum is preserved as source metadata only. This crate has no
+//! API that converts a legacy causality label directly into `CausalConclusionV1`.
+
+use holo_hash::ActionHash;
+use mycelix_clinical_causality::ExternalCausalityScaleLabelV1;
+use serde::Serialize;
+use thiserror::Error;
+use trials_integrity::{AdverseEvent, Causality};
+
+pub const LEGACY_CAUSALITY_SYSTEM: &str = "urn:mycelix-health:trials:legacy-causality";
+pub const LEGACY_CAUSALITY_VERSION: &str = "1";
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+pub enum LegacyCausalityMigrationStateV1 {
+    /// The source label has been preserved, but no high-assurance causal conclusion
+    /// exists until a fresh evidence-first assessment is performed.
+    RequiresFreshEvidenceAssessment,
+}
+
+/// Lossless source-context record for a legacy trial causality label.
+///
+/// Intentionally serializable but not deserializable: callers should construct it
+/// from the actual legacy `AdverseEvent` record obtained through the trusted read
+/// path. Even then, this type does not prove the DHT validity of that source action.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct LegacyTrialCausalityImportV1 {
+    pub schema_version: u16,
+    pub source_action_hash: ActionHash,
+    pub source_trial_hash: ActionHash,
+    pub source_participant_hash: ActionHash,
+    pub source_event_id: String,
+    pub source_event_term: String,
+    pub external_scale_label: ExternalCausalityScaleLabelV1,
+    pub migration_state: LegacyCausalityMigrationStateV1,
+}
+
+pub fn import_legacy_trial_causality(
+    source_action_hash: ActionHash,
+    event: &AdverseEvent,
+) -> Result<LegacyTrialCausalityImportV1, TrialCausalityAdapterError> {
+    if event.event_id.trim().is_empty() {
+        return Err(TrialCausalityAdapterError::MissingEventId);
+    }
+    if event.event_term.trim().is_empty() {
+        return Err(TrialCausalityAdapterError::MissingEventTerm);
+    }
+
+    Ok(LegacyTrialCausalityImportV1 {
+        schema_version: 1,
+        source_action_hash,
+        source_trial_hash: event.trial_hash.clone(),
+        source_participant_hash: event.participant_hash.clone(),
+        source_event_id: event.event_id.clone(),
+        source_event_term: event.event_term.clone(),
+        external_scale_label: legacy_causality_label(&event.causality),
+        migration_state: LegacyCausalityMigrationStateV1::RequiresFreshEvidenceAssessment,
+    })
+}
+
+/// Preserve the original enum value as an external scale label. No semantic mapping
+/// into the high-assurance causal conclusion vocabulary occurs here.
+pub fn legacy_causality_label(causality: &Causality) -> ExternalCausalityScaleLabelV1 {
+    ExternalCausalityScaleLabelV1 {
+        system: LEGACY_CAUSALITY_SYSTEM.to_string(),
+        version: LEGACY_CAUSALITY_VERSION.to_string(),
+        label: match causality {
+            Causality::DefinitelyRelated => "DefinitelyRelated",
+            Causality::ProbablyRelated => "ProbablyRelated",
+            Causality::PossiblyRelated => "PossiblyRelated",
+            Causality::UnlikelyRelated => "UnlikelyRelated",
+            Causality::NotRelated => "NotRelated",
+            Causality::Unknown => "Unknown",
+        }
+        .to_string(),
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TrialCausalityAdapterError {
+    #[error("legacy adverse event ID is required")]
+    MissingEventId,
+    #[error("legacy adverse event term is required")]
+    MissingEventTerm,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_legacy_label_is_preserved_without_normalization() {
+        let cases = [
+            (Causality::DefinitelyRelated, "DefinitelyRelated"),
+            (Causality::ProbablyRelated, "ProbablyRelated"),
+            (Causality::PossiblyRelated, "PossiblyRelated"),
+            (Causality::UnlikelyRelated, "UnlikelyRelated"),
+            (Causality::NotRelated, "NotRelated"),
+            (Causality::Unknown, "Unknown"),
+        ];
+
+        for (source, expected) in cases {
+            let label = legacy_causality_label(&source);
+            assert_eq!(label.system, LEGACY_CAUSALITY_SYSTEM);
+            assert_eq!(label.version, LEGACY_CAUSALITY_VERSION);
+            assert_eq!(label.label, expected);
+        }
+    }
+
+    #[test]
+    fn migration_state_has_no_causal_conclusion_variant() {
+        assert_eq!(
+            LegacyCausalityMigrationStateV1::RequiresFreshEvidenceAssessment,
+            LegacyCausalityMigrationStateV1::RequiresFreshEvidenceAssessment
+        );
+    }
+}

--- a/docs/security/CLINICAL_CAUSALITY_TRIAL_ADAPTER_V1.md
+++ b/docs/security/CLINICAL_CAUSALITY_TRIAL_ADAPTER_V1.md
@@ -1,0 +1,60 @@
+# Clinical Causality Trial Adapter v1
+
+Status: migration-only / experimental.
+
+## Purpose
+
+This adapter preserves the exact legacy `trials::AdverseEvent::causality` value and source action context without treating the old label as causal evidence.
+
+Historical trial records may remain readable and auditable while the high-assurance path requires a fresh evidence-first assessment.
+
+## Safety invariant
+
+`legacy causality label != qualified causal conclusion`
+
+There is intentionally no API in this crate that maps:
+
+- `DefinitelyRelated`;
+- `ProbablyRelated`;
+- `PossiblyRelated`;
+- `UnlikelyRelated`;
+- `NotRelated`;
+- `Unknown`
+
+into `CausalConclusionV1`.
+
+All six values are preserved verbatim as `ExternalCausalityScaleLabelV1` under:
+
+- system: `urn:mycelix-health:trials:legacy-causality`;
+- version: `1`.
+
+The migration state is always `RequiresFreshEvidenceAssessment`.
+
+## Source lineage
+
+The migration object preserves the exact source action hash, trial hash, participant hash, event ID, and event term. It is serializable for audit/export but intentionally not deserializable as a trusted construction path.
+
+The caller is still responsible for obtaining the legacy event through a trusted/DHT-valid read path. Merely constructing or serializing this import object does not prove the source action exists or belongs to the exact legacy adverse-event entry definition.
+
+## Fresh assessment
+
+A qualified replacement assessment must independently establish:
+
+1. typed observed clinical facts;
+2. patient-subject binding;
+3. exact exposure/administration occurrence lineage;
+4. temporal association;
+5. required alternative/concomitant reviews;
+6. supporting/challenging evidence;
+7. assessment method/version;
+8. assessor authority and evidence-source trust at later runtime boundaries.
+
+The preserved legacy label may be attached only as external/source metadata.
+
+## Non-claims
+
+- no automatic causal reinterpretation;
+- no proof of legacy event DHT validity by this pure adapter;
+- no regulatory-reporting interpretation;
+- no clinical qualification;
+- no population-level signal inference.


### PR DESCRIPTION
## Stack

Depends on #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

## Why

Historical trial adverse-event records already carry a `Causality` enum. Those records must remain readable, but their labels must not automatically become evidence-bearing conclusions in the new high-assurance causality model.

## Model

Adds `mycelix-clinical-causality-trial-adapter`.

The adapter consumes the exact legacy `trials_integrity::AdverseEvent` type and preserves:

- exact source action hash;
- trial hash;
- participant hash;
- event ID/term;
- the original causality enum value as an external scale label;
- migration state `RequiresFreshEvidenceAssessment`.

All six legacy labels are preserved verbatim under the versioned source system `urn:mycelix-health:trials:legacy-causality`.

## Safety property

There is intentionally **no API** mapping `DefinitelyRelated`, `ProbablyRelated`, `PossiblyRelated`, `UnlikelyRelated`, `NotRelated`, or `Unknown` directly into `CausalConclusionV1`.

A fresh high-assurance conclusion requires independently verified observed-event, exposure, temporal, alternative-etiology, concomitant-exposure, and other policy-required evidence through #73.

## Non-claims

- the pure adapter does not prove the supplied source action is DHT-valid;
- it does not establish exact source entry definition;
- it does not construct a regulatory-reportability decision;
- it does not establish assessor authority or evidence-source trust;
- it does not clinically qualify historical causality labels.

See `docs/security/CLINICAL_CAUSALITY_TRIAL_ADAPTER_V1.md`.