### PR TITLE
security(causality): add opaque-commitment canonical publication index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ members = [
     "zomes/medication_administration_occurrence/coordinator",
     "zomes/clinical_causality/integrity",
     "zomes/clinical_causality/coordinator",
+    "zomes/clinical_causality_index/integrity",
+    "zomes/clinical_causality_index/coordinator",
     "zomes/consent/integrity",
     "zomes/consent/coordinator",
     "zomes/bridge/integrity",

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -80,6 +80,8 @@ integrity:
       path: ../target/wasm32-unknown-unknown/release/medication_administration_occurrence_integrity.wasm
     - name: clinical_causality_integrity
       path: ../target/wasm32-unknown-unknown/release/clinical_causality_integrity.wasm
+    - name: clinical_causality_index_integrity
+      path: ../target/wasm32-unknown-unknown/release/clinical_causality_index_integrity.wasm
     - name: consent_integrity
       path: ../target/wasm32-unknown-unknown/release/consent_integrity.wasm
     - name: bridge_integrity
@@ -129,6 +131,11 @@ coordinator:
     - name: clinical_causality
       path: ../target/wasm32-unknown-unknown/release/clinical_causality.wasm
       dependencies:
+        - name: clinical_causality_integrity
+    - name: clinical_causality_index
+      path: ../target/wasm32-unknown-unknown/release/clinical_causality_index.wasm
+      dependencies:
+        - name: clinical_causality_index_integrity
         - name: clinical_causality_integrity
     - name: consent
       path: ../target/wasm32-unknown-unknown/release/consent.wasm

--- a/docs/security/CLINICAL_CAUSALITY_COMMITMENT_INDEX_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_CAUSALITY_COMMITMENT_INDEX_QUALIFICATION_CHECKLIST.md
@@ -1,0 +1,69 @@
+# Clinical causality commitment index v1 — qualification checklist
+
+This checklist is design/test guidance, not runtime qualification evidence.
+
+## Build / packaging
+
+- [ ] `cargo fmt -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] exact-head workspace build/test succeeds
+- [ ] commitment-index integrity/coordinator WASM builds
+- [ ] DNA packages both new zomes with correct dependency wiring
+
+## Deterministic anchor
+
+- [ ] same scheme + commitment value yields same anchor hash
+- [ ] changed commitment value changes anchor hash
+- [ ] changed commitment scheme changes anchor hash
+- [ ] zero commitment is rejected
+- [ ] committed synthetic anchor entries are rejected
+
+## Admission validation
+
+- [ ] correct attestation author can admit exact attestation under exact commitment anchor
+- [ ] third-party admission is rejected
+- [ ] wrong commitment anchor is rejected
+- [ ] non-EntryHash base is rejected
+- [ ] non-ActionHash target is rejected
+- [ ] missing/invalid target is rejected
+- [ ] structurally malformed causal attestation target is rejected
+- [ ] link deletion is rejected
+- [ ] exact source-entry-definition proof is covered under P0 #72 before promotion
+
+## Canonical discovery
+
+- [ ] zero-admission snapshot succeeds
+- [ ] one admitted attestation materializes
+- [ ] duplicate admission links to same target are idempotent
+- [ ] multiple admitted attestations for one commitment all materialize
+- [ ] changed target set between network reads fails closed
+- [ ] unavailable target fails closed
+- [ ] cross-commitment target fails closed
+- [ ] more than 256 observed links fails closed
+- [ ] returned snapshot always carries `NetworkBackedStableDoubleRead`
+
+## Canonical-state integration
+
+- [ ] high-assurance canonical reducer consumes only index-admitted publications
+- [ ] unindexed but otherwise valid attestation remains explicitly noncanonical
+- [ ] conflicting index-admitted publications for one commitment become conflict, never last-write-wins
+- [ ] publication correction materialization remains bounded by #84 semantics
+- [ ] read-boundary metadata is preserved end-to-end
+
+## Privacy
+
+- [ ] index exposes no patient/event/drug/symptom/dose/assessor identifiers
+- [ ] deterministic base derives only from already-public opaque commitment
+- [ ] no stable cross-key correlator is introduced
+- [ ] key-rotation continuity requires separate protected migration evidence
+
+## Promotion blockers
+
+Do not promote beyond experimental until:
+
+1. exact-head CI executes successfully;
+2. conductor adversarial tests cover admission and discovery;
+3. P0 #72 exact source-entry-definition proof is resolved;
+4. a canonical-state adapter prevents unindexed publications from entering the high-assurance reducer;
+5. P0 #83's bounded completeness contract is preserved end-to-end;
+6. privacy review confirms the index does not create a new sensitive correlation surface.

--- a/docs/security/CLINICAL_CAUSALITY_COMMITMENT_INDEX_V1.md
+++ b/docs/security/CLINICAL_CAUSALITY_COMMITMENT_INDEX_V1.md
@@ -1,0 +1,81 @@
+# Clinical causality commitment index v1
+
+## Purpose
+
+Provide a privacy-preserving canonical-admission and discovery surface for public qualified causal attestations that share one opaque qualified-receipt commitment.
+
+The index does not make every syntactically valid causal attestation canonical. Canonical status requires a separate DHT-valid admission link under the deterministic commitment-scoped index base.
+
+## Why admission is separate
+
+A modified coordinator can publish a DHT-valid causal attestation and omit any best-effort indexing call. Therefore the system must not treat mere attestation existence as equivalent to canonical high-assurance publication.
+
+V1 uses this rule:
+
+> valid causal attestation + valid commitment-index admission = canonical publication candidate
+
+A valid but unindexed attestation remains noncanonical evidence and must not enter the canonical high-assurance reducer through the new adapter path.
+
+## Deterministic index identity
+
+The link base is the `EntryHash` of a synthetic `CausalCommitmentIndexAnchorV1` containing:
+
+- schema version 1;
+- the already-public opaque commitment scheme;
+- the already-public opaque commitment value.
+
+The synthetic anchor entry does not need to be committed. The integrity zome rejects committed index-anchor entries; only the deterministic hash is used as the link base.
+
+The commitment scheme is part of index identity, so identical 32-byte values under HMAC-SHA-256 and keyed BLAKE3 do not collide semantically.
+
+## Admission validation
+
+For `CommitmentToAttestations` links, integrity validation requires:
+
+1. base is an `EntryHash`;
+2. target is an `ActionHash`;
+3. target resolves through `must_get_valid_record`;
+4. target decodes as a qualified causal attestation and passes its shape validation;
+5. deterministic base recomputed from the target's opaque receipt commitment exactly matches the supplied base;
+6. link author equals the target attestation action author.
+
+A third party therefore cannot canonize another verifier's attestation, and an attestation cannot be indexed under another receipt commitment.
+
+Admission links are append-only. Link deletion is rejected.
+
+## Canonical discovery snapshot
+
+`materialize_causal_commitment_index_snapshot`:
+
+1. derives the deterministic anchor from the requested commitment;
+2. performs a network-backed first link read;
+3. bounds observed fan-out to 256 links;
+4. deduplicates/sorts action targets;
+5. materializes every observed attestation with network-backed reads;
+6. rechecks each target's exact commitment;
+7. performs a second network-backed index read;
+8. fails if the observed target set changed.
+
+The result carries `NetworkBackedStableDoubleRead`, exact observation timestamps, anchor hash, observed target count, and every materialized index-admitted attestation.
+
+## Epistemic boundary
+
+The index solves **canonical admission/discovery**, not eventual-consistency impossibility.
+
+A stable double-read means the observed canonical target set did not change around materialization. It does not prove an admission link has not been authored elsewhere and not yet propagated.
+
+Canonical readers must preserve this bounded read classification. They must not rename it to global completeness.
+
+## Privacy
+
+The index base contains only a deterministic hash of the opaque keyed commitment that is already public in the attestation. It introduces no patient, medication, event, symptom, assessor, dosage, or research identifier.
+
+There is intentionally no stable cross-key correlator. Rotating the private commitment key may move the same protected receipt to a different public index root. Cross-key continuity requires a separately reviewed protected migration proof.
+
+## Source-entry-type limitation
+
+The index validator currently resolves a DHT-valid target and structurally decodes it as `QualifiedCausalAssessmentAttestation`, then binds admission to the target author and exact commitment. Exact source zome/entry-definition proof remains a promotion blocker under P0 #72.
+
+## Non-claims
+
+This index does not establish clinical truth, causal effect, population treatment effect, regulatory reportability, global DHT completeness, or that every noncanonical attestation is malicious. It establishes only the v1 canonical-admission contract described above.

--- a/zomes/clinical_causality_index/coordinator/Cargo.toml
+++ b/zomes/clinical_causality_index/coordinator/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "clinical_causality_index"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Coordinator for canonical opaque-commitment causal attestation admission and discovery"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { workspace = true }
+clinical_causality_index_integrity = { path = "../integrity" }
+clinical_causality_integrity = { path = "../../clinical_causality/integrity" }
+
+[features]
+default = []

--- a/zomes/clinical_causality_index/coordinator/src/lib.rs
+++ b/zomes/clinical_causality_index/coordinator/src/lib.rs
@@ -1,0 +1,170 @@
+#![deny(unsafe_code)]
+//! Canonical admission/discovery for privacy-minimized causal attestations.
+//!
+//! Admission is represented by an append-only validated link from a deterministic
+//! synthetic anchor derived from the already-public opaque receipt commitment to
+//! one exact causal attestation action. High-assurance readers consume only
+//! index-admitted publications; unindexed attestations remain noncanonical evidence.
+
+use clinical_causality_index_integrity::{
+    commitment_index_anchor_hash, LinkTypes, OpaqueCausalCommitmentV1,
+};
+use clinical_causality_integrity::QualifiedCausalAssessmentAttestation;
+use hdk::prelude::*;
+
+const MAX_INDEXED_ATTESTATIONS_PER_COMMITMENT: usize = 256;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AdmitCausalAttestationInputV1 {
+    pub attestation_action_hash: ActionHash,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct IndexedCausalAttestationV1 {
+    pub action_hash: ActionHash,
+    pub attestation: QualifiedCausalAssessmentAttestation,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CausalCommitmentIndexReadBoundaryV1 {
+    NetworkBackedStableDoubleRead,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CausalCommitmentIndexSnapshotV1 {
+    pub commitment: OpaqueCausalCommitmentV1,
+    pub anchor_hash: EntryHash,
+    pub attestations: Vec<IndexedCausalAttestationV1>,
+    pub read_boundary: CausalCommitmentIndexReadBoundaryV1,
+    pub observed_attestation_target_count: usize,
+    pub observation_started_at: Timestamp,
+    pub observation_completed_at: Timestamp,
+}
+
+/// Admit one exact already-published causal attestation into the canonical
+/// commitment-scoped index.
+///
+/// Integrity validation requires the link author to be the target attestation
+/// author and the deterministic base to match the target's opaque commitment.
+#[hdk_extern]
+pub fn admit_qualified_causal_attestation(
+    input: AdmitCausalAttestationInputV1,
+) -> ExternResult<ActionHash> {
+    let record = get(
+        input.attestation_action_hash.clone(),
+        GetOptions::network(),
+    )?
+    .ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Qualified causal attestation was not found for canonical admission".to_string()
+    )))?;
+    let attestation: QualifiedCausalAssessmentAttestation =
+        decode_entry(&record, "qualified causal attestation")?;
+    let base = commitment_index_anchor_hash(
+        attestation.attestation.qualified_receipt_commitment,
+    )?;
+
+    create_link(
+        base,
+        input.attestation_action_hash,
+        LinkTypes::CommitmentToAttestations,
+        (),
+    )
+}
+
+/// Discover index-admitted causal attestations for one exact opaque receipt
+/// commitment, requiring the target set to remain stable across two network-backed
+/// reads around materialization.
+///
+/// This proves only stability of the observed canonical-index view during this
+/// interval. It does not prove that an unpropagated valid admission does not exist.
+#[hdk_extern]
+pub fn materialize_causal_commitment_index_snapshot(
+    commitment: OpaqueCausalCommitmentV1,
+) -> ExternResult<CausalCommitmentIndexSnapshotV1> {
+    let observation_started_at = sys_time()?;
+    let anchor_hash = commitment_index_anchor_hash(commitment)?;
+    let first_targets = observed_attestation_targets(&anchor_hash)?;
+
+    let mut attestations = Vec::with_capacity(first_targets.len());
+    for action_hash in &first_targets {
+        let record = get(action_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
+            WasmErrorInner::Guest(
+                "Observed canonical causal attestation could not be materialized".to_string()
+            )
+        ))?;
+        let attestation: QualifiedCausalAssessmentAttestation =
+            decode_entry(&record, "qualified causal attestation")?;
+        if attestation.attestation.qualified_receipt_commitment != commitment {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Canonical causal index target crosses opaque receipt-commitment lineage"
+                    .to_string()
+            )));
+        }
+        attestations.push(IndexedCausalAttestationV1 {
+            action_hash: action_hash.clone(),
+            attestation,
+        });
+    }
+
+    let second_targets = observed_attestation_targets(&anchor_hash)?;
+    let observation_completed_at = sys_time()?;
+    if first_targets != second_targets {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Canonical causal index target set changed during materialization; retry from a fresh snapshot"
+                .to_string()
+        )));
+    }
+
+    Ok(CausalCommitmentIndexSnapshotV1 {
+        commitment,
+        anchor_hash,
+        attestations,
+        read_boundary: CausalCommitmentIndexReadBoundaryV1::NetworkBackedStableDoubleRead,
+        observed_attestation_target_count: first_targets.len(),
+        observation_started_at,
+        observation_completed_at,
+    })
+}
+
+fn observed_attestation_targets(anchor_hash: &EntryHash) -> ExternResult<Vec<ActionHash>> {
+    let links = get_links(
+        LinkQuery::try_new(
+            anchor_hash.clone(),
+            LinkTypes::CommitmentToAttestations,
+        )?,
+        GetStrategy::Network,
+    )?;
+
+    if links.len() > MAX_INDEXED_ATTESTATIONS_PER_COMMITMENT {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Causal receipt commitment has more than {MAX_INDEXED_ATTESTATIONS_PER_COMMITMENT} observed canonical attestation links; refusing unbounded materialization"
+        ))));
+    }
+
+    let mut targets = Vec::with_capacity(links.len());
+    for link in links {
+        let target = link.target.into_action_hash().ok_or(wasm_error!(
+            WasmErrorInner::Guest(
+                "Canonical causal commitment index target must be an ActionHash".to_string()
+            )
+        ))?;
+        if !targets.contains(&target) {
+            targets.push(target);
+        }
+    }
+    targets.sort_by(|left, right| left.get_raw_36().cmp(right.get_raw_36()));
+    Ok(targets)
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}

--- a/zomes/clinical_causality_index/integrity/Cargo.toml
+++ b/zomes/clinical_causality_index/integrity/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "clinical_causality_index_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Integrity boundary for canonical opaque-commitment causal attestation admission"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdi = { workspace = true }
+clinical_causality_integrity = { path = "../../clinical_causality/integrity" }
+
+[features]
+default = []

--- a/zomes/clinical_causality_index/integrity/src/lib.rs
+++ b/zomes/clinical_causality_index/integrity/src/lib.rs
@@ -1,0 +1,202 @@
+#![deny(unsafe_code)]
+#![allow(clippy::collapsible_match)]
+//! Canonical admission index for privacy-minimized causal attestations.
+//!
+//! A causal attestation may exist on the DHT without an admission link, but only
+//! attestations admitted through this integrity boundary participate in the
+//! high-assurance commitment-scoped read model. The deterministic link base is
+//! derived solely from the attestation's already-public opaque receipt commitment.
+
+use clinical_causality_integrity::{
+    CausalCommitmentSchemeV1, OpaqueCausalCommitmentV1, QualifiedCausalAssessmentAttestation,
+};
+use hdi::prelude::*;
+
+const INDEX_SCHEMA_VERSION: u16 = 1;
+
+pub use clinical_causality_integrity::{
+    CausalAttestationCorrection, QualifiedCausalAssessmentAttestationV1,
+};
+
+/// Synthetic anchor used only to derive a deterministic `EntryHash` link base.
+/// The anchor entry itself is never required to be committed.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq, Eq)]
+pub struct CausalCommitmentIndexAnchorV1 {
+    pub schema_version: u16,
+    pub commitment: OpaqueCausalCommitmentV1,
+}
+
+impl CausalCommitmentIndexAnchorV1 {
+    pub fn new(commitment: OpaqueCausalCommitmentV1) -> ExternResult<Self> {
+        if commitment.value == [0u8; 32] {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Causal commitment index anchor cannot use a zero commitment".to_string()
+            )));
+        }
+        Ok(Self {
+            schema_version: INDEX_SCHEMA_VERSION,
+            commitment,
+        })
+    }
+}
+
+/// Compute the canonical commitment-scoped publication index base.
+pub fn commitment_index_anchor_hash(
+    commitment: OpaqueCausalCommitmentV1,
+) -> ExternResult<EntryHash> {
+    hash_entry(&CausalCommitmentIndexAnchorV1::new(commitment)?)
+}
+
+/// Reserved synthetic entry type. V1 rejects committing it; only its deterministic
+/// entry hash is used as a link base.
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    CommitmentIndexAnchor(CausalCommitmentIndexAnchorV1),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    CommitmentToAttestations,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(_) => invalid(
+            "Clinical causality commitment index has no committed entries; anchors are synthetic",
+        ),
+        FlatOp::RegisterUpdate(_) => invalid(
+            "Clinical causality commitment index entries cannot be updated",
+        ),
+        FlatOp::RegisterDelete(_) => invalid(
+            "Clinical causality commitment index entries cannot be deleted",
+        ),
+        FlatOp::RegisterCreateLink {
+            link_type,
+            base_address,
+            target_address,
+            action,
+            ..
+        } => validate_create_link(link_type, base_address, target_address, action),
+        FlatOp::RegisterDeleteLink { .. } => invalid(
+            "Canonical causal commitment admission links are append-only and cannot be deleted",
+        ),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_create_link(
+    link_type: LinkTypes,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    action: CreateLink,
+) -> ExternResult<ValidateCallbackResult> {
+    match link_type {
+        LinkTypes::CommitmentToAttestations => {
+            let base = base_address.into_entry_hash().ok_or(wasm_error!(
+                WasmErrorInner::Guest(
+                    "Causal commitment admission link base must be an EntryHash".to_string()
+                )
+            ))?;
+            let target = target_address.into_action_hash().ok_or(wasm_error!(
+                WasmErrorInner::Guest(
+                    "Causal commitment admission link target must be an ActionHash".to_string()
+                )
+            ))?;
+
+            let record = must_get_valid_record(target)?;
+            let attestation: QualifiedCausalAssessmentAttestation =
+                decode_entry(&record, "qualified causal attestation")?;
+
+            let shape = attestation.attestation.validate()?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+
+            let expected = commitment_index_anchor_hash(
+                attestation.attestation.qualified_receipt_commitment,
+            )?;
+            if base != expected {
+                return invalid(
+                    "Causal commitment admission link base does not match target receipt commitment",
+                );
+            }
+
+            // Canonical admission must be performed by the same verifier that authored
+            // the target attestation. A third party cannot canonize someone else's claim.
+            if record.action().author() != &action.author {
+                return invalid(
+                    "Causal commitment admission link must be authored by attestation author",
+                );
+            }
+
+            Ok(ValidateCallbackResult::Valid)
+        }
+    }
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn commitment(seed: u8) -> OpaqueCausalCommitmentV1 {
+        OpaqueCausalCommitmentV1 {
+            scheme: CausalCommitmentSchemeV1::Blake3Keyed,
+            value: [seed; 32],
+        }
+    }
+
+    #[test]
+    fn same_commitment_has_same_anchor() {
+        assert_eq!(
+            commitment_index_anchor_hash(commitment(7)).unwrap(),
+            commitment_index_anchor_hash(commitment(7)).unwrap()
+        );
+    }
+
+    #[test]
+    fn different_commitment_changes_anchor() {
+        assert_ne!(
+            commitment_index_anchor_hash(commitment(7)).unwrap(),
+            commitment_index_anchor_hash(commitment(8)).unwrap()
+        );
+    }
+
+    #[test]
+    fn commitment_scheme_is_part_of_anchor_identity() {
+        let mut other = commitment(7);
+        other.scheme = CausalCommitmentSchemeV1::HmacSha256;
+        assert_ne!(
+            commitment_index_anchor_hash(commitment(7)).unwrap(),
+            commitment_index_anchor_hash(other).unwrap()
+        );
+    }
+
+    #[test]
+    fn zero_commitment_is_rejected() {
+        let value = OpaqueCausalCommitmentV1 {
+            scheme: CausalCommitmentSchemeV1::Blake3Keyed,
+            value: [0u8; 32],
+        };
+        assert!(commitment_index_anchor_hash(value).is_err());
+    }
+}

--- a/zomes/clinical_causality_index/integrity/src/lib.rs
+++ b/zomes/clinical_causality_index/integrity/src/lib.rs
@@ -7,15 +7,14 @@
 //! high-assurance commitment-scoped read model. The deterministic link base is
 //! derived solely from the attestation's already-public opaque receipt commitment.
 
-use clinical_causality_integrity::{
-    CausalCommitmentSchemeV1, OpaqueCausalCommitmentV1, QualifiedCausalAssessmentAttestation,
-};
+use clinical_causality_integrity::QualifiedCausalAssessmentAttestation;
 use hdi::prelude::*;
 
 const INDEX_SCHEMA_VERSION: u16 = 1;
 
 pub use clinical_causality_integrity::{
-    CausalAttestationCorrection, QualifiedCausalAssessmentAttestationV1,
+    CausalAttestationCorrection, OpaqueCausalCommitmentV1,
+    QualifiedCausalAssessmentAttestationV1,
 };
 
 /// Synthetic anchor used only to derive a deterministic `EntryHash` link base.
@@ -157,6 +156,7 @@ fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clinical_causality_integrity::CausalCommitmentSchemeV1;
 
     fn commitment(seed: u8) -> OpaqueCausalCommitmentV1 {
         OpaqueCausalCommitmentV1 {


### PR DESCRIPTION
## Stack

Depends on #84 -> #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

Implements the next P0 #83 step: canonical commitment-scoped publication admission/discovery without adding patient/event/drug identifiers or a cross-key correlator.

## Why a separate index zome

A normal best-effort post-publication index call cannot make indexing mandatory against a modified coordinator. V1 therefore treats index admission as a separate high-assurance state transition:

`valid causal attestation + valid commitment-index admission = canonical publication candidate`.

A DHT-valid but unindexed attestation remains noncanonical evidence and must not enter the canonical high-assurance reducer through the new adapter path.

## Deterministic privacy-preserving index

The link base is the deterministic `EntryHash` of a synthetic v1 anchor containing only:

- schema version;
- the already-public opaque commitment scheme;
- the already-public opaque commitment bytes.

The anchor entry itself is never required to be committed. The integrity zome rejects committed anchor entries.

## Admission validation

`CommitmentToAttestations` requires:

- EntryHash base;
- ActionHash target;
- DHT-valid target record;
- target decodes/validates as a qualified causal attestation;
- base recomputed from the target's exact opaque commitment matches exactly;
- admission link author equals the target attestation author.

A third party cannot canonize another verifier's claim, and an attestation cannot be indexed under another receipt commitment. Admission links are append-only.

## Canonical discovery

`materialize_causal_commitment_index_snapshot` performs a bounded network-backed stable double-read of one commitment index, materializes/rechecks every observed target, and fails closed on target-set drift or fan-out above 256.

The returned boundary is `NetworkBackedStableDoubleRead`; it does not claim global DHT completeness or absence of an unpropagated admission.

## Privacy

No patient, medication, symptom, event, assessor, dosage, or research identifier is introduced. The index is scoped only by the opaque commitment already public in the causal attestation. Key rotation intentionally changes index roots unless a separately reviewed protected migration proof is supplied.

## Non-claims / blockers

- Exact source zome/entry-definition proof remains P0 #72.
- Eventual-consistency completeness remains bounded under P0 #83.
- This PR does not yet replace the low-level #82 reducer; a child canonical-state adapter must consume only index-admitted publications before promotion.
- No clinical/research qualification is claimed until exact-head CI and conductor adversarial tests execute successfully.

See `docs/security/CLINICAL_CAUSALITY_COMMITMENT_INDEX_V1.md` and the qualification checklist.