### PR TITLE
security(causality): add bounded stable-double-read materializer

### DIFF
--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
@@ -52,3 +52,5 @@ Do not promote this lane beyond experimental until:
 5. downstream consumers preserve the bounded read classification end-to-end;
 6. privacy review confirms no patient/event/drug identifiers or cross-key correlator were introduced;
 7. qualification evidence is tied to the exact frozen branch head, not an ancestor.
+
+Semantic expansion of the read-boundary claim requires a new contract version rather than editing this v1 meaning in place.

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
@@ -1,0 +1,49 @@
+# Clinical causality read materialization v1 — qualification checklist
+
+This checklist is test design and review guidance, not runtime evidence.
+
+## Build / lint
+
+- [ ] `cargo fmt -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] workspace build/test passes on the exact PR head
+- [ ] causal coordinator WASM/package build passes
+
+## Stable-double-read behavior
+
+- [ ] zero-correction snapshot succeeds and reports count 0
+- [ ] one valid correction materializes and reports count 1
+- [ ] duplicate links to the same correction action are idempotent
+- [ ] a new correction target appearing between reads fails closed
+- [ ] a target disappearing/changing between reads fails closed
+- [ ] an unfetchable correction target fails closed
+- [ ] a structurally wrong correction target fails closed
+- [ ] a correction targeting another attestation fails closed
+- [ ] a correction crossing opaque receipt-commitment lineage fails closed
+- [ ] non-ActionHash link targets fail closed
+- [ ] more than 256 observed correction targets fails closed
+
+## Epistemic boundary
+
+- [ ] returned snapshot always carries `NetworkBackedStableDoubleRead`
+- [ ] no API field claims `Complete`, `Global`, or `Authoritative`
+- [ ] tests/documentation prove a stable double-read cannot establish absence of an unpropagated correction
+- [ ] callers cannot silently upgrade the snapshot into global-current truth
+
+## Adversarial conductor / DHT tests
+
+- [ ] ordinary valid attestation + correction path
+- [ ] malicious coordinator cannot create an integrity-invalid correction/link
+- [ ] delayed correction propagation is represented as a bounded snapshot, not global absence
+- [ ] two different publications sharing one opaque receipt commitment remain discoverability-sensitive under P0 #83
+- [ ] exact source-entry-definition validation remains blocked on P0 #72 where applicable
+
+## Promotion blockers
+
+Do not promote this lane beyond experimental until:
+
+1. exact-head CI executes successfully;
+2. conductor-level adversarial tests cover the stable-double-read behavior;
+3. P0 #72 exact source-entry-definition checks are resolved for cross-zome dependencies;
+4. P0 #83 defines the canonical completeness/discovery contract for all publications sharing one commitment;
+5. privacy review confirms no patient/event/drug identifiers or cross-key correlator were introduced.

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
@@ -28,6 +28,8 @@ This checklist is test design and review guidance, not runtime evidence.
 - [ ] returned snapshot always carries `NetworkBackedStableDoubleRead`
 - [ ] no API field claims `Complete`, `Global`, or `Authoritative`
 - [ ] tests/documentation prove a stable double-read cannot establish absence of an unpropagated correction
+- [ ] downstream adapters preserve the read-boundary class rather than stripping it
+- [ ] downstream APIs do not rename bounded-read state to generic/global `Current`
 - [ ] callers cannot silently upgrade the snapshot into global-current truth
 
 ## Adversarial conductor / DHT tests
@@ -46,4 +48,5 @@ Do not promote this lane beyond experimental until:
 2. conductor-level adversarial tests cover the stable-double-read behavior;
 3. P0 #72 exact source-entry-definition checks are resolved for cross-zome dependencies;
 4. P0 #83 defines the canonical completeness/discovery contract for all publications sharing one commitment;
-5. privacy review confirms no patient/event/drug identifiers or cross-key correlator were introduced.
+5. downstream consumers preserve the bounded read classification end-to-end;
+6. privacy review confirms no patient/event/drug identifiers or cross-key correlator were introduced.

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
@@ -54,3 +54,5 @@ Do not promote this lane beyond experimental until:
 7. qualification evidence is tied to the exact frozen branch head, not an ancestor.
 
 Semantic expansion of the read-boundary claim requires a new contract version rather than editing this v1 meaning in place.
+
+The exact commit selected for qualification must be recorded in the evidence receipt produced by the CI lane.

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
@@ -28,6 +28,7 @@ This checklist is test design and review guidance, not runtime evidence.
 - [ ] returned snapshot always carries `NetworkBackedStableDoubleRead`
 - [ ] no API field claims `Complete`, `Global`, or `Authoritative`
 - [ ] tests/documentation prove a stable double-read cannot establish absence of an unpropagated correction
+- [ ] tests/documentation cover network race/freshness limitations
 - [ ] downstream adapters preserve the read-boundary class rather than stripping it
 - [ ] downstream APIs do not rename bounded-read state to generic/global `Current`
 - [ ] callers cannot silently upgrade the snapshot into global-current truth

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md
@@ -50,4 +50,5 @@ Do not promote this lane beyond experimental until:
 3. P0 #72 exact source-entry-definition checks are resolved for cross-zome dependencies;
 4. P0 #83 defines the canonical completeness/discovery contract for all publications sharing one commitment;
 5. downstream consumers preserve the bounded read classification end-to-end;
-6. privacy review confirms no patient/event/drug identifiers or cross-key correlator were introduced.
+6. privacy review confirms no patient/event/drug identifiers or cross-key correlator were introduced;
+7. qualification evidence is tied to the exact frozen branch head, not an ancestor.

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
@@ -46,7 +46,7 @@ Duplicate links to the same correction action are semantically idempotent and de
 
 ## Network-read caveat
 
-Holochain is eventually consistent. Network-backed reads improve freshness but cannot prove absence of data that has not propagated to the queried view. The returned boundary is therefore intentionally narrower than `Complete`, `Authoritative`, or `Global`.
+Holochain is eventually consistent. Network-backed reads improve freshness but cannot prove absence of data that has not propagated to the queried view. Depending on conductor/network settings, network reads may also use race behavior in which an early peer response is returned before another queried peer has integrated newer data. The double-read therefore establishes only stability of the observed view around materialization, not global completeness. The returned boundary is intentionally narrower than `Complete`, `Authoritative`, or `Global`.
 
 ## Relationship to the reducer
 

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
@@ -1,0 +1,59 @@
+# Clinical causality read materialization v1
+
+## Purpose
+
+Provide one canonical coordinator path for materializing a known qualified causal-attestation publication and every correction link observed by the local conductor without upgrading eventual-consistency observations into a claim of global completeness.
+
+## Returned boundary
+
+`CausalAttestationPublicationSnapshotV1` always carries:
+
+- `read_boundary = NetworkBackedStableDoubleRead`;
+- the exact attestation action hash and decoded publication;
+- every correction target observed in the stable link set;
+- the observed correction-target count;
+- observation start/end timestamps.
+
+`NetworkBackedStableDoubleRead` means only:
+
+1. the coordinator requested network-backed link metadata;
+2. it captured the correction-link target set;
+3. it materialized and decoded every observed correction target;
+4. every correction was verified to target the requested attestation and opaque receipt-commitment lineage;
+5. a second network-backed link query returned the same target set.
+
+It does **not** mean:
+
+- no unpropagated correction exists;
+- no other publication shares the same opaque receipt commitment;
+- the conductor has a globally complete DHT view;
+- the snapshot is safe to upgrade into global `Current` truth;
+- a missing record is proven not to exist elsewhere.
+
+## Fail-closed behavior
+
+Materialization fails when:
+
+- the requested attestation is unavailable;
+- an observed correction target cannot be fetched/decoded;
+- a correction targets another attestation;
+- a correction crosses opaque receipt-commitment lineage;
+- correction fan-out exceeds 256 observed targets;
+- either link target is not an `ActionHash`;
+- the correction target set changes between the two reads.
+
+Duplicate links to the same correction action are semantically idempotent and deduplicated before comparison.
+
+## Network-read caveat
+
+Holochain is eventually consistent. Network-backed reads improve freshness but cannot prove absence of data that has not propagated to the queried view. The returned boundary is therefore intentionally narrower than `Complete`, `Authoritative`, or `Global`.
+
+## Relationship to the reducer
+
+The #82 reducer remains a pure projection of supplied records. This materializer strengthens how correction records for one known publication are collected, but it does not solve discovery of every publication sharing one opaque receipt commitment. P0 #83 tracks canonical commitment-scoped publication discovery and non-upgradable read-boundary semantics.
+
+## Privacy
+
+The materializer does not introduce patient, medication, symptom, assessor, or clinical-event identifiers. It operates on already-public attestation/correction actions and their opaque receipt commitment.
+
+No stable cross-key correlation identifier is introduced. Commitment-key rotation may intentionally split public lineages unless a separately reviewed protected migration proof is used.

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
@@ -48,6 +48,8 @@ Duplicate links to the same correction action are semantically idempotent and de
 
 Holochain is eventually consistent. Network-backed reads improve freshness but cannot prove absence of data that has not propagated to the queried view. Depending on conductor/network settings, network reads may use race behavior in which an early peer response is returned before another queried peer has integrated newer data. The double-read therefore establishes only stability of the observed view around materialization, not global completeness. The returned boundary is intentionally narrower than `Complete`, `Authoritative`, or `Global`.
 
+This bounded snapshot is suitable as evidence of **what this conductor observed during this read interval**. It is not evidence that the world contained nothing else.
+
 ## Relationship to the reducer
 
 The #82 reducer remains a pure projection of supplied records. This materializer strengthens how correction records for one known publication are collected, but it does not solve discovery of every publication sharing one opaque receipt commitment. P0 #83 tracks canonical commitment-scoped publication discovery and non-upgradable read-boundary semantics.

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
@@ -46,7 +46,7 @@ Duplicate links to the same correction action are semantically idempotent and de
 
 ## Network-read caveat
 
-Holochain is eventually consistent. Network-backed reads improve freshness but cannot prove absence of data that has not propagated to the queried view. Depending on conductor/network settings, network reads may also use race behavior in which an early peer response is returned before another queried peer has integrated newer data. The double-read therefore establishes only stability of the observed view around materialization, not global completeness. The returned boundary is intentionally narrower than `Complete`, `Authoritative`, or `Global`.
+Holochain is eventually consistent. Network-backed reads improve freshness but cannot prove absence of data that has not propagated to the queried view. Depending on conductor/network settings, network reads may use race behavior in which an early peer response is returned before another queried peer has integrated newer data. The double-read therefore establishes only stability of the observed view around materialization, not global completeness. The returned boundary is intentionally narrower than `Complete`, `Authoritative`, or `Global`.
 
 ## Relationship to the reducer
 

--- a/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
+++ b/docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md
@@ -59,3 +59,7 @@ The #82 reducer remains a pure projection of supplied records. This materializer
 The materializer does not introduce patient, medication, symptom, assessor, or clinical-event identifiers. It operates on already-public attestation/correction actions and their opaque receipt commitment.
 
 No stable cross-key correlation identifier is introduced. Commitment-key rotation may intentionally split public lineages unless a separately reviewed protected migration proof is used.
+
+## Version status
+
+This v1 contract is frozen for qualification. Semantic changes require a new version rather than silently broadening `NetworkBackedStableDoubleRead`.

--- a/zomes/clinical_causality/coordinator/src/lib.rs
+++ b/zomes/clinical_causality/coordinator/src/lib.rs
@@ -13,24 +13,36 @@ use hdk::prelude::*;
 
 const MAX_CORRECTIONS_PER_ATTESTATION: usize = 256;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ObservedCausalCorrectionV1 {
     pub action_hash: ActionHash,
     pub correction: CausalAttestationCorrection,
 }
 
-/// One locally observed, stable-double-read publication snapshot.
+/// Exact epistemic boundary of this materializer.
+///
+/// `NetworkBackedStableDoubleRead` means both correction-link reads requested network-backed
+/// metadata and returned the same target set around materialization. It does **not** mean the
+/// conductor has a globally complete DHT view or that an unpropagated correction is absent.
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CausalSnapshotReadBoundaryV1 {
+    NetworkBackedStableDoubleRead,
+}
+
+/// One observed publication snapshot whose correction-link target set was stable across two
+/// network-backed reads surrounding materialization.
 ///
 /// This is deliberately not named a globally complete read set. Holochain propagation is
 /// eventually consistent: a correction that has not reached this conductor cannot be proven
-/// absent. The guarantee here is narrower: the correction-link target set was unchanged across
-/// two local queries surrounding materialization, and every observed target was fetched and
-/// decoded successfully.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+/// absent. The guarantee here is narrower: the observed correction-link target set was unchanged
+/// across the two reads and every observed target was fetched and decoded successfully.
+#[derive(Clone, Serialize, Deserialize)]
 pub struct CausalAttestationPublicationSnapshotV1 {
     pub attestation_action_hash: ActionHash,
     pub attestation: QualifiedCausalAssessmentAttestation,
     pub corrections: Vec<ObservedCausalCorrectionV1>,
+    pub read_boundary: CausalSnapshotReadBoundaryV1,
+    pub observed_correction_target_count: usize,
     pub observation_started_at: Timestamp,
     pub observation_completed_at: Timestamp,
 }
@@ -40,7 +52,7 @@ pub fn create_causal_verifier_authorization(
     authorization: CausalAssessmentVerifierAuthorization,
 ) -> ExternResult<Record> {
     let hash = create_entry(EntryTypes::CausalAssessmentVerifierAuthorization(authorization))?;
-    get(hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+    get(hash, GetOptions::network())?.ok_or(wasm_error!(WasmErrorInner::Guest(
         "Committed causal verifier authorization could not be read back".to_string()
     )))
 }
@@ -50,7 +62,7 @@ pub fn publish_qualified_causal_attestation(
     attestation: QualifiedCausalAssessmentAttestation,
 ) -> ExternResult<Record> {
     let hash = create_entry(EntryTypes::QualifiedCausalAssessmentAttestation(attestation))?;
-    get(hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+    get(hash, GetOptions::network())?.ok_or(wasm_error!(WasmErrorInner::Guest(
         "Committed qualified causal attestation could not be read back".to_string()
     )))
 }
@@ -67,24 +79,25 @@ pub fn append_causal_attestation_correction(
         LinkTypes::AttestationToCorrections,
         (),
     )?;
-    get(correction_hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+    get(correction_hash, GetOptions::network())?.ok_or(wasm_error!(WasmErrorInner::Guest(
         "Committed causal attestation correction could not be read back".to_string()
     )))
 }
 
 /// Materialize one known causal-attestation publication and every correction link observed by
-/// this conductor, requiring the correction target set to be stable across two local reads.
+/// this conductor, requiring the correction target set to be stable across two network-backed
+/// reads.
 ///
 /// This does **not** prove global absence of unseen/unpropagated corrections or discover every
 /// other publication that may share the same opaque receipt commitment. Consumers must retain
-/// that bounded-read distinction in any safety decision.
+/// `read_boundary` in any safety decision and must not upgrade it to global completeness.
 #[hdk_extern]
 pub fn materialize_causal_attestation_publication_snapshot(
     attestation_hash: ActionHash,
 ) -> ExternResult<CausalAttestationPublicationSnapshotV1> {
     let observation_started_at = sys_time()?;
 
-    let attestation_record = get(attestation_hash.clone(), GetOptions::default())?.ok_or(
+    let attestation_record = get(attestation_hash.clone(), GetOptions::network())?.ok_or(
         wasm_error!(WasmErrorInner::Guest(
             "Qualified causal attestation was not found".to_string()
         )),
@@ -96,7 +109,7 @@ pub fn materialize_causal_attestation_publication_snapshot(
     let mut corrections = Vec::with_capacity(first_targets.len());
 
     for correction_hash in &first_targets {
-        let record = get(correction_hash.clone(), GetOptions::default())?.ok_or(wasm_error!(
+        let record = get(correction_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
             WasmErrorInner::Guest(
                 "Observed causal correction link target could not be materialized".to_string()
             )
@@ -136,6 +149,8 @@ pub fn materialize_causal_attestation_publication_snapshot(
         attestation_action_hash: attestation_hash,
         attestation,
         corrections,
+        read_boundary: CausalSnapshotReadBoundaryV1::NetworkBackedStableDoubleRead,
+        observed_correction_target_count: first_targets.len(),
         observation_started_at,
         observation_completed_at,
     })
@@ -147,7 +162,7 @@ fn observed_correction_targets(attestation_hash: &ActionHash) -> ExternResult<Ve
             attestation_hash.clone(),
             LinkTypes::AttestationToCorrections,
         )?,
-        GetStrategy::default(),
+        GetStrategy::Network,
     )?;
 
     if links.len() > MAX_CORRECTIONS_PER_ATTESTATION {

--- a/zomes/clinical_causality/coordinator/src/lib.rs
+++ b/zomes/clinical_causality/coordinator/src/lib.rs
@@ -2,13 +2,38 @@
 //! Thin coordinator for qualified clinical causal-assessment attestations.
 //!
 //! Causal assessment/qualification belongs to the pure crates and trust enforcement
-//! belongs to the integrity zome. This coordinator only commits exact entries/links.
+//! belongs to the integrity zome. This coordinator commits exact entries/links and
+//! exposes a bounded stable-double-read materializer for one known attestation.
 
 use clinical_causality_integrity::{
     CausalAssessmentVerifierAuthorization, CausalAttestationCorrection, EntryTypes, LinkTypes,
     QualifiedCausalAssessmentAttestation,
 };
 use hdk::prelude::*;
+
+const MAX_CORRECTIONS_PER_ATTESTATION: usize = 256;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ObservedCausalCorrectionV1 {
+    pub action_hash: ActionHash,
+    pub correction: CausalAttestationCorrection,
+}
+
+/// One locally observed, stable-double-read publication snapshot.
+///
+/// This is deliberately not named a globally complete read set. Holochain propagation is
+/// eventually consistent: a correction that has not reached this conductor cannot be proven
+/// absent. The guarantee here is narrower: the correction-link target set was unchanged across
+/// two local queries surrounding materialization, and every observed target was fetched and
+/// decoded successfully.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CausalAttestationPublicationSnapshotV1 {
+    pub attestation_action_hash: ActionHash,
+    pub attestation: QualifiedCausalAssessmentAttestation,
+    pub corrections: Vec<ObservedCausalCorrectionV1>,
+    pub observation_started_at: Timestamp,
+    pub observation_completed_at: Timestamp,
+}
 
 #[hdk_extern]
 pub fn create_causal_verifier_authorization(
@@ -45,4 +70,116 @@ pub fn append_causal_attestation_correction(
     get(correction_hash, GetOptions::default())?.ok_or(wasm_error!(WasmErrorInner::Guest(
         "Committed causal attestation correction could not be read back".to_string()
     )))
+}
+
+/// Materialize one known causal-attestation publication and every correction link observed by
+/// this conductor, requiring the correction target set to be stable across two local reads.
+///
+/// This does **not** prove global absence of unseen/unpropagated corrections or discover every
+/// other publication that may share the same opaque receipt commitment. Consumers must retain
+/// that bounded-read distinction in any safety decision.
+#[hdk_extern]
+pub fn materialize_causal_attestation_publication_snapshot(
+    attestation_hash: ActionHash,
+) -> ExternResult<CausalAttestationPublicationSnapshotV1> {
+    let observation_started_at = sys_time()?;
+
+    let attestation_record = get(attestation_hash.clone(), GetOptions::default())?.ok_or(
+        wasm_error!(WasmErrorInner::Guest(
+            "Qualified causal attestation was not found".to_string()
+        )),
+    )?;
+    let attestation: QualifiedCausalAssessmentAttestation =
+        decode_entry(&attestation_record, "qualified causal attestation")?;
+
+    let first_targets = observed_correction_targets(&attestation_hash)?;
+    let mut corrections = Vec::with_capacity(first_targets.len());
+
+    for correction_hash in &first_targets {
+        let record = get(correction_hash.clone(), GetOptions::default())?.ok_or(wasm_error!(
+            WasmErrorInner::Guest(
+                "Observed causal correction link target could not be materialized".to_string()
+            )
+        ))?;
+        let correction: CausalAttestationCorrection =
+            decode_entry(&record, "causal attestation correction")?;
+
+        if correction.attestation_hash != attestation_hash {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Observed causal correction does not target the requested attestation".to_string()
+            )));
+        }
+        if correction.qualified_receipt_commitment
+            != attestation.attestation.qualified_receipt_commitment
+        {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Observed causal correction crosses opaque receipt-commitment lineage".to_string()
+            )));
+        }
+
+        corrections.push(ObservedCausalCorrectionV1 {
+            action_hash: correction_hash.clone(),
+            correction,
+        });
+    }
+
+    let second_targets = observed_correction_targets(&attestation_hash)?;
+    let observation_completed_at = sys_time()?;
+    if first_targets != second_targets {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Causal correction link set changed during materialization; retry from a fresh snapshot"
+                .to_string()
+        )));
+    }
+
+    Ok(CausalAttestationPublicationSnapshotV1 {
+        attestation_action_hash: attestation_hash,
+        attestation,
+        corrections,
+        observation_started_at,
+        observation_completed_at,
+    })
+}
+
+fn observed_correction_targets(attestation_hash: &ActionHash) -> ExternResult<Vec<ActionHash>> {
+    let links = get_links(
+        LinkQuery::try_new(
+            attestation_hash.clone(),
+            LinkTypes::AttestationToCorrections,
+        )?,
+        GetStrategy::default(),
+    )?;
+
+    if links.len() > MAX_CORRECTIONS_PER_ATTESTATION {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Causal attestation has more than {MAX_CORRECTIONS_PER_ATTESTATION} observed correction links; refusing unbounded materialization"
+        ))));
+    }
+
+    let mut targets = Vec::with_capacity(links.len());
+    for link in links {
+        let target = link.target.into_action_hash().ok_or(wasm_error!(
+            WasmErrorInner::Guest(
+                "Causal correction link target must be an ActionHash".to_string()
+            )
+        ))?;
+        if !targets.contains(&target) {
+            targets.push(target);
+        }
+    }
+    targets.sort_by(|left, right| left.get_raw_36().cmp(right.get_raw_36()));
+    Ok(targets)
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
 }


### PR DESCRIPTION
## Stack

Depends on #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

## Why

The #82 reducer can only reason over records supplied by its caller. This tranche adds one canonical coordinator path for materializing a known causal-attestation publication plus every correction link observed by the conductor, while making the eventual-consistency boundary explicit and machine-readable.

Tracked by P0 #83.

## Bounded read contract

`CausalAttestationPublicationSnapshotV1` always reports:

- exact attestation action/publication;
- every correction target observed in the materialized link set;
- observed correction count;
- observation start/end timestamps;
- `read_boundary = NetworkBackedStableDoubleRead`.

The coordinator performs:

1. network-backed attestation fetch;
2. first network-backed correction-link read;
3. bounded materialization/decoding of every observed target;
4. exact attestation + opaque receipt-commitment lineage checks;
5. second network-backed correction-link read;
6. fail-closed comparison of the two target sets.

If the correction target set changes during materialization, the call fails and must be retried from a fresh snapshot.

## Fail-closed bounds

The materializer rejects:

- missing attestation;
- missing/undecodable correction target;
- cross-attestation correction;
- cross-receipt-commitment correction;
- non-ActionHash correction target;
- correction fan-out above 256 observed targets;
- link-set change between the two reads.

Duplicate links to the same correction action are idempotent.

## Explicit non-claim

Holochain remains eventually consistent. A stable network-backed double-read **does not** prove:

- no unpropagated correction exists;
- the conductor has a globally complete DHT view;
- no other publication shares the same opaque receipt commitment;
- global `Current` truth.

Canonical commitment-scoped publication discovery and non-upgradable completeness semantics remain tracked by P0 #83.

See:

- `docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_V1.md`
- `docs/security/CLINICAL_CAUSALITY_READ_MATERIALIZATION_QUALIFICATION_CHECKLIST.md`

This PR remains draft until exact-head CI and conductor-level adversarial tests execute successfully.