### PR TITLE
security(causality): add nested canonical commitment snapshots

### DIFF
--- a/docs/security/CLINICAL_CAUSALITY_CANONICAL_SNAPSHOT_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_CAUSALITY_CANONICAL_SNAPSHOT_QUALIFICATION_CHECKLIST.md
@@ -1,0 +1,62 @@
+# Clinical causality canonical snapshot v1 — qualification checklist
+
+This checklist is test design/review guidance, not runtime evidence.
+
+## Build / lint
+
+- [ ] `cargo fmt -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] exact-head workspace tests pass
+- [ ] `clinical_causality_index` WASM/package builds
+
+## Outer index closure
+
+- [ ] zero-admission commitment returns an empty bounded snapshot
+- [ ] one admitted publication returns one publication snapshot
+- [ ] multiple admitted publications all materialize deterministically
+- [ ] new admission between index reads A/B fails closed
+- [ ] disappearing/changing observed target between A/B fails closed
+- [ ] duplicate links to the same attestation action are idempotent
+- [ ] >256 observed index links fails closed
+
+## Inner correction closure
+
+- [ ] zero-correction publication succeeds
+- [ ] one/multiple corrections materialize in deterministic action-hash order
+- [ ] new correction between inner reads A/B fails closed
+- [ ] wrong-attestation correction fails closed
+- [ ] cross-commitment correction fails closed
+- [ ] unavailable/malformed correction target fails closed
+- [ ] >256 observed corrections for one attestation fails closed
+
+## Final closure pass
+
+- [ ] correction arriving after a publication's inner read B but before final closure is detected
+- [ ] unchanged correction sets survive final closure
+- [ ] total correction count >4,096 fails closed
+- [ ] integer overflow in total correction accounting fails closed
+
+## Canonicality
+
+- [ ] only index-admitted publications appear in returned snapshot
+- [ ] valid but unindexed attestation is absent from canonical snapshot
+- [ ] admission under another commitment is rejected at integrity validation
+- [ ] third-party admission is rejected at integrity validation
+
+## Epistemic boundary
+
+- [ ] result always carries `NestedNetworkBackedStableReadsWithFinalClosureChecks`
+- [ ] no field/API claims global completeness or global current truth
+- [ ] eventual-consistency/race limitations remain explicit
+- [ ] downstream reducer preserves the exact bounded-read class
+
+## Promotion blockers
+
+Do not promote beyond experimental until:
+
+1. exact-head CI executes successfully;
+2. conductor-level race/adversarial tests exercise outer, inner, and final closure;
+3. P0 #72 exact source-entry-definition proof is resolved;
+4. canonical reducer accepts this snapshot type and refuses arbitrary/unindexed publication sets;
+5. P0 #83 non-upgradable completeness semantics are preserved end-to-end;
+6. privacy review confirms no new sensitive correlation surface.

--- a/docs/security/CLINICAL_CAUSALITY_CANONICAL_SNAPSHOT_V1.md
+++ b/docs/security/CLINICAL_CAUSALITY_CANONICAL_SNAPSHOT_V1.md
@@ -1,0 +1,81 @@
+# Clinical causality canonical snapshot v1
+
+## Purpose
+
+Materialize one bounded runtime capsule containing every **index-admitted causal publication observed** for one opaque qualified-receipt commitment plus every correction observed for those publications.
+
+This is the runtime composition layer between canonical admission (#85), correction materialization (#84), and the conflict-preserving causal reducer (#82).
+
+## Closure sequence
+
+`materialize_canonical_causal_commitment_snapshot` performs:
+
+1. network-backed commitment-index read A;
+2. for every observed admitted attestation:
+   - network-backed attestation fetch;
+   - correction-link read A;
+   - bounded materialization and exact target/commitment checks;
+   - correction-link read B, which must match A;
+3. network-backed commitment-index read B, which must match index read A;
+4. final correction-link read C for every publication, which must still match its materialized correction set;
+5. only then return the canonical snapshot.
+
+This catches membership drift that occurs while later publications are being materialized and is stronger than independently materializing each publication without an outer closure pass.
+
+## Bounds
+
+- maximum observed index links per commitment: 256;
+- maximum observed correction links per attestation: 256;
+- maximum total materialized corrections in one canonical snapshot: 4,096;
+- duplicate links to the same action are idempotent after target deduplication.
+
+Any bound violation fails closed.
+
+## Returned semantics
+
+The returned snapshot carries:
+
+- exact opaque commitment;
+- deterministic index anchor hash;
+- all observed index-admitted publication snapshots;
+- every observed correction record for each publication;
+- per-publication correction observation windows/counts;
+- global observation window/counts;
+- `NestedNetworkBackedStableReadsWithFinalClosureChecks` as the explicit read boundary.
+
+## What this establishes
+
+The capsule establishes a tightly bounded claim:
+
+> During this conductor's materialization interval, the observed canonical index membership was stable across the outer reads, each observed publication's correction set was stable across its inner reads, and every correction set still matched at final closure.
+
+## What this does not establish
+
+It does not prove:
+
+- global DHT completeness;
+- absence of an admission/correction that has not propagated;
+- that a noncanonical/unindexed attestation does not exist;
+- clinical truth or causal effect;
+- population-level causal effect;
+- regulatory reportability.
+
+The read-boundary classification must survive into every downstream state/result that uses this snapshot.
+
+## Canonical vs noncanonical
+
+Only attestations admitted through the validated opaque-commitment index appear in this snapshot. An otherwise valid but unindexed causal attestation is intentionally excluded from the canonical high-assurance runtime view.
+
+That exclusion is semantic, not censorship or deletion: noncanonical attestations may still exist as DHT evidence and may later be admitted by their original author if they satisfy the admission contract.
+
+## Privacy
+
+The snapshot uses only already-public opaque commitments and public attestation/correction records. It introduces no patient, medication, symptom, event, dose, assessor, or cross-key stable identifier.
+
+## Promotion blockers
+
+- exact source zome/entry-definition proof under P0 #72;
+- exact-head build/test evidence;
+- conductor adversarial tests for all closure races and bounds;
+- canonical reducer integration that refuses non-index-admitted publications;
+- P0 #83 bounded-read semantics preserved end-to-end.

--- a/zomes/clinical_causality_index/coordinator/src/lib.rs
+++ b/zomes/clinical_causality_index/coordinator/src/lib.rs
@@ -7,12 +7,17 @@
 //! index-admitted publications; unindexed attestations remain noncanonical evidence.
 
 use clinical_causality_index_integrity::{
-    commitment_index_anchor_hash, LinkTypes, OpaqueCausalCommitmentV1,
+    commitment_index_anchor_hash, LinkTypes as IndexLinkTypes, OpaqueCausalCommitmentV1,
 };
-use clinical_causality_integrity::QualifiedCausalAssessmentAttestation;
+use clinical_causality_integrity::{
+    CausalAttestationCorrection, LinkTypes as CausalLinkTypes,
+    QualifiedCausalAssessmentAttestation,
+};
 use hdk::prelude::*;
 
 const MAX_INDEXED_ATTESTATIONS_PER_COMMITMENT: usize = 256;
+const MAX_CORRECTIONS_PER_ATTESTATION: usize = 256;
+const MAX_TOTAL_CORRECTIONS_PER_CANONICAL_SNAPSHOT: usize = 4096;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct AdmitCausalAttestationInputV1 {
@@ -37,6 +42,47 @@ pub struct CausalCommitmentIndexSnapshotV1 {
     pub attestations: Vec<IndexedCausalAttestationV1>,
     pub read_boundary: CausalCommitmentIndexReadBoundaryV1,
     pub observed_attestation_target_count: usize,
+    pub observation_started_at: Timestamp,
+    pub observation_completed_at: Timestamp,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CanonicalObservedCausalCorrectionV1 {
+    pub action_hash: ActionHash,
+    pub correction: CausalAttestationCorrection,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CanonicalCorrectionReadBoundaryV1 {
+    NetworkBackedStableDoubleReadWithFinalClosureCheck,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CanonicalCausalPublicationSnapshotV1 {
+    pub attestation_action_hash: ActionHash,
+    pub attestation: QualifiedCausalAssessmentAttestation,
+    pub corrections: Vec<CanonicalObservedCausalCorrectionV1>,
+    pub correction_read_boundary: CanonicalCorrectionReadBoundaryV1,
+    pub observed_correction_target_count: usize,
+    pub correction_observation_started_at: Timestamp,
+    pub correction_observation_completed_at: Timestamp,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CanonicalCausalCommitmentReadBoundaryV1 {
+    NestedNetworkBackedStableReadsWithFinalClosureChecks,
+}
+
+/// One bounded canonical snapshot of every index-admitted publication observed for
+/// one opaque receipt commitment plus every correction observed for those publications.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CanonicalCausalCommitmentSnapshotV1 {
+    pub commitment: OpaqueCausalCommitmentV1,
+    pub anchor_hash: EntryHash,
+    pub publications: Vec<CanonicalCausalPublicationSnapshotV1>,
+    pub read_boundary: CanonicalCausalCommitmentReadBoundaryV1,
+    pub observed_attestation_target_count: usize,
+    pub observed_total_correction_target_count: usize,
     pub observation_started_at: Timestamp,
     pub observation_completed_at: Timestamp,
 }
@@ -66,7 +112,7 @@ pub fn admit_qualified_causal_attestation(
     create_link(
         base,
         input.attestation_action_hash,
-        LinkTypes::CommitmentToAttestations,
+        IndexLinkTypes::CommitmentToAttestations,
         (),
     )
 }
@@ -74,9 +120,6 @@ pub fn admit_qualified_causal_attestation(
 /// Discover index-admitted causal attestations for one exact opaque receipt
 /// commitment, requiring the target set to remain stable across two network-backed
 /// reads around materialization.
-///
-/// This proves only stability of the observed canonical-index view during this
-/// interval. It does not prove that an unpropagated valid admission does not exist.
 #[hdk_extern]
 pub fn materialize_causal_commitment_index_snapshot(
     commitment: OpaqueCausalCommitmentV1,
@@ -87,19 +130,7 @@ pub fn materialize_causal_commitment_index_snapshot(
 
     let mut attestations = Vec::with_capacity(first_targets.len());
     for action_hash in &first_targets {
-        let record = get(action_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
-            WasmErrorInner::Guest(
-                "Observed canonical causal attestation could not be materialized".to_string()
-            )
-        ))?;
-        let attestation: QualifiedCausalAssessmentAttestation =
-            decode_entry(&record, "qualified causal attestation")?;
-        if attestation.attestation.qualified_receipt_commitment != commitment {
-            return Err(wasm_error!(WasmErrorInner::Guest(
-                "Canonical causal index target crosses opaque receipt-commitment lineage"
-                    .to_string()
-            )));
-        }
+        let attestation = materialize_exact_attestation(action_hash, commitment)?;
         attestations.push(IndexedCausalAttestationV1 {
             action_hash: action_hash.clone(),
             attestation,
@@ -126,11 +157,157 @@ pub fn materialize_causal_commitment_index_snapshot(
     })
 }
 
+/// Materialize one bounded canonical commitment snapshot.
+///
+/// The operation stable-double-reads the canonical index, stable-double-reads every
+/// admitted publication's correction set, rechecks the outer index, and finally
+/// rechecks every correction target set once more. It therefore captures a tightly
+/// bounded observed state while making no claim that an unpropagated future/remote
+/// admission or correction does not exist.
+#[hdk_extern]
+pub fn materialize_canonical_causal_commitment_snapshot(
+    commitment: OpaqueCausalCommitmentV1,
+) -> ExternResult<CanonicalCausalCommitmentSnapshotV1> {
+    let observation_started_at = sys_time()?;
+    let anchor_hash = commitment_index_anchor_hash(commitment)?;
+    let first_attestation_targets = observed_attestation_targets(&anchor_hash)?;
+
+    let mut total_corrections = 0usize;
+    let mut publications = Vec::with_capacity(first_attestation_targets.len());
+
+    for attestation_hash in &first_attestation_targets {
+        let publication = materialize_canonical_publication(attestation_hash, commitment)?;
+        total_corrections = total_corrections
+            .checked_add(publication.observed_correction_target_count)
+            .ok_or(wasm_error!(WasmErrorInner::Guest(
+                "Canonical causal snapshot correction count overflow".to_string()
+            )))?;
+        if total_corrections > MAX_TOTAL_CORRECTIONS_PER_CANONICAL_SNAPSHOT {
+            return Err(wasm_error!(WasmErrorInner::Guest(format!(
+                "Canonical causal snapshot exceeds total correction limit of {MAX_TOTAL_CORRECTIONS_PER_CANONICAL_SNAPSHOT}"
+            ))));
+        }
+        publications.push(publication);
+    }
+
+    let second_attestation_targets = observed_attestation_targets(&anchor_hash)?;
+    if first_attestation_targets != second_attestation_targets {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Canonical causal index changed while publication corrections were being materialized"
+                .to_string()
+        )));
+    }
+
+    // Final closure pass: ensure no observed correction target set changed after its
+    // inner double-read while later publications were being materialized.
+    for publication in &publications {
+        let final_targets = observed_correction_targets(&publication.attestation_action_hash)?;
+        let expected_targets: Vec<ActionHash> = publication
+            .corrections
+            .iter()
+            .map(|record| record.action_hash.clone())
+            .collect();
+        if final_targets != expected_targets {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Canonical causal correction set changed before final snapshot closure"
+                    .to_string()
+            )));
+        }
+    }
+
+    let observation_completed_at = sys_time()?;
+    Ok(CanonicalCausalCommitmentSnapshotV1 {
+        commitment,
+        anchor_hash,
+        publications,
+        read_boundary:
+            CanonicalCausalCommitmentReadBoundaryV1::NestedNetworkBackedStableReadsWithFinalClosureChecks,
+        observed_attestation_target_count: first_attestation_targets.len(),
+        observed_total_correction_target_count: total_corrections,
+        observation_started_at,
+        observation_completed_at,
+    })
+}
+
+fn materialize_canonical_publication(
+    attestation_hash: &ActionHash,
+    commitment: OpaqueCausalCommitmentV1,
+) -> ExternResult<CanonicalCausalPublicationSnapshotV1> {
+    let correction_observation_started_at = sys_time()?;
+    let attestation = materialize_exact_attestation(attestation_hash, commitment)?;
+    let first_correction_targets = observed_correction_targets(attestation_hash)?;
+
+    let mut corrections = Vec::with_capacity(first_correction_targets.len());
+    for correction_hash in &first_correction_targets {
+        let record = get(correction_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
+            WasmErrorInner::Guest(
+                "Observed canonical causal correction could not be materialized".to_string()
+            )
+        ))?;
+        let correction: CausalAttestationCorrection =
+            decode_entry(&record, "causal attestation correction")?;
+        if correction.attestation_hash != *attestation_hash {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Canonical causal correction targets another attestation".to_string()
+            )));
+        }
+        if correction.qualified_receipt_commitment != commitment {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Canonical causal correction crosses opaque receipt-commitment lineage"
+                    .to_string()
+            )));
+        }
+        corrections.push(CanonicalObservedCausalCorrectionV1 {
+            action_hash: correction_hash.clone(),
+            correction,
+        });
+    }
+
+    let second_correction_targets = observed_correction_targets(attestation_hash)?;
+    let correction_observation_completed_at = sys_time()?;
+    if first_correction_targets != second_correction_targets {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Canonical causal correction set changed during publication materialization"
+                .to_string()
+        )));
+    }
+
+    Ok(CanonicalCausalPublicationSnapshotV1 {
+        attestation_action_hash: attestation_hash.clone(),
+        attestation,
+        corrections,
+        correction_read_boundary:
+            CanonicalCorrectionReadBoundaryV1::NetworkBackedStableDoubleReadWithFinalClosureCheck,
+        observed_correction_target_count: first_correction_targets.len(),
+        correction_observation_started_at,
+        correction_observation_completed_at,
+    })
+}
+
+fn materialize_exact_attestation(
+    action_hash: &ActionHash,
+    commitment: OpaqueCausalCommitmentV1,
+) -> ExternResult<QualifiedCausalAssessmentAttestation> {
+    let record = get(action_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
+        WasmErrorInner::Guest(
+            "Observed canonical causal attestation could not be materialized".to_string()
+        )
+    ))?;
+    let attestation: QualifiedCausalAssessmentAttestation =
+        decode_entry(&record, "qualified causal attestation")?;
+    if attestation.attestation.qualified_receipt_commitment != commitment {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Canonical causal index target crosses opaque receipt-commitment lineage".to_string()
+        )));
+    }
+    Ok(attestation)
+}
+
 fn observed_attestation_targets(anchor_hash: &EntryHash) -> ExternResult<Vec<ActionHash>> {
     let links = get_links(
         LinkQuery::try_new(
             anchor_hash.clone(),
-            LinkTypes::CommitmentToAttestations,
+            IndexLinkTypes::CommitmentToAttestations,
         )?,
         GetStrategy::Network,
     )?;
@@ -141,12 +318,35 @@ fn observed_attestation_targets(anchor_hash: &EntryHash) -> ExternResult<Vec<Act
         ))));
     }
 
+    deduplicated_action_targets(links, "Canonical causal commitment index target")
+}
+
+fn observed_correction_targets(attestation_hash: &ActionHash) -> ExternResult<Vec<ActionHash>> {
+    let links = get_links(
+        LinkQuery::try_new(
+            attestation_hash.clone(),
+            CausalLinkTypes::AttestationToCorrections,
+        )?,
+        GetStrategy::Network,
+    )?;
+
+    if links.len() > MAX_CORRECTIONS_PER_ATTESTATION {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Canonical causal attestation has more than {MAX_CORRECTIONS_PER_ATTESTATION} observed correction links; refusing unbounded materialization"
+        ))));
+    }
+
+    deduplicated_action_targets(links, "Canonical causal correction target")
+}
+
+fn deduplicated_action_targets(
+    links: Vec<Link>,
+    label: &'static str,
+) -> ExternResult<Vec<ActionHash>> {
     let mut targets = Vec::with_capacity(links.len());
     for link in links {
         let target = link.target.into_action_hash().ok_or(wasm_error!(
-            WasmErrorInner::Guest(
-                "Canonical causal commitment index target must be an ActionHash".to_string()
-            )
+            WasmErrorInner::Guest(format!("{label} must be an ActionHash"))
         ))?;
         if !targets.contains(&target) {
             targets.push(target);


### PR DESCRIPTION
## Stack

Depends on #85 -> #84 -> #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

## Why

#85 establishes canonical opaque-commitment admission/discovery, while #84 bounds corrections for one known publication. This tranche composes those runtime reads into one bounded canonical commitment snapshot so downstream consumers do not have to assemble the pieces correctly themselves.

## Nested closure protocol

For one opaque receipt commitment:

1. network-backed commitment-index read A;
2. for every observed admitted attestation:
   - exact attestation materialization;
   - correction-link read A;
   - bounded correction materialization with exact target/commitment checks;
   - correction-link read B, which must equal A;
3. commitment-index read B, which must equal index read A;
4. final correction-link read C for every publication, which must still match the materialized correction set;
5. return only after every closure check succeeds.

This catches index drift during inner materialization and correction drift that occurs after one publication's inner double-read while later publications are still being processed.

## Bounds

- <=256 observed admitted attestations per commitment;
- <=256 observed corrections per attestation;
- <=4,096 total corrections per canonical snapshot;
- checked total-count arithmetic;
- duplicate links to the same action are idempotent.

## Returned boundary

`CanonicalCausalCommitmentSnapshotV1` carries `NestedNetworkBackedStableReadsWithFinalClosureChecks`, exact observation windows/counts, deterministic anchor identity, and only index-admitted publications with their observed corrections.

This is still a bounded observation, not proof of global DHT completeness. It cannot establish absence of an unpropagated admission/correction.

## Canonicality

Valid but unindexed causal attestations are intentionally excluded from this runtime capsule. They remain noncanonical DHT evidence rather than silently entering the high-assurance state path.

## Non-claims / blockers

- P0 #72 exact source-entry-definition proof remains required.
- P0 #83 bounded completeness semantics remain in force.
- A child pure canonical reducer still needs to consume this exact snapshot type and preserve its read boundary.
- No clinical/research qualification is claimed without exact-head CI and conductor adversarial/race tests.

See `docs/security/CLINICAL_CAUSALITY_CANONICAL_SNAPSHOT_V1.md` and its qualification checklist.