### PR TITLE
privacy(population): add qualified aggregate release preflight

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ members = [
     "crates/clinical-causality-attestation-state",
     "crates/clinical-causality-canonical-state",
     "crates/clinical-population-evidence",
+    "crates/clinical-population-release",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-population-release/Cargo.toml
+++ b/crates/clinical-population-release/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mycelix-clinical-population-release"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Privacy-qualified release boundary for Mycelix-Health population evidence"
+
+[dependencies]
+blake3 = "1.8.5"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }

--- a/crates/clinical-population-release/README.md
+++ b/crates/clinical-population-release/README.md
@@ -1,0 +1,10 @@
+# mycelix-clinical-population-release
+
+Experimental privacy-release preflight/qualification primitives for population evidence.
+
+Supported v1 paths:
+
+- fixed/pre-specified static reports with primary + complementary suppression and composition-review evidence;
+- interactive differential-privacy releases with exact mechanism descriptors and chained accountant receipts.
+
+This crate does **not** itself establish institutional trust in suppression review, DP implementations, or privacy-accountant state. See `docs/security/CLINICAL_POPULATION_RELEASE_V1.md` and the qualification checklist.

--- a/crates/clinical-population-release/src/lib.rs
+++ b/crates/clinical-population-release/src/lib.rs
@@ -1,0 +1,829 @@
+#![deny(unsafe_code)]
+//! Privacy-qualified release boundary for population evidence.
+//!
+//! V1 deliberately exposes only two broad-release modes:
+//!
+//! - static pre-specified reports with primary + complementary suppression evidence;
+//! - interactive releases backed by an explicit differential-privacy mechanism and
+//!   a chained privacy-accountant receipt.
+//!
+//! Threshold-only interactive querying is intentionally absent.
+
+use mycelix_clinical_integrity::{DigestDomain, IntegrityError, StoredDigest};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+const RELEASE_HASH_CONTEXT: &str = "mycelix.health.population-release.v1";
+const FRAME_VERSION: u8 = 1;
+const MAX_ID_LEN: usize = 160;
+const MAX_ALLOWED_DP_MECHANISMS: usize = 16;
+/// Conservative mechanical floor for static-report cells. This is not a claim that
+/// 11 is universally sufficient for privacy; deployment policy may only raise it.
+pub const ABSOLUTE_STATIC_CELL_FLOOR: u64 = 11;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum PopulationReleaseArtifactKindV1 {
+    ReleasePolicy,
+    StaticSuppressionEvidence,
+    DpMechanismDescriptor,
+    PrivacyAccountantReceipt,
+    ReleaseRequest,
+    ReleaseReceipt,
+}
+
+impl PopulationReleaseArtifactKindV1 {
+    fn label(self) -> &'static [u8] {
+        match self {
+            Self::ReleasePolicy => b"release-policy",
+            Self::StaticSuppressionEvidence => b"static-suppression-evidence",
+            Self::DpMechanismDescriptor => b"dp-mechanism-descriptor",
+            Self::PrivacyAccountantReceipt => b"privacy-accountant-receipt",
+            Self::ReleaseRequest => b"release-request",
+            Self::ReleaseReceipt => b"release-receipt",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PopulationReleaseDigestV1 {
+    pub kind: PopulationReleaseArtifactKindV1,
+    pub value: [u8; 32],
+}
+
+impl PopulationReleaseDigestV1 {
+    pub fn validate(&self) -> Result<(), PopulationReleaseError> {
+        if self.value == [0u8; 32] {
+            return Err(PopulationReleaseError::ZeroReleaseDigest);
+        }
+        Ok(())
+    }
+
+    fn require_kind(
+        self,
+        expected: PopulationReleaseArtifactKindV1,
+    ) -> Result<Self, PopulationReleaseError> {
+        self.validate()?;
+        if self.kind != expected {
+            return Err(PopulationReleaseError::WrongReleaseDigestKind {
+                expected,
+                actual: self.kind,
+            });
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum PopulationFindingKindV1 {
+    SafetySignalCandidate,
+    DenominatorBasedAssociation,
+    CausalEffectEstimate,
+    PopulationReplication,
+}
+
+impl PopulationFindingKindV1 {
+    fn expected_domain(self) -> DigestDomain {
+        match self {
+            Self::SafetySignalCandidate => DigestDomain::ClinicalSafetySignalCandidate,
+            Self::DenominatorBasedAssociation => DigestDomain::ClinicalPopulationAssociation,
+            Self::CausalEffectEstimate => DigestDomain::ClinicalCausalEffectEstimate,
+            Self::PopulationReplication => DigestDomain::ClinicalPopulationReplication,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ReducedFractionV1 {
+    pub numerator: u64,
+    pub denominator: u64,
+}
+
+impl ReducedFractionV1 {
+    pub const ZERO: Self = Self {
+        numerator: 0,
+        denominator: 1,
+    };
+
+    pub fn validate(&self) -> Result<(), PopulationReleaseError> {
+        if self.denominator == 0 {
+            return Err(PopulationReleaseError::ZeroFractionDenominator);
+        }
+        if self.numerator == 0 {
+            if self.denominator != 1 {
+                return Err(PopulationReleaseError::NonCanonicalFraction);
+            }
+            return Ok(());
+        }
+        if gcd(self.numerator, self.denominator) != 1 {
+            return Err(PopulationReleaseError::NonCanonicalFraction);
+        }
+        Ok(())
+    }
+
+    pub fn less_than_or_equal(self, other: Self) -> bool {
+        (self.numerator as u128) * (other.denominator as u128)
+            <= (other.numerator as u128) * (self.denominator as u128)
+    }
+
+    pub fn is_zero(self) -> bool {
+        self.numerator == 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PrivacyLossV1 {
+    pub epsilon: ReducedFractionV1,
+    pub delta: ReducedFractionV1,
+}
+
+impl PrivacyLossV1 {
+    pub const ZERO: Self = Self {
+        epsilon: ReducedFractionV1::ZERO,
+        delta: ReducedFractionV1::ZERO,
+    };
+
+    pub fn validate(&self) -> Result<(), PopulationReleaseError> {
+        self.epsilon.validate()?;
+        self.delta.validate()?;
+        if !self.delta.less_than_or_equal(ReducedFractionV1 {
+            numerator: 1,
+            denominator: 1,
+        }) {
+            return Err(PopulationReleaseError::DeltaOutsideUnitInterval);
+        }
+        Ok(())
+    }
+
+    fn less_than_or_equal(self, other: Self) -> bool {
+        self.epsilon.less_than_or_equal(other.epsilon)
+            && self.delta.less_than_or_equal(other.delta)
+    }
+
+    fn is_componentwise_non_decreasing_from(self, previous: Self) -> bool {
+        previous.epsilon.less_than_or_equal(self.epsilon)
+            && previous.delta.less_than_or_equal(self.delta)
+    }
+
+    fn is_zero(self) -> bool {
+        self.epsilon.is_zero() && self.delta.is_zero()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum DpMechanismKindV1 {
+    Laplace,
+    Gaussian,
+    DiscreteGaussian,
+    Exponential,
+    OtherQualified,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PopulationReleasePolicyV1 {
+    pub schema_version: u16,
+    pub policy_id: String,
+    /// Static/pre-specified reports only. Must be >= the software floor.
+    pub static_minimum_cell_count: u64,
+    pub max_static_report_cells: u64,
+    pub allowed_dp_mechanisms: Vec<DpMechanismKindV1>,
+    pub max_per_release_privacy_loss: PrivacyLossV1,
+    pub max_cumulative_privacy_loss: PrivacyLossV1,
+    pub max_interactive_queries: u64,
+    /// Exact deployment-selected accountant instance and method. These are bound by
+    /// policy so callers cannot pair a strong policy ID with a different accountant.
+    pub accountant_instance_digest: StoredDigest,
+    pub accountant_method_digest: StoredDigest,
+}
+
+impl PopulationReleasePolicyV1 {
+    pub fn validate(&self) -> Result<(), PopulationReleaseError> {
+        require_version(self.schema_version, "release policy")?;
+        validate_id("release policy ID", &self.policy_id)?;
+        if self.static_minimum_cell_count < ABSOLUTE_STATIC_CELL_FLOOR {
+            return Err(PopulationReleaseError::StaticCellThresholdBelowSoftwareFloor);
+        }
+        if self.max_static_report_cells == 0 {
+            return Err(PopulationReleaseError::ZeroStaticReportCellLimit);
+        }
+        if self.allowed_dp_mechanisms.is_empty()
+            || self.allowed_dp_mechanisms.len() > MAX_ALLOWED_DP_MECHANISMS
+        {
+            return Err(PopulationReleaseError::InvalidAllowedDpMechanismSet);
+        }
+        let unique: BTreeSet<_> = self.allowed_dp_mechanisms.iter().copied().collect();
+        if unique.len() != self.allowed_dp_mechanisms.len() {
+            return Err(PopulationReleaseError::DuplicateAllowedDpMechanism);
+        }
+        self.max_per_release_privacy_loss.validate()?;
+        self.max_cumulative_privacy_loss.validate()?;
+        if self.max_per_release_privacy_loss.is_zero()
+            || self.max_cumulative_privacy_loss.is_zero()
+        {
+            return Err(PopulationReleaseError::ZeroInteractivePrivacyBudget);
+        }
+        if !self
+            .max_per_release_privacy_loss
+            .less_than_or_equal(self.max_cumulative_privacy_loss)
+        {
+            return Err(PopulationReleaseError::PerReleaseBudgetExceedsCumulativeBudget);
+        }
+        if self.max_interactive_queries == 0 {
+            return Err(PopulationReleaseError::ZeroInteractiveQueryLimit);
+        }
+        require_shape(self.accountant_instance_digest)?;
+        require_shape(self.accountant_method_digest)?;
+        Ok(())
+    }
+
+    pub fn verified_digest(&self) -> Result<PopulationReleaseDigestV1, PopulationReleaseError> {
+        self.validate()?;
+        hash_json(PopulationReleaseArtifactKindV1::ReleasePolicy, self)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StaticSuppressionEvidenceV1 {
+    pub schema_version: u16,
+    pub source_finding_kind: PopulationFindingKindV1,
+    pub source_finding_digest: StoredDigest,
+    pub report_specification_digest: StoredDigest,
+    pub raw_aggregate_digest: StoredDigest,
+    pub public_output_digest: StoredDigest,
+    pub total_report_cells: u64,
+    pub minimum_cell_threshold: u64,
+    pub primary_suppression_count: u64,
+    pub complementary_suppression_count: u64,
+    pub primary_suppression_evidence_digest: StoredDigest,
+    pub complementary_suppression_evidence_digest: StoredDigest,
+    pub composition_review_evidence_digest: StoredDigest,
+}
+
+impl StaticSuppressionEvidenceV1 {
+    pub fn validate(
+        &self,
+        policy: &PopulationReleasePolicyV1,
+    ) -> Result<(), PopulationReleaseError> {
+        require_version(self.schema_version, "static suppression evidence")?;
+        validate_source_finding(self.source_finding_kind, self.source_finding_digest)?;
+        for digest in [
+            self.report_specification_digest,
+            self.raw_aggregate_digest,
+            self.public_output_digest,
+            self.primary_suppression_evidence_digest,
+            self.complementary_suppression_evidence_digest,
+            self.composition_review_evidence_digest,
+        ] {
+            require_shape(digest)?;
+        }
+        if self.total_report_cells == 0
+            || self.total_report_cells > policy.max_static_report_cells
+        {
+            return Err(PopulationReleaseError::InvalidStaticReportCellCount);
+        }
+        if self.minimum_cell_threshold < policy.static_minimum_cell_count
+            || self.minimum_cell_threshold < ABSOLUTE_STATIC_CELL_FLOOR
+        {
+            return Err(PopulationReleaseError::StaticCellThresholdBelowPolicy);
+        }
+        let total_suppressed = self
+            .primary_suppression_count
+            .checked_add(self.complementary_suppression_count)
+            .ok_or(PopulationReleaseError::SuppressionCountOverflow)?;
+        if total_suppressed > self.total_report_cells {
+            return Err(PopulationReleaseError::SuppressionCountExceedsReportCells);
+        }
+        if self.primary_suppression_evidence_digest
+            == self.complementary_suppression_evidence_digest
+            || self.primary_suppression_evidence_digest
+                == self.composition_review_evidence_digest
+            || self.complementary_suppression_evidence_digest
+                == self.composition_review_evidence_digest
+        {
+            return Err(PopulationReleaseError::SuppressionEvidenceNotIndependentArtifacts);
+        }
+        Ok(())
+    }
+
+    pub fn verified_digest(
+        &self,
+        policy: &PopulationReleasePolicyV1,
+    ) -> Result<PopulationReleaseDigestV1, PopulationReleaseError> {
+        self.validate(policy)?;
+        hash_json(
+            PopulationReleaseArtifactKindV1::StaticSuppressionEvidence,
+            self,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct DifferentialPrivacyMechanismV1 {
+    pub schema_version: u16,
+    pub mechanism_id: String,
+    pub mechanism_kind: DpMechanismKindV1,
+    pub implementation_version: String,
+    pub implementation_digest: StoredDigest,
+    pub privacy_unit_definition_digest: StoredDigest,
+    pub adjacency_definition_digest: StoredDigest,
+    pub contribution_bounds_digest: StoredDigest,
+    pub sensitivity_analysis_digest: StoredDigest,
+    pub randomness_source_evidence_digest: StoredDigest,
+    pub release_privacy_loss: PrivacyLossV1,
+}
+
+impl DifferentialPrivacyMechanismV1 {
+    pub fn validate(
+        &self,
+        policy: &PopulationReleasePolicyV1,
+    ) -> Result<(), PopulationReleaseError> {
+        require_version(self.schema_version, "DP mechanism")?;
+        validate_id("DP mechanism ID", &self.mechanism_id)?;
+        validate_id("DP implementation version", &self.implementation_version)?;
+        if !policy.allowed_dp_mechanisms.contains(&self.mechanism_kind) {
+            return Err(PopulationReleaseError::DpMechanismNotAllowedByPolicy);
+        }
+        for digest in [
+            self.implementation_digest,
+            self.privacy_unit_definition_digest,
+            self.adjacency_definition_digest,
+            self.contribution_bounds_digest,
+            self.sensitivity_analysis_digest,
+            self.randomness_source_evidence_digest,
+        ] {
+            require_shape(digest)?;
+        }
+        self.release_privacy_loss.validate()?;
+        if self.release_privacy_loss.epsilon.is_zero() {
+            return Err(PopulationReleaseError::ZeroDpEpsilon);
+        }
+        if !self
+            .release_privacy_loss
+            .less_than_or_equal(policy.max_per_release_privacy_loss)
+        {
+            return Err(PopulationReleaseError::PerReleasePrivacyBudgetExceeded);
+        }
+        Ok(())
+    }
+
+    pub fn verified_digest(
+        &self,
+        policy: &PopulationReleasePolicyV1,
+    ) -> Result<PopulationReleaseDigestV1, PopulationReleaseError> {
+        self.validate(policy)?;
+        hash_json(PopulationReleaseArtifactKindV1::DpMechanismDescriptor, self)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PrivacyAccountantReceiptV1 {
+    pub schema_version: u16,
+    pub accountant_instance_digest: StoredDigest,
+    pub accountant_method_digest: StoredDigest,
+    pub sequence: u64,
+    pub previous_receipt_digest: Option<PopulationReleaseDigestV1>,
+    pub cumulative_privacy_loss: PrivacyLossV1,
+    pub query_count: u64,
+    pub last_query_spec_digest: Option<StoredDigest>,
+    pub last_mechanism_digest: Option<PopulationReleaseDigestV1>,
+    pub last_output_digest: Option<StoredDigest>,
+    pub accountant_evidence_digest: StoredDigest,
+    pub observed_at_micros: i64,
+}
+
+impl PrivacyAccountantReceiptV1 {
+    pub fn validate_shape(
+        &self,
+        policy: &PopulationReleasePolicyV1,
+    ) -> Result<(), PopulationReleaseError> {
+        require_version(self.schema_version, "privacy accountant receipt")?;
+        if self.accountant_instance_digest != policy.accountant_instance_digest
+            || self.accountant_method_digest != policy.accountant_method_digest
+        {
+            return Err(PopulationReleaseError::WrongPrivacyAccountant);
+        }
+        require_shape(self.accountant_instance_digest)?;
+        require_shape(self.accountant_method_digest)?;
+        require_shape(self.accountant_evidence_digest)?;
+        self.cumulative_privacy_loss.validate()?;
+        if !self
+            .cumulative_privacy_loss
+            .less_than_or_equal(policy.max_cumulative_privacy_loss)
+        {
+            return Err(PopulationReleaseError::CumulativePrivacyBudgetExceeded);
+        }
+        if self.query_count > policy.max_interactive_queries {
+            return Err(PopulationReleaseError::InteractiveQueryLimitExceeded);
+        }
+        match (
+            self.sequence,
+            self.previous_receipt_digest,
+            self.last_query_spec_digest,
+            self.last_mechanism_digest,
+            self.last_output_digest,
+        ) {
+            (0, None, None, None, None) => {
+                if self.query_count != 0 || !self.cumulative_privacy_loss.is_zero() {
+                    return Err(PopulationReleaseError::InvalidAccountantGenesis);
+                }
+            }
+            (0, ..) => return Err(PopulationReleaseError::InvalidAccountantGenesis),
+            (_, Some(previous), Some(query), Some(mechanism), Some(output)) => {
+                previous.require_kind(PopulationReleaseArtifactKindV1::PrivacyAccountantReceipt)?;
+                require_shape(query)?;
+                mechanism.require_kind(PopulationReleaseArtifactKindV1::DpMechanismDescriptor)?;
+                require_shape(output)?;
+                if self.query_count != self.sequence {
+                    return Err(PopulationReleaseError::AccountantSequenceQueryCountMismatch);
+                }
+            }
+            _ => return Err(PopulationReleaseError::IncompleteAccountantLineage),
+        }
+        Ok(())
+    }
+
+    pub fn verified_digest(
+        &self,
+        policy: &PopulationReleasePolicyV1,
+    ) -> Result<PopulationReleaseDigestV1, PopulationReleaseError> {
+        self.validate_shape(policy)?;
+        hash_json(
+            PopulationReleaseArtifactKindV1::PrivacyAccountantReceipt,
+            self,
+        )
+    }
+}
+
+/// Verify exact accountant-chain continuity. This does not re-implement the
+/// accountant's mathematics; the exact accountant method/evidence remains explicit.
+pub fn verify_accountant_transition(
+    previous: &PrivacyAccountantReceiptV1,
+    next: &PrivacyAccountantReceiptV1,
+    policy: &PopulationReleasePolicyV1,
+) -> Result<(), PopulationReleaseError> {
+    previous.validate_shape(policy)?;
+    next.validate_shape(policy)?;
+    let previous_digest = previous.verified_digest(policy)?;
+    if next.previous_receipt_digest != Some(previous_digest) {
+        return Err(PopulationReleaseError::AccountantPredecessorMismatch);
+    }
+    if next.sequence != previous.sequence.checked_add(1).ok_or(
+        PopulationReleaseError::AccountantSequenceOverflow,
+    )? {
+        return Err(PopulationReleaseError::AccountantSequenceGap);
+    }
+    if next.query_count != previous.query_count.checked_add(1).ok_or(
+        PopulationReleaseError::AccountantQueryCountOverflow,
+    )? {
+        return Err(PopulationReleaseError::AccountantQueryCountGap);
+    }
+    if !next
+        .cumulative_privacy_loss
+        .is_componentwise_non_decreasing_from(previous.cumulative_privacy_loss)
+    {
+        return Err(PopulationReleaseError::PrivacyLossDecreased);
+    }
+    if next.observed_at_micros < previous.observed_at_micros {
+        return Err(PopulationReleaseError::AccountantTimeWentBackwards);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct StaticReleaseRequestV1 {
+    pub suppression: StaticSuppressionEvidenceV1,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct InteractiveDpReleaseRequestV1 {
+    pub source_finding_kind: PopulationFindingKindV1,
+    pub source_finding_digest: StoredDigest,
+    pub query_specification_digest: StoredDigest,
+    pub output_schema_digest: StoredDigest,
+    pub public_output_digest: StoredDigest,
+    pub mechanism: DifferentialPrivacyMechanismV1,
+    pub accountant_before: PrivacyAccountantReceiptV1,
+    pub accountant_after: PrivacyAccountantReceiptV1,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PopulationReleaseModeV1 {
+    StaticPreSpecifiedReport(StaticReleaseRequestV1),
+    InteractiveDifferentialPrivacy(InteractiveDpReleaseRequestV1),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PopulationReleaseRequestV1 {
+    pub schema_version: u16,
+    pub release_id: String,
+    pub policy: PopulationReleasePolicyV1,
+    pub mode: PopulationReleaseModeV1,
+    pub requested_at_micros: i64,
+}
+
+impl PopulationReleaseRequestV1 {
+    pub fn validate(&self) -> Result<(), PopulationReleaseError> {
+        require_version(self.schema_version, "population release request")?;
+        validate_id("release ID", &self.release_id)?;
+        self.policy.validate()?;
+        match &self.mode {
+            PopulationReleaseModeV1::StaticPreSpecifiedReport(request) => {
+                request.suppression.validate(&self.policy)?;
+            }
+            PopulationReleaseModeV1::InteractiveDifferentialPrivacy(request) => {
+                validate_source_finding(
+                    request.source_finding_kind,
+                    request.source_finding_digest,
+                )?;
+                for digest in [
+                    request.query_specification_digest,
+                    request.output_schema_digest,
+                    request.public_output_digest,
+                ] {
+                    require_shape(digest)?;
+                }
+                request.mechanism.validate(&self.policy)?;
+                verify_accountant_transition(
+                    &request.accountant_before,
+                    &request.accountant_after,
+                    &self.policy,
+                )?;
+                let mechanism_digest = request.mechanism.verified_digest(&self.policy)?;
+                if request.accountant_after.last_query_spec_digest
+                    != Some(request.query_specification_digest)
+                    || request.accountant_after.last_mechanism_digest != Some(mechanism_digest)
+                    || request.accountant_after.last_output_digest != Some(request.public_output_digest)
+                {
+                    return Err(PopulationReleaseError::AccountantTransitionDoesNotBindRelease);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn verified_digest(&self) -> Result<PopulationReleaseDigestV1, PopulationReleaseError> {
+        self.validate()?;
+        hash_json(PopulationReleaseArtifactKindV1::ReleaseRequest, self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PopulationReleaseModeClassV1 {
+    StaticPreSpecifiedReport,
+    InteractiveDifferentialPrivacy,
+}
+
+/// Non-serializable capability created only after all v1 release checks succeed.
+pub struct PopulationReleaseCapabilityV1 {
+    request_digest: PopulationReleaseDigestV1,
+    policy_digest: PopulationReleaseDigestV1,
+    source_finding_digest: StoredDigest,
+    public_output_digest: StoredDigest,
+    mode: PopulationReleaseModeClassV1,
+    requested_at_micros: i64,
+}
+
+pub fn authorize_population_release(
+    request: &PopulationReleaseRequestV1,
+) -> Result<PopulationReleaseCapabilityV1, PopulationReleaseError> {
+    request.validate()?;
+    let request_digest = request.verified_digest()?;
+    let policy_digest = request.policy.verified_digest()?;
+    let (source_finding_digest, public_output_digest, mode) = match &request.mode {
+        PopulationReleaseModeV1::StaticPreSpecifiedReport(static_request) => (
+            static_request.suppression.source_finding_digest,
+            static_request.suppression.public_output_digest,
+            PopulationReleaseModeClassV1::StaticPreSpecifiedReport,
+        ),
+        PopulationReleaseModeV1::InteractiveDifferentialPrivacy(dp_request) => (
+            dp_request.source_finding_digest,
+            dp_request.public_output_digest,
+            PopulationReleaseModeClassV1::InteractiveDifferentialPrivacy,
+        ),
+    };
+    Ok(PopulationReleaseCapabilityV1 {
+        request_digest,
+        policy_digest,
+        source_finding_digest,
+        public_output_digest,
+        mode,
+        requested_at_micros: request.requested_at_micros,
+    })
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PopulationReleaseReceiptV1 {
+    pub schema_version: u16,
+    pub request_digest: PopulationReleaseDigestV1,
+    pub policy_digest: PopulationReleaseDigestV1,
+    pub source_finding_digest: StoredDigest,
+    pub public_output_digest: StoredDigest,
+    pub mode: PopulationReleaseModeClassV1,
+    pub requested_at_micros: i64,
+    pub released_at_micros: i64,
+}
+
+impl PopulationReleaseCapabilityV1 {
+    pub fn into_receipt(
+        self,
+        released_at_micros: i64,
+    ) -> Result<PopulationReleaseReceiptV1, PopulationReleaseError> {
+        if released_at_micros < self.requested_at_micros {
+            return Err(PopulationReleaseError::ReleaseTimeBeforeRequest);
+        }
+        Ok(PopulationReleaseReceiptV1 {
+            schema_version: 1,
+            request_digest: self.request_digest,
+            policy_digest: self.policy_digest,
+            source_finding_digest: self.source_finding_digest,
+            public_output_digest: self.public_output_digest,
+            mode: self.mode,
+            requested_at_micros: self.requested_at_micros,
+            released_at_micros,
+        })
+    }
+}
+
+impl PopulationReleaseReceiptV1 {
+    pub fn verified_digest(&self) -> Result<PopulationReleaseDigestV1, PopulationReleaseError> {
+        require_version(self.schema_version, "population release receipt")?;
+        self.request_digest
+            .require_kind(PopulationReleaseArtifactKindV1::ReleaseRequest)?;
+        self.policy_digest
+            .require_kind(PopulationReleaseArtifactKindV1::ReleasePolicy)?;
+        require_shape(self.source_finding_digest)?;
+        require_shape(self.public_output_digest)?;
+        if self.released_at_micros < self.requested_at_micros {
+            return Err(PopulationReleaseError::ReleaseTimeBeforeRequest);
+        }
+        hash_json(PopulationReleaseArtifactKindV1::ReleaseReceipt, self)
+    }
+}
+
+fn validate_source_finding(
+    kind: PopulationFindingKindV1,
+    digest: StoredDigest,
+) -> Result<(), PopulationReleaseError> {
+    require_shape(digest)?;
+    let expected = kind.expected_domain();
+    if digest.domain != expected {
+        return Err(PopulationReleaseError::WrongSourceFindingDomain {
+            expected,
+            actual: digest.domain,
+        });
+    }
+    Ok(())
+}
+
+fn require_shape(digest: StoredDigest) -> Result<(), PopulationReleaseError> {
+    digest.validate_shape()?;
+    Ok(())
+}
+
+fn require_version(version: u16, label: &'static str) -> Result<(), PopulationReleaseError> {
+    if version != 1 {
+        return Err(PopulationReleaseError::UnsupportedVersion { label, version });
+    }
+    Ok(())
+}
+
+fn validate_id(label: &'static str, value: &str) -> Result<(), PopulationReleaseError> {
+    if value.trim().is_empty() {
+        return Err(PopulationReleaseError::MissingId(label));
+    }
+    if value.len() > MAX_ID_LEN {
+        return Err(PopulationReleaseError::OversizedId(label));
+    }
+    Ok(())
+}
+
+fn gcd(mut a: u64, mut b: u64) -> u64 {
+    while b != 0 {
+        let r = a % b;
+        a = b;
+        b = r;
+    }
+    a
+}
+
+fn hash_json<T: Serialize>(
+    kind: PopulationReleaseArtifactKindV1,
+    value: &T,
+) -> Result<PopulationReleaseDigestV1, PopulationReleaseError> {
+    let encoded = serde_json::to_vec(value)
+        .map_err(|error| PopulationReleaseError::Serialization(error.to_string()))?;
+    let label = kind.label();
+    let mut hasher = blake3::Hasher::new_derive_key(RELEASE_HASH_CONTEXT);
+    hasher.update(&[FRAME_VERSION]);
+    hasher.update(&(label.len() as u16).to_be_bytes());
+    hasher.update(label);
+    hasher.update(&(encoded.len() as u64).to_be_bytes());
+    hasher.update(&encoded);
+    let value = *hasher.finalize().as_bytes();
+    if value == [0u8; 32] {
+        return Err(PopulationReleaseError::ZeroReleaseDigest);
+    }
+    Ok(PopulationReleaseDigestV1 { kind, value })
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PopulationReleaseError {
+    #[error("unsupported {label} version {version}")]
+    UnsupportedVersion { label: &'static str, version: u16 },
+    #[error("{0} is required")]
+    MissingId(&'static str),
+    #[error("{0} exceeds the v1 identifier bound")]
+    OversizedId(&'static str),
+    #[error("release digest cannot be all zero")]
+    ZeroReleaseDigest,
+    #[error("release digest kind mismatch: expected {expected:?}, got {actual:?}")]
+    WrongReleaseDigestKind {
+        expected: PopulationReleaseArtifactKindV1,
+        actual: PopulationReleaseArtifactKindV1,
+    },
+    #[error("fraction denominator cannot be zero")]
+    ZeroFractionDenominator,
+    #[error("fraction must use one reduced canonical representation")]
+    NonCanonicalFraction,
+    #[error("delta must be in the closed unit interval")]
+    DeltaOutsideUnitInterval,
+    #[error("static minimum cell count is below the software floor")]
+    StaticCellThresholdBelowSoftwareFloor,
+    #[error("static report cell limit cannot be zero")]
+    ZeroStaticReportCellLimit,
+    #[error("allowed DP mechanism set is empty or too large")]
+    InvalidAllowedDpMechanismSet,
+    #[error("allowed DP mechanism set contains duplicates")]
+    DuplicateAllowedDpMechanism,
+    #[error("interactive privacy budget cannot be zero")]
+    ZeroInteractivePrivacyBudget,
+    #[error("per-release privacy budget exceeds cumulative budget")]
+    PerReleaseBudgetExceedsCumulativeBudget,
+    #[error("interactive query limit cannot be zero")]
+    ZeroInteractiveQueryLimit,
+    #[error("source finding digest domain mismatch: expected {expected:?}, got {actual:?}")]
+    WrongSourceFindingDomain {
+        expected: DigestDomain,
+        actual: DigestDomain,
+    },
+    #[error("static report cell count is zero or exceeds policy")]
+    InvalidStaticReportCellCount,
+    #[error("static cell threshold is below policy")]
+    StaticCellThresholdBelowPolicy,
+    #[error("suppression count overflow")]
+    SuppressionCountOverflow,
+    #[error("suppression counts exceed total report cells")]
+    SuppressionCountExceedsReportCells,
+    #[error("primary, complementary, and composition-review evidence must be distinct artifacts")]
+    SuppressionEvidenceNotIndependentArtifacts,
+    #[error("DP mechanism is not allowed by release policy")]
+    DpMechanismNotAllowedByPolicy,
+    #[error("DP epsilon must be greater than zero")]
+    ZeroDpEpsilon,
+    #[error("per-release privacy budget exceeded")]
+    PerReleasePrivacyBudgetExceeded,
+    #[error("privacy accountant does not match policy-bound instance/method")]
+    WrongPrivacyAccountant,
+    #[error("cumulative privacy budget exceeded")]
+    CumulativePrivacyBudgetExceeded,
+    #[error("interactive query limit exceeded")]
+    InteractiveQueryLimitExceeded,
+    #[error("privacy-accountant genesis receipt is invalid")]
+    InvalidAccountantGenesis,
+    #[error("privacy-accountant sequence and query count differ")]
+    AccountantSequenceQueryCountMismatch,
+    #[error("privacy-accountant lineage fields are incomplete")]
+    IncompleteAccountantLineage,
+    #[error("privacy-accountant predecessor digest mismatch")]
+    AccountantPredecessorMismatch,
+    #[error("privacy-accountant sequence overflow")]
+    AccountantSequenceOverflow,
+    #[error("privacy-accountant sequence has a gap")]
+    AccountantSequenceGap,
+    #[error("privacy-accountant query count overflow")]
+    AccountantQueryCountOverflow,
+    #[error("privacy-accountant query count has a gap")]
+    AccountantQueryCountGap,
+    #[error("cumulative privacy loss decreased")]
+    PrivacyLossDecreased,
+    #[error("privacy-accountant observation time went backwards")]
+    AccountantTimeWentBackwards,
+    #[error("privacy-accountant transition does not bind this exact query/mechanism/output")]
+    AccountantTransitionDoesNotBindRelease,
+    #[error("release time precedes request time")]
+    ReleaseTimeBeforeRequest,
+    #[error("serialization failed: {0}")]
+    Serialization(String),
+    #[error(transparent)]
+    Integrity(#[from] IntegrityError),
+}

--- a/crates/clinical-population-release/tests/boundaries.rs
+++ b/crates/clinical-population-release/tests/boundaries.rs
@@ -1,0 +1,248 @@
+use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain, StoredDigest};
+use mycelix_clinical_population_release::*;
+
+fn digest(domain: DigestDomain, seed: u8) -> StoredDigest {
+    StoredDigest {
+        algorithm: DigestAlgorithm::Blake3_256,
+        domain,
+        value: [seed; 32],
+    }
+}
+
+fn fraction(numerator: u64, denominator: u64) -> ReducedFractionV1 {
+    ReducedFractionV1 {
+        numerator,
+        denominator,
+    }
+}
+
+fn loss(epsilon_n: u64, epsilon_d: u64, delta_n: u64, delta_d: u64) -> PrivacyLossV1 {
+    PrivacyLossV1 {
+        epsilon: fraction(epsilon_n, epsilon_d),
+        delta: fraction(delta_n, delta_d),
+    }
+}
+
+fn policy() -> PopulationReleasePolicyV1 {
+    PopulationReleasePolicyV1 {
+        schema_version: 1,
+        policy_id: "population-release-policy-v1".into(),
+        static_minimum_cell_count: 11,
+        max_static_report_cells: 10_000,
+        allowed_dp_mechanisms: vec![DpMechanismKindV1::Gaussian],
+        max_per_release_privacy_loss: loss(1, 2, 1, 100_000),
+        max_cumulative_privacy_loss: loss(2, 1, 1, 1_000),
+        max_interactive_queries: 100,
+        accountant_instance_digest: digest(DigestDomain::ClinicalArtifact, 1),
+        accountant_method_digest: digest(DigestDomain::ClinicalArtifact, 2),
+    }
+}
+
+fn static_evidence() -> StaticSuppressionEvidenceV1 {
+    StaticSuppressionEvidenceV1 {
+        schema_version: 1,
+        source_finding_kind: PopulationFindingKindV1::DenominatorBasedAssociation,
+        source_finding_digest: digest(DigestDomain::ClinicalPopulationAssociation, 10),
+        report_specification_digest: digest(DigestDomain::ClinicalArtifact, 11),
+        raw_aggregate_digest: digest(DigestDomain::ClinicalArtifact, 12),
+        public_output_digest: digest(DigestDomain::ClinicalArtifact, 13),
+        total_report_cells: 40,
+        minimum_cell_threshold: 11,
+        primary_suppression_count: 3,
+        complementary_suppression_count: 2,
+        primary_suppression_evidence_digest: digest(DigestDomain::ClinicalArtifact, 14),
+        complementary_suppression_evidence_digest: digest(DigestDomain::ClinicalArtifact, 15),
+        composition_review_evidence_digest: digest(DigestDomain::ClinicalArtifact, 16),
+    }
+}
+
+fn mechanism(policy: &PopulationReleasePolicyV1) -> DifferentialPrivacyMechanismV1 {
+    let mechanism = DifferentialPrivacyMechanismV1 {
+        schema_version: 1,
+        mechanism_id: "gaussian-count-v1".into(),
+        mechanism_kind: DpMechanismKindV1::Gaussian,
+        implementation_version: "1.0.0".into(),
+        implementation_digest: digest(DigestDomain::ClinicalArtifact, 20),
+        privacy_unit_definition_digest: digest(DigestDomain::ClinicalArtifact, 21),
+        adjacency_definition_digest: digest(DigestDomain::ClinicalArtifact, 22),
+        contribution_bounds_digest: digest(DigestDomain::ClinicalArtifact, 23),
+        sensitivity_analysis_digest: digest(DigestDomain::ClinicalArtifact, 24),
+        randomness_source_evidence_digest: digest(DigestDomain::ClinicalArtifact, 25),
+        release_privacy_loss: loss(1, 10, 1, 1_000_000),
+    };
+    mechanism.validate(policy).unwrap();
+    mechanism
+}
+
+fn genesis(policy: &PopulationReleasePolicyV1) -> PrivacyAccountantReceiptV1 {
+    PrivacyAccountantReceiptV1 {
+        schema_version: 1,
+        accountant_instance_digest: policy.accountant_instance_digest,
+        accountant_method_digest: policy.accountant_method_digest,
+        sequence: 0,
+        previous_receipt_digest: None,
+        cumulative_privacy_loss: PrivacyLossV1::ZERO,
+        query_count: 0,
+        last_query_spec_digest: None,
+        last_mechanism_digest: None,
+        last_output_digest: None,
+        accountant_evidence_digest: digest(DigestDomain::ClinicalArtifact, 30),
+        observed_at_micros: 100,
+    }
+}
+
+fn interactive_request() -> PopulationReleaseRequestV1 {
+    let policy = policy();
+    let mechanism = mechanism(&policy);
+    let before = genesis(&policy);
+    let query = digest(DigestDomain::ClinicalArtifact, 31);
+    let output = digest(DigestDomain::ClinicalArtifact, 32);
+    let mechanism_digest = mechanism.verified_digest(&policy).unwrap();
+    let after = PrivacyAccountantReceiptV1 {
+        schema_version: 1,
+        accountant_instance_digest: policy.accountant_instance_digest,
+        accountant_method_digest: policy.accountant_method_digest,
+        sequence: 1,
+        previous_receipt_digest: Some(before.verified_digest(&policy).unwrap()),
+        cumulative_privacy_loss: loss(1, 10, 1, 1_000_000),
+        query_count: 1,
+        last_query_spec_digest: Some(query),
+        last_mechanism_digest: Some(mechanism_digest),
+        last_output_digest: Some(output),
+        accountant_evidence_digest: digest(DigestDomain::ClinicalArtifact, 33),
+        observed_at_micros: 110,
+    };
+    PopulationReleaseRequestV1 {
+        schema_version: 1,
+        release_id: "interactive-release-1".into(),
+        policy,
+        mode: PopulationReleaseModeV1::InteractiveDifferentialPrivacy(
+            InteractiveDpReleaseRequestV1 {
+                source_finding_kind: PopulationFindingKindV1::CausalEffectEstimate,
+                source_finding_digest: digest(DigestDomain::ClinicalCausalEffectEstimate, 34),
+                query_specification_digest: query,
+                output_schema_digest: digest(DigestDomain::ClinicalArtifact, 35),
+                public_output_digest: output,
+                mechanism,
+                accountant_before: before,
+                accountant_after: after,
+            },
+        ),
+        requested_at_micros: 120,
+    }
+}
+
+#[test]
+fn software_static_floor_rejects_threshold_ten() {
+    let mut policy = policy();
+    policy.static_minimum_cell_count = 10;
+    assert!(matches!(
+        policy.validate(),
+        Err(PopulationReleaseError::StaticCellThresholdBelowSoftwareFloor)
+    ));
+}
+
+#[test]
+fn static_release_requires_distinct_suppression_and_composition_evidence() {
+    let policy = policy();
+    let mut evidence = static_evidence();
+    evidence.complementary_suppression_evidence_digest =
+        evidence.primary_suppression_evidence_digest;
+    assert!(matches!(
+        evidence.validate(&policy),
+        Err(PopulationReleaseError::SuppressionEvidenceNotIndependentArtifacts)
+    ));
+}
+
+#[test]
+fn qualified_static_request_mints_consumable_release_receipt() {
+    let request = PopulationReleaseRequestV1 {
+        schema_version: 1,
+        release_id: "static-release-1".into(),
+        policy: policy(),
+        mode: PopulationReleaseModeV1::StaticPreSpecifiedReport(StaticReleaseRequestV1 {
+            suppression: static_evidence(),
+        }),
+        requested_at_micros: 100,
+    };
+    let receipt = authorize_population_release(&request)
+        .unwrap()
+        .into_receipt(101)
+        .unwrap();
+    assert_eq!(
+        receipt.mode,
+        PopulationReleaseModeClassV1::StaticPreSpecifiedReport
+    );
+    receipt.verified_digest().unwrap();
+}
+
+#[test]
+fn interactive_release_binds_exact_accountant_query_mechanism_and_output() {
+    let request = interactive_request();
+    authorize_population_release(&request).unwrap();
+
+    let mut substituted = request.clone();
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut dp) = substituted.mode
+    else {
+        unreachable!()
+    };
+    dp.public_output_digest = digest(DigestDomain::ClinicalArtifact, 99);
+    assert!(matches!(
+        authorize_population_release(&substituted),
+        Err(PopulationReleaseError::AccountantTransitionDoesNotBindRelease)
+    ));
+}
+
+#[test]
+fn accountant_predecessor_substitution_fails_closed() {
+    let mut request = interactive_request();
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut dp) = request.mode else {
+        unreachable!()
+    };
+    dp.accountant_after.previous_receipt_digest = Some(PopulationReleaseDigestV1 {
+        kind: PopulationReleaseArtifactKindV1::PrivacyAccountantReceipt,
+        value: [77; 32],
+    });
+    assert!(matches!(
+        authorize_population_release(&request),
+        Err(PopulationReleaseError::AccountantPredecessorMismatch)
+    ));
+}
+
+#[test]
+fn wrong_source_finding_domain_fails_closed() {
+    let mut request = interactive_request();
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut dp) = request.mode else {
+        unreachable!()
+    };
+    dp.source_finding_digest = digest(DigestDomain::ClinicalSafetySignalCandidate, 55);
+    assert!(matches!(
+        authorize_population_release(&request),
+        Err(PopulationReleaseError::WrongSourceFindingDomain { .. })
+    ));
+}
+
+#[test]
+fn noncanonical_fraction_is_rejected() {
+    let fraction = ReducedFractionV1 {
+        numerator: 2,
+        denominator: 4,
+    };
+    assert!(matches!(
+        fraction.validate(),
+        Err(PopulationReleaseError::NonCanonicalFraction)
+    ));
+}
+
+#[test]
+fn cumulative_budget_cannot_exceed_bound_policy() {
+    let mut request = interactive_request();
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut dp) = request.mode else {
+        unreachable!()
+    };
+    dp.accountant_after.cumulative_privacy_loss = loss(3, 1, 1, 1_000_000);
+    assert!(matches!(
+        authorize_population_release(&request),
+        Err(PopulationReleaseError::CumulativePrivacyBudgetExceeded)
+    ));
+}

--- a/docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_GAP.md
+++ b/docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_GAP.md
@@ -1,0 +1,29 @@
+# P0 Design Note: Trusted Population Privacy Accountant Admission
+
+## Gap
+
+`mycelix-clinical-population-release` binds interactive releases to an exact accountant instance/method and verifies predecessor/sequence/query/output/mechanism/budget continuity.
+
+However, `PrivacyAccountantReceiptV1` is a serializable pure-Rust artifact. A malicious in-process caller can manufacture a structurally coherent genesis and successor chain using the policy-bound public instance/method digests.
+
+Therefore structural chain validation is **not** institutional trust in the accountant state.
+
+## Required follow-up
+
+Before interactive population release can be promoted:
+
+1. establish a verifier-owned accountant state root outside caller control;
+2. admit the exact accountant implementation/version/method under deployment policy;
+3. bind each accepted successor to the previous trusted state;
+4. reject alternate/forked genesis for the same accountant instance;
+5. make query/output/mechanism replay semantics explicit;
+6. preserve cumulative epsilon/delta and query-count continuity;
+7. make accountant revocation/supersession append-only and auditable;
+8. execute fork/replay/concurrent-query adversarial tests;
+9. qualify the exact DP implementation against NIST SP 800-226 hazards and assumptions.
+
+A likely runtime pattern is the same one used elsewhere in the health stack: a private verified transition is consumed into a privacy-minimized receipt, then a DNA/runtime-pinned authority attests one exact successor state. The exact design should be reviewed before implementation.
+
+## Promotion rule
+
+Until this boundary is implemented, interactive DP release is experimental preflight only. Do not describe a structurally valid `PrivacyAccountantReceiptV1` as trusted privacy-budget state.

--- a/docs/security/CLINICAL_POPULATION_RELEASE_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_POPULATION_RELEASE_QUALIFICATION_CHECKLIST.md
@@ -1,0 +1,76 @@
+# Clinical Population Release Qualification Checklist
+
+## Source / build
+
+- [ ] Exact branch/head SHA recorded.
+- [ ] `cargo fmt -- --check` passes.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes.
+- [ ] `cargo test --workspace` passes.
+- [ ] `mycelix-clinical-population-release` is a workspace member.
+
+## Static report mode
+
+- [ ] Threshold below the software floor fails.
+- [ ] Deployment threshold can be stricter than the software floor.
+- [ ] Primary suppression evidence is required.
+- [ ] Complementary/secondary suppression evidence is required.
+- [ ] Composition/differencing review evidence is required.
+- [ ] Suppression evidence artifacts cannot silently collapse to one digest.
+- [ ] Report cell counts are bounded and overflow-safe.
+- [ ] Wrong source-finding digest domain fails closed.
+- [ ] Repeated/ad-hoc query use is not exposed through the static path.
+- [ ] Adversarial complementary-cell/differencing fixtures execute successfully.
+
+## Differential-privacy mode
+
+- [ ] No threshold-only interactive mode exists.
+- [ ] Privacy unit definition is bound.
+- [ ] Adjacency definition is bound.
+- [ ] Contribution/clipping bounds are bound.
+- [ ] Sensitivity-analysis evidence is bound.
+- [ ] Exact mechanism implementation/version is bound.
+- [ ] Randomness-source evidence is bound.
+- [ ] Epsilon/delta have canonical non-floating representation.
+- [ ] Delta outside `[0,1]` fails closed.
+- [ ] Disallowed mechanism kind fails closed.
+- [ ] Per-release privacy limit is enforced.
+- [ ] Cumulative privacy limit is enforced.
+- [ ] Query-count limit is enforced.
+
+## Accountant lineage
+
+- [ ] Genesis requires sequence/query count zero and zero cumulative loss.
+- [ ] Successor binds exact predecessor receipt digest.
+- [ ] Sequence gaps fail closed.
+- [ ] Query-count gaps fail closed.
+- [ ] Cumulative privacy loss cannot decrease.
+- [ ] Observation time cannot move backwards.
+- [ ] Successor binds exact query specification.
+- [ ] Successor binds exact DP mechanism digest.
+- [ ] Successor binds exact public output.
+- [ ] Replay/fork fixtures execute successfully.
+- [ ] Deployment-selected accountant instance/method is policy-bound.
+- [ ] Verifier-owned accountant trust/state-root admission is implemented and qualified.
+
+## Capability / receipt
+
+- [ ] Only validated requests mint `PopulationReleaseCapabilityV1` through the safe API.
+- [ ] Capability is non-serializable.
+- [ ] Receipt binds exact request/policy/source/output/mode.
+- [ ] Release time cannot precede request time.
+- [ ] Stored/wire release digests are treated as claims until exact artifact verification.
+
+## Privacy and governance
+
+- [ ] Static floor is documented as a minimum, not universal sufficiency.
+- [ ] Jurisdiction/deployment policy may require higher static thresholds.
+- [ ] No raw cohort/case-set object is broadly published by this crate.
+- [ ] No patient-level data is added to release receipts.
+- [ ] Release does not upgrade signal -> association -> causality.
+- [ ] Composition across other release systems has an explicit governance/accounting plan.
+- [ ] NIST SP 800-226 implementation hazards are reviewed for each qualified DP mechanism.
+- [ ] Disclosure review verifies minimum-necessary output for approved purpose.
+
+## Promotion rule
+
+Do not describe a population output as privacy-qualified for broad release until every applicable item above has exact-head executable evidence. A well-formed pure-crate receipt is not sufficient evidence of trusted suppression review or a trusted differential-privacy accountant.

--- a/docs/security/CLINICAL_POPULATION_RELEASE_SOURCES.md
+++ b/docs/security/CLINICAL_POPULATION_RELEASE_SOURCES.md
@@ -1,0 +1,8 @@
+# Clinical Population Release v1 — External Guidance References
+
+Design references used for v1:
+
+- NIST SP 800-226, *Guidelines for Evaluating Differential Privacy Guarantees* (final, March 2025): differential privacy guarantees depend on exact implementation choices, privacy units/neighbouring datasets, parameters, sensitivity/contribution assumptions, and composition/accounting. V1 therefore does not accept a generic `dp=true` marker.
+- CMS cell-size suppression policy: beneficiary-related cells of 1-10 must not be displayed and may not be derivable from percentages/formulas. V1 uses 11 only as a conservative software floor for the fixed static-report path, not as a universal privacy guarantee.
+
+The policy values used by a deployment remain jurisdiction/research-governance decisions and may be stricter than these software minima.

--- a/docs/security/CLINICAL_POPULATION_RELEASE_V1.md
+++ b/docs/security/CLINICAL_POPULATION_RELEASE_V1.md
@@ -1,0 +1,128 @@
+# Clinical Population Release v1
+
+## Status
+
+Experimental protected-boundary contract. Not a de-identification certification, not a universal privacy guarantee, and not authority to publish PHI.
+
+## Goal
+
+Population evidence can contain case counts, cohort counts, strata and analysis outputs that are useful for medicine/research but unsafe to expose by default. V1 creates a release gate with only two supported modes:
+
+1. `StaticPreSpecifiedReport`
+2. `InteractiveDifferentialPrivacy`
+
+There is intentionally no threshold-only interactive-query mode.
+
+## Static pre-specified reports
+
+A static release binds:
+
+- one exact population finding;
+- one exact report specification;
+- the exact protected aggregate result;
+- the exact public output;
+- a deployment cell threshold;
+- primary suppression evidence;
+- complementary/secondary suppression evidence;
+- a composition/differencing review artifact.
+
+The software floor is 11. This mirrors the conservative shape of the CMS cell-suppression rule that beneficiary-related cells 1-10 must not be published or derivable. It is **not** a claim that 11 is universally sufficient. Deployment/jurisdiction/research policy may only require a higher threshold.
+
+Static threshold suppression is intentionally limited to a fixed/pre-specified report. It is not accepted as the privacy mechanism for repeated arbitrary slicing.
+
+## Interactive differential privacy
+
+An interactive release binds the exact:
+
+- source population finding;
+- query specification;
+- output schema;
+- public output;
+- DP mechanism kind and implementation version;
+- implementation digest;
+- privacy-unit definition;
+- adjacency/neighbouring-dataset definition;
+- contribution/clipping bounds;
+- sensitivity analysis;
+- randomness-source evidence;
+- per-release epsilon/delta;
+- deployment-selected accountant instance/method;
+- predecessor accountant receipt;
+- cumulative privacy loss/query count;
+- accountant evidence;
+- release policy.
+
+NIST SP 800-226 is the design reference for treating differential privacy as a collection of exact guarantees/implementation assumptions rather than a `dp=true` property.
+
+## Privacy parameters
+
+V1 represents epsilon/delta as reduced rational numbers rather than floating-point values. This avoids NaN/infinity/serialization ambiguity and gives one canonical representation for artifact hashing.
+
+The release gate checks:
+
+- delta is within `[0,1]`;
+- the mechanism is explicitly allowed by policy;
+- per-release privacy loss does not exceed policy;
+- cumulative reported privacy loss does not exceed policy;
+- query count does not exceed policy;
+- accountant lineage is contiguous;
+- cumulative reported loss cannot decrease;
+- the successor accountant receipt binds the exact query, mechanism and public output.
+
+The gate does **not** implement a differential-privacy accountant or attempt to reproduce its mathematics. The accountant method/version/evidence are explicit inputs.
+
+## Accountant trust boundary
+
+`PrivacyAccountantReceiptV1` is serializable evidence. A malicious caller can serialize a structurally plausible receipt.
+
+Therefore the pure v1 crate proves only:
+
+- canonical receipt shape;
+- exact policy binding;
+- exact predecessor lineage;
+- monotonic bounded counters/loss;
+- exact query/mechanism/output binding.
+
+Promotion requires a verifier-owned trust layer that establishes the deployment-selected accountant implementation/state root and prevents arbitrary genesis/state fabrication.
+
+## Release capability
+
+Only a validated request can create the non-serializable `PopulationReleaseCapabilityV1`. Consuming it creates a `PopulationReleaseReceiptV1` bound to the exact request/policy/source/output/mode and release time.
+
+This reduces accidental bypass in safe code. It is not a defense against hostile code that can fabricate every upstream evidence artifact.
+
+## Epistemic invariants
+
+Privacy release never changes scientific evidence class:
+
+- a `SafetySignalCandidateV1` remains hypothesis-generating;
+- a `DenominatorBasedAssociationV1` remains an association;
+- a `CausalEffectEstimateV1` remains an estimate;
+- a `PopulationReplicationV1` remains replication evidence.
+
+Publication is not epistemic promotion.
+
+## Privacy non-claims
+
+V1 does not claim:
+
+- that cell threshold 11 alone prevents re-identification;
+- that secondary suppression evidence is correct merely because a digest exists;
+- that a DP implementation is correct merely because its descriptor is well formed;
+- that an accountant receipt is institutionally trusted merely because its chain is well formed;
+- that public output contains no other disclosure channel;
+- that composition across independent release systems is automatically accounted for;
+- that a released aggregate is clinically or scientifically correct.
+
+## Promotion blockers
+
+Before broad production release:
+
+1. qualify suppression/composition review authority;
+2. qualify trusted accountant admission/state roots;
+3. execute exact-head CI;
+4. execute differencing and overlapping-query adversarial tests;
+5. execute accountant replay/fork/budget tests;
+6. independently review DP mechanism implementations and sensitivity/contribution bounds;
+7. review jurisdiction-specific disclosure requirements;
+8. ensure released outputs are the minimum necessary for the approved purpose.


### PR DESCRIPTION
## Stack

Depends on #88 -> #87 -> #86 -> #85 -> #84 -> #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

## Why

#88 deliberately keeps population findings protected/internal. This tranche adds the first privacy-release preflight rather than exposing case/cohort/strata data directly.

## Two supported release modes only

### StaticPreSpecifiedReport

Requires the exact source finding, fixed report specification, protected aggregate, public output, deployment cell threshold, primary suppression evidence, complementary/secondary suppression evidence, and composition/differencing review evidence.

The software floor is 11, matching the conservative shape of CMS' rule that beneficiary-related cells 1-10 must not be published or derivable. This is a minimum, not a universal privacy guarantee; deployments may require higher thresholds.

Static threshold suppression is not exposed as an interactive-query privacy mechanism.

### InteractiveDifferentialPrivacy

Requires the exact source finding/query/output plus a versioned mechanism descriptor binding implementation, privacy unit, adjacency definition, contribution bounds, sensitivity evidence, randomness evidence, epsilon/delta, and a deployment-selected accountant lineage.

Epsilon/delta use reduced rationals rather than floating point. The gate enforces per-release and cumulative policy bounds, query-count bounds, exact predecessor continuity, non-decreasing cumulative loss, and exact query/mechanism/output binding.

There is intentionally no `dp=true` field or threshold-only interactive mode.

## Accountant non-claim / P0 #90

The pure crate validates accountant-chain structure but does not establish institutional trust in accountant state. `PrivacyAccountantReceiptV1` is serializable, so a malicious caller could fabricate a plausible chain unless a verifier-owned runtime/state root admits it.

P0 #90 is therefore a promotion blocker for interactive DP release.

## Capability

Only a validated request can mint the non-serializable `PopulationReleaseCapabilityV1`; consuming it creates a receipt bound to the exact request/policy/source/output/mode/time.

## Epistemic invariant

Privacy release never upgrades scientific evidence class. Signals remain signals, associations remain associations, causal-effect estimates remain estimates, and replication remains replication evidence.

## References

- NIST SP 800-226 (2025) for evaluating differential-privacy guarantees and implementation assumptions.
- CMS cell-size suppression policy for the static software-floor precedent.

## Qualification

See:
- `docs/security/CLINICAL_POPULATION_RELEASE_V1.md`
- `docs/security/CLINICAL_POPULATION_RELEASE_QUALIFICATION_CHECKLIST.md`
- `docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_GAP.md`

This PR remains draft until exact-head CI executes successfully. Interactive release also remains blocked on #90.