### PR TITLE
privacy(population): add DNA-rooted trusted accountant state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ members = [
     "zomes/clinical_causality/coordinator",
     "zomes/clinical_causality_index/integrity",
     "zomes/clinical_causality_index/coordinator",
+    "zomes/population_accountant/integrity",
+    "zomes/population_accountant/coordinator",
     "zomes/consent/integrity",
     "zomes/consent/coordinator",
     "zomes/bridge/integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ members = [
     "crates/clinical-causality-canonical-state",
     "crates/clinical-population-evidence",
     "crates/clinical-population-release",
+    "crates/clinical-population-accountant-state",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-population-accountant-state/Cargo.toml
+++ b/crates/clinical-population-accountant-state/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "mycelix-clinical-population-accountant-state"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Conflict-preserving canonical state reducer for trusted privacy-accountant lineage"
+
+[dependencies]
+holo_hash = { workspace = true }
+population_accountant_integrity = { path = "../../zomes/population_accountant/integrity" }
+serde = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/clinical-population-accountant-state/Cargo.toml
+++ b/crates/clinical-population-accountant-state/Cargo.toml
@@ -10,3 +10,7 @@ holo_hash = { workspace = true }
 population_accountant_integrity = { path = "../../zomes/population_accountant/integrity" }
 serde = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
+mycelix-clinical-population-release = { path = "../clinical-population-release" }

--- a/crates/clinical-population-accountant-state/src/lib.rs
+++ b/crates/clinical-population-accountant-state/src/lib.rs
@@ -1,0 +1,368 @@
+#![deny(unsafe_code)]
+//! Conflict-preserving read model for DNA-qualified privacy-accountant state.
+//!
+//! This reducer never chooses a winner by timestamp or insertion order. A stable
+//! chain is current only within the supplied read set. Forks, missing predecessors,
+//! mixed lineages, and semantically invalidating corrections fail closed.
+
+use holo_hash::ActionHash;
+use population_accountant_integrity::{
+    PopulationAccountantCorrectionReason, PopulationAccountantStateCorrection,
+    TrustedPopulationAccountantState,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const MAX_STATES: usize = 4096;
+const MAX_CORRECTIONS_PER_STATE: usize = 256;
+
+#[derive(Clone)]
+pub struct ObservedPopulationAccountantStateV1 {
+    pub action_hash: ActionHash,
+    pub state: TrustedPopulationAccountantState,
+    pub corrections: Vec<ObservedPopulationAccountantCorrectionV1>,
+}
+
+#[derive(Clone)]
+pub struct ObservedPopulationAccountantCorrectionV1 {
+    pub action_hash: ActionHash,
+    pub correction: PopulationAccountantStateCorrection,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PopulationAccountantStateLifecycleV1 {
+    Eligible,
+    DuplicatePublicationSuppressed,
+    Superseded,
+    Invalidated,
+    ReviewRequired,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PopulationAccountantStateLineageV1 {
+    pub action_hash: ActionHash,
+    pub sequence: u64,
+    pub query_count: u64,
+    pub lifecycle: PopulationAccountantStateLifecycleV1,
+}
+
+#[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CanonicalPopulationAccountantStateV1 {
+    NoTrustedStateObserved,
+    ObservedCurrentWithinRead {
+        action_hash: ActionHash,
+        sequence: u64,
+        query_count: u64,
+    },
+    ConflictWithinRead {
+        competing_state_hashes: Vec<ActionHash>,
+    },
+    NoCurrentStateWithinRead {
+        lineage: Vec<PopulationAccountantStateLineageV1>,
+    },
+    ReviewRequiredWithinRead {
+        lineage: Vec<PopulationAccountantStateLineageV1>,
+    },
+}
+
+pub fn reduce_population_accountant_state(
+    observed: &[ObservedPopulationAccountantStateV1],
+) -> Result<CanonicalPopulationAccountantStateV1, PopulationAccountantStateError> {
+    if observed.is_empty() {
+        return Ok(CanonicalPopulationAccountantStateV1::NoTrustedStateObserved);
+    }
+    if observed.len() > MAX_STATES {
+        return Err(PopulationAccountantStateError::TooManyStates);
+    }
+    reject_duplicate_state_actions(observed)?;
+    require_one_lineage(observed)?;
+    require_predecessor_closure(observed)?;
+
+    let mut lineage = Vec::with_capacity(observed.len());
+    for item in observed {
+        let lifecycle = lifecycle_for(item, observed)?;
+        lineage.push(PopulationAccountantStateLineageV1 {
+            action_hash: item.action_hash.clone(),
+            sequence: item.state.projection.sequence,
+            query_count: item.state.projection.query_count,
+            lifecycle,
+        });
+    }
+    lineage.sort_by(|left, right| {
+        left.sequence
+            .cmp(&right.sequence)
+            .then_with(|| left.action_hash.get_raw_36().cmp(right.action_hash.get_raw_36()))
+    });
+
+    if lineage.iter().any(|item| {
+        matches!(
+            item.lifecycle,
+            PopulationAccountantStateLifecycleV1::ReviewRequired
+        )
+    }) {
+        return Ok(CanonicalPopulationAccountantStateV1::ReviewRequiredWithinRead {
+            lineage,
+        });
+    }
+
+    let active_indices: Vec<usize> = lineage
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| {
+            matches!(item.lifecycle, PopulationAccountantStateLifecycleV1::Eligible)
+                .then_some(index)
+        })
+        .collect();
+
+    if active_indices.is_empty() {
+        return Ok(CanonicalPopulationAccountantStateV1::NoCurrentStateWithinRead {
+            lineage,
+        });
+    }
+
+    let live_actions: Vec<ActionHash> = active_indices
+        .iter()
+        .map(|index| lineage[*index].action_hash.clone())
+        .collect();
+
+    // More than one eligible genesis is an explicit fork.
+    let eligible_genesis: Vec<ActionHash> = live_actions
+        .iter()
+        .filter_map(|hash| {
+            let item = find_observed(observed, hash)?;
+            item.state.projection.previous_state_hash.is_none().then_some(hash.clone())
+        })
+        .collect();
+    if eligible_genesis.len() > 1 {
+        return Ok(CanonicalPopulationAccountantStateV1::ConflictWithinRead {
+            competing_state_hashes: sorted_hashes(eligible_genesis),
+        });
+    }
+
+    // Any predecessor with multiple eligible children is a sibling-state fork.
+    for parent_hash in &live_actions {
+        let children: Vec<ActionHash> = live_actions
+            .iter()
+            .filter_map(|candidate_hash| {
+                let candidate = find_observed(observed, candidate_hash)?;
+                (candidate.state.projection.previous_state_hash.as_ref() == Some(parent_hash))
+                    .then_some(candidate_hash.clone())
+            })
+            .collect();
+        if children.len() > 1 {
+            return Ok(CanonicalPopulationAccountantStateV1::ConflictWithinRead {
+                competing_state_hashes: sorted_hashes(children),
+            });
+        }
+    }
+
+    // A current state is an eligible state that is not the predecessor of another
+    // eligible state. More than one leaf means competing live branches.
+    let leaves: Vec<ActionHash> = live_actions
+        .iter()
+        .filter(|candidate| {
+            !live_actions.iter().any(|other| {
+                find_observed(observed, other)
+                    .and_then(|item| item.state.projection.previous_state_hash.as_ref())
+                    == Some(*candidate)
+            })
+        })
+        .cloned()
+        .collect();
+
+    if leaves.len() != 1 {
+        return Ok(CanonicalPopulationAccountantStateV1::ConflictWithinRead {
+            competing_state_hashes: sorted_hashes(leaves),
+        });
+    }
+
+    let leaf = find_observed(observed, &leaves[0]).ok_or(
+        PopulationAccountantStateError::InternalMissingState,
+    )?;
+
+    // A live leaf whose ancestry contains semantic invalidation cannot be upgraded
+    // to trusted-current merely because the leaf itself lacks a correction.
+    let mut cursor = leaf.state.projection.previous_state_hash.clone();
+    while let Some(parent_hash) = cursor {
+        let parent = find_observed(observed, &parent_hash).ok_or(
+            PopulationAccountantStateError::MissingPredecessor,
+        )?;
+        match lifecycle_for(parent, observed)? {
+            PopulationAccountantStateLifecycleV1::Eligible
+            | PopulationAccountantStateLifecycleV1::DuplicatePublicationSuppressed => {}
+            PopulationAccountantStateLifecycleV1::Superseded
+            | PopulationAccountantStateLifecycleV1::Invalidated
+            | PopulationAccountantStateLifecycleV1::ReviewRequired => {
+                return Ok(CanonicalPopulationAccountantStateV1::ReviewRequiredWithinRead {
+                    lineage,
+                });
+            }
+        }
+        cursor = parent.state.projection.previous_state_hash.clone();
+    }
+
+    Ok(CanonicalPopulationAccountantStateV1::ObservedCurrentWithinRead {
+        action_hash: leaf.action_hash.clone(),
+        sequence: leaf.state.projection.sequence,
+        query_count: leaf.state.projection.query_count,
+    })
+}
+
+fn lifecycle_for(
+    item: &ObservedPopulationAccountantStateV1,
+    all: &[ObservedPopulationAccountantStateV1],
+) -> Result<PopulationAccountantStateLifecycleV1, PopulationAccountantStateError> {
+    if item.corrections.len() > MAX_CORRECTIONS_PER_STATE {
+        return Err(PopulationAccountantStateError::TooManyCorrections);
+    }
+    reject_duplicate_corrections(item)?;
+
+    let mut saw_duplicate = false;
+    let mut saw_superseded = false;
+    let mut saw_review = false;
+    let mut saw_invalidation = false;
+
+    for observed in &item.corrections {
+        let correction = &observed.correction;
+        if correction.state_hash != item.action_hash
+            || correction.private_receipt_commitment
+                != item.state.projection.private_receipt_commitment
+        {
+            return Err(PopulationAccountantStateError::CorrectionLineageMismatch);
+        }
+        match correction.reason {
+            PopulationAccountantCorrectionReason::EnteredInError
+            | PopulationAccountantCorrectionReason::AccountantImplementationRevoked
+            | PopulationAccountantCorrectionReason::AccountantMethodRevoked => {
+                saw_invalidation = true;
+            }
+            PopulationAccountantCorrectionReason::Other => saw_review = true,
+            PopulationAccountantCorrectionReason::PolicySuperseded => saw_superseded = true,
+            PopulationAccountantCorrectionReason::DuplicateState => saw_duplicate = true,
+        }
+    }
+
+    if saw_invalidation {
+        return Ok(PopulationAccountantStateLifecycleV1::Invalidated);
+    }
+    if saw_review {
+        return Ok(PopulationAccountantStateLifecycleV1::ReviewRequired);
+    }
+    if saw_superseded {
+        return Ok(PopulationAccountantStateLifecycleV1::Superseded);
+    }
+    if saw_duplicate {
+        let equivalents = all
+            .iter()
+            .filter(|candidate| {
+                candidate.action_hash != item.action_hash
+                    && candidate.state.projection.private_receipt_commitment
+                        == item.state.projection.private_receipt_commitment
+                    && candidate.state.projection == item.state.projection
+            })
+            .count();
+        if equivalents == 0 {
+            return Ok(PopulationAccountantStateLifecycleV1::ReviewRequired);
+        }
+        return Ok(PopulationAccountantStateLifecycleV1::DuplicatePublicationSuppressed);
+    }
+    Ok(PopulationAccountantStateLifecycleV1::Eligible)
+}
+
+fn require_one_lineage(
+    observed: &[ObservedPopulationAccountantStateV1],
+) -> Result<(), PopulationAccountantStateError> {
+    let first = &observed[0].state.projection;
+    for item in &observed[1..] {
+        let current = &item.state.projection;
+        if current.release_policy_digest != first.release_policy_digest
+            || current.accountant_instance_digest != first.accountant_instance_digest
+            || current.accountant_method_digest != first.accountant_method_digest
+        {
+            return Err(PopulationAccountantStateError::MixedAccountantLineage);
+        }
+    }
+    Ok(())
+}
+
+fn require_predecessor_closure(
+    observed: &[ObservedPopulationAccountantStateV1],
+) -> Result<(), PopulationAccountantStateError> {
+    for item in observed {
+        if let Some(parent_hash) = &item.state.projection.previous_state_hash {
+            let parent = find_observed(observed, parent_hash).ok_or(
+                PopulationAccountantStateError::MissingPredecessor,
+            )?;
+            if parent.state.projection.sequence.checked_add(1)
+                != Some(item.state.projection.sequence)
+                || parent.state.projection.query_count.checked_add(1)
+                    != Some(item.state.projection.query_count)
+            {
+                return Err(PopulationAccountantStateError::NonContiguousLineage);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn reject_duplicate_state_actions(
+    observed: &[ObservedPopulationAccountantStateV1],
+) -> Result<(), PopulationAccountantStateError> {
+    for (index, item) in observed.iter().enumerate() {
+        if observed[..index]
+            .iter()
+            .any(|previous| previous.action_hash == item.action_hash)
+        {
+            return Err(PopulationAccountantStateError::DuplicateStateAction);
+        }
+    }
+    Ok(())
+}
+
+fn reject_duplicate_corrections(
+    item: &ObservedPopulationAccountantStateV1,
+) -> Result<(), PopulationAccountantStateError> {
+    for (index, correction) in item.corrections.iter().enumerate() {
+        if item.corrections[..index].iter().any(|previous| {
+            previous.action_hash == correction.action_hash
+                || previous.correction.correction_id == correction.correction.correction_id
+        }) {
+            return Err(PopulationAccountantStateError::DuplicateCorrection);
+        }
+    }
+    Ok(())
+}
+
+fn find_observed<'a>(
+    observed: &'a [ObservedPopulationAccountantStateV1],
+    action_hash: &ActionHash,
+) -> Option<&'a ObservedPopulationAccountantStateV1> {
+    observed.iter().find(|item| &item.action_hash == action_hash)
+}
+
+fn sorted_hashes(mut values: Vec<ActionHash>) -> Vec<ActionHash> {
+    values.sort_by(|left, right| left.get_raw_36().cmp(right.get_raw_36()));
+    values
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PopulationAccountantStateError {
+    #[error("too many accountant states for one bounded reduction")]
+    TooManyStates,
+    #[error("too many corrections attached to one accountant state")]
+    TooManyCorrections,
+    #[error("duplicate accountant state action")]
+    DuplicateStateAction,
+    #[error("duplicate correction action or correction ID")]
+    DuplicateCorrection,
+    #[error("correction crosses accountant-state lineage")]
+    CorrectionLineageMismatch,
+    #[error("supplied accountant states mix policy/instance/method lineages")]
+    MixedAccountantLineage,
+    #[error("supplied accountant read set is missing a predecessor")]
+    MissingPredecessor,
+    #[error("accountant predecessor sequence/query lineage is not contiguous")]
+    NonContiguousLineage,
+    #[error("internal reducer lookup unexpectedly lost a state")]
+    InternalMissingState,
+}

--- a/crates/clinical-population-accountant-state/tests/reducer.rs
+++ b/crates/clinical-population-accountant-state/tests/reducer.rs
@@ -136,11 +136,12 @@ fn missing_predecessor_fails_closed() {
 #[test]
 fn invalidated_ancestor_contaminates_descendant_current_claim() {
     let mut root = observed(1, 0, None);
-    root.corrections.push(correction(
+    let invalidation = correction(
         20,
         &root,
         PopulationAccountantCorrectionReason::AccountantImplementationRevoked,
-    ));
+    );
+    root.corrections.push(invalidation);
     let child = observed(2, 1, Some(root.action_hash.clone()));
     let result = reduce_population_accountant_state(&[root, child]).unwrap();
     assert!(matches!(

--- a/crates/clinical-population-accountant-state/tests/reducer.rs
+++ b/crates/clinical-population-accountant-state/tests/reducer.rs
@@ -1,0 +1,170 @@
+use holo_hash::ActionHash;
+use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain, StoredDigest};
+use mycelix_clinical_population_accountant_state::{
+    reduce_population_accountant_state, CanonicalPopulationAccountantStateV1,
+    ObservedPopulationAccountantCorrectionV1, ObservedPopulationAccountantStateV1,
+    PopulationAccountantStateError,
+};
+use mycelix_clinical_population_release::{
+    PopulationReleaseArtifactKindV1, PopulationReleaseDigestV1, PrivacyLossV1,
+    ReducedFractionV1,
+};
+use population_accountant_integrity::{
+    AccountantCommitmentSchemeV1, OpaqueAccountantReceiptCommitmentV1,
+    PopulationAccountantCorrectionReason, PopulationAccountantStateCorrection,
+    PopulationAccountantStateProjectionV1, TrustedPopulationAccountantState,
+};
+
+fn action(seed: u8) -> ActionHash {
+    ActionHash::from_raw_36(vec![seed; 36])
+}
+
+fn stored(seed: u8) -> StoredDigest {
+    StoredDigest {
+        algorithm: DigestAlgorithm::Blake3_256,
+        domain: DigestDomain::ClinicalArtifact,
+        value: [seed; 32],
+    }
+}
+
+fn policy() -> PopulationReleaseDigestV1 {
+    PopulationReleaseDigestV1 {
+        kind: PopulationReleaseArtifactKindV1::ReleasePolicy,
+        value: [9; 32],
+    }
+}
+
+fn loss(sequence: u64) -> PrivacyLossV1 {
+    if sequence == 0 {
+        PrivacyLossV1::ZERO
+    } else {
+        PrivacyLossV1 {
+            epsilon: ReducedFractionV1 {
+                numerator: sequence,
+                denominator: 10,
+            },
+            delta: ReducedFractionV1::ZERO,
+        }
+    }
+}
+
+fn observed(seed: u8, sequence: u64, previous: Option<ActionHash>) -> ObservedPopulationAccountantStateV1 {
+    ObservedPopulationAccountantStateV1 {
+        action_hash: action(seed),
+        state: TrustedPopulationAccountantState {
+            projection: PopulationAccountantStateProjectionV1 {
+                schema_version: 1,
+                state_id: format!("state-{seed}"),
+                release_policy_digest: policy(),
+                accountant_instance_digest: stored(2),
+                accountant_method_digest: stored(3),
+                sequence,
+                query_count: sequence,
+                cumulative_privacy_loss: loss(sequence),
+                previous_state_hash: previous,
+                private_receipt_commitment: OpaqueAccountantReceiptCommitmentV1 {
+                    scheme: AccountantCommitmentSchemeV1::Blake3Keyed,
+                    value: [seed; 32],
+                },
+            },
+            verifier_authorization_hash: action(seed.saturating_add(100)),
+        },
+        corrections: Vec::new(),
+    }
+}
+
+fn correction(
+    correction_seed: u8,
+    item: &ObservedPopulationAccountantStateV1,
+    reason: PopulationAccountantCorrectionReason,
+) -> ObservedPopulationAccountantCorrectionV1 {
+    ObservedPopulationAccountantCorrectionV1 {
+        action_hash: action(correction_seed),
+        correction: PopulationAccountantStateCorrection {
+            correction_id: format!("correction-{correction_seed}"),
+            state_hash: item.action_hash.clone(),
+            private_receipt_commitment: item.state.projection.private_receipt_commitment,
+            reason,
+            rationale_commitment: None,
+        },
+    }
+}
+
+#[test]
+fn one_genesis_is_observed_current_within_read() {
+    let states = vec![observed(1, 0, None)];
+    let result = reduce_population_accountant_state(&states).unwrap();
+    assert!(matches!(
+        result,
+        CanonicalPopulationAccountantStateV1::ObservedCurrentWithinRead { sequence: 0, .. }
+    ));
+}
+
+#[test]
+fn two_genesis_states_are_conflict() {
+    let states = vec![observed(1, 0, None), observed(2, 0, None)];
+    let result = reduce_population_accountant_state(&states).unwrap();
+    assert!(matches!(
+        result,
+        CanonicalPopulationAccountantStateV1::ConflictWithinRead { .. }
+    ));
+}
+
+#[test]
+fn sibling_successors_are_conflict() {
+    let root = observed(1, 0, None);
+    let root_hash = root.action_hash.clone();
+    let states = vec![
+        root,
+        observed(2, 1, Some(root_hash.clone())),
+        observed(3, 1, Some(root_hash)),
+    ];
+    let result = reduce_population_accountant_state(&states).unwrap();
+    assert!(matches!(
+        result,
+        CanonicalPopulationAccountantStateV1::ConflictWithinRead { .. }
+    ));
+}
+
+#[test]
+fn missing_predecessor_fails_closed() {
+    let states = vec![observed(2, 1, Some(action(1)))];
+    let result = reduce_population_accountant_state(&states);
+    assert!(matches!(result, Err(PopulationAccountantStateError::MissingPredecessor)));
+}
+
+#[test]
+fn invalidated_ancestor_contaminates_descendant_current_claim() {
+    let mut root = observed(1, 0, None);
+    root.corrections.push(correction(
+        20,
+        &root,
+        PopulationAccountantCorrectionReason::AccountantImplementationRevoked,
+    ));
+    let child = observed(2, 1, Some(root.action_hash.clone()));
+    let result = reduce_population_accountant_state(&[root, child]).unwrap();
+    assert!(matches!(
+        result,
+        CanonicalPopulationAccountantStateV1::ReviewRequiredWithinRead { .. }
+    ));
+}
+
+#[test]
+fn clean_contiguous_chain_returns_leaf() {
+    let root = observed(1, 0, None);
+    let child = observed(2, 1, Some(root.action_hash.clone()));
+    let child_hash = child.action_hash.clone();
+    let result = reduce_population_accountant_state(&[root, child]).unwrap();
+    match result {
+        CanonicalPopulationAccountantStateV1::ObservedCurrentWithinRead {
+            action_hash,
+            sequence,
+            query_count,
+        } => {
+            assert_eq!(action_hash, child_hash);
+            assert_eq!(sequence, 1);
+            assert_eq!(query_count, 1);
+        }
+        _ => panic!("expected current child state"),
+    }
+}

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -58,6 +58,15 @@ integrity:
       # Root authorizations approve one exact qualified receipt + one exact public
       # projection and are hard-capped at 15 minutes by the integrity zome.
       max_verifier_authorization_duration_micros: 900000000
+    population_accountant:
+      schema_version: 1
+      # Privacy-accountant trust is independent of research/release authority.
+      # Empty by default: interactive DP has no trusted budget state until a
+      # deployment deliberately repacks this DNA with trusted root AgentPubKeys.
+      root_authorities: []
+      # Roots authorize one exact verifier + one exact accountant state projection.
+      # The integrity zome hard-caps this at 15 minutes.
+      max_verifier_authorization_duration_micros: 900000000
   zomes:
     # Tier 1: MVP Core
     - name: patient_integrity
@@ -82,6 +91,8 @@ integrity:
       path: ../target/wasm32-unknown-unknown/release/clinical_causality_integrity.wasm
     - name: clinical_causality_index_integrity
       path: ../target/wasm32-unknown-unknown/release/clinical_causality_index_integrity.wasm
+    - name: population_accountant_integrity
+      path: ../target/wasm32-unknown-unknown/release/population_accountant_integrity.wasm
     - name: consent_integrity
       path: ../target/wasm32-unknown-unknown/release/consent_integrity.wasm
     - name: bridge_integrity
@@ -137,6 +148,10 @@ coordinator:
       dependencies:
         - name: clinical_causality_index_integrity
         - name: clinical_causality_integrity
+    - name: population_accountant
+      path: ../target/wasm32-unknown-unknown/release/population_accountant.wasm
+      dependencies:
+        - name: population_accountant_integrity
     - name: consent
       path: ../target/wasm32-unknown-unknown/release/consent.wasm
       dependencies:

--- a/docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_QUALIFICATION_CHECKLIST.md
@@ -1,0 +1,74 @@
+# Clinical Population Accountant Trust v1 — Qualification Checklist
+
+This checklist is evidence design, not qualification evidence by itself.
+
+## Build / package
+
+- [ ] `cargo fmt -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] workspace build includes `population_accountant_integrity`, `population_accountant`, and `mycelix-clinical-population-accountant-state`
+- [ ] DNA packaging includes both accountant zomes
+- [ ] exact-head CI completes successfully
+
+## Fail-closed DNA configuration
+
+- [ ] packaged default has `population_accountant.root_authorities: []`
+- [ ] empty roots reject verifier authorizations
+- [ ] duplicate roots reject configuration
+- [ ] authorization duration above 15 minutes rejects
+- [ ] malformed/missing accountant DNA properties fail closed
+
+## Exact authorization
+
+- [ ] only DNA-pinned root authors verifier authorization
+- [ ] state author must equal authorization grantee
+- [ ] state action timestamp must fall inside authorization window
+- [ ] authorization binds exact state projection digest
+- [ ] policy, accountant instance/method, sequence, predecessor and receipt commitment all match exactly
+- [ ] authorization replay against changed state ID/projection fails
+
+## Lineage
+
+- [ ] genesis requires sequence/query count/privacy loss = 0 and no predecessor
+- [ ] successor requires exact predecessor action
+- [ ] successor cannot cross release policy/accountant instance/accountant method
+- [ ] sequence and query count are contiguous
+- [ ] cumulative epsilon/delta never decrease
+- [ ] successor cannot reuse predecessor receipt commitment
+- [ ] missing predecessor fails closed
+
+## Corrections
+
+- [ ] state/update/delete are rejected
+- [ ] corrections are root-authored, append-only and exact-target
+- [ ] correction link author equals correction author
+- [ ] correction cannot cross private receipt commitment
+- [ ] `Other` requires rationale commitment
+
+## Reducer
+
+- [ ] single genesis -> observed current within supplied read
+- [ ] multiple genesis -> conflict
+- [ ] sibling successors -> conflict
+- [ ] multiple live leaves -> conflict
+- [ ] missing predecessor -> error
+- [ ] invalidated/superseded/review-required ancestor prevents descendant current promotion
+- [ ] no timestamp/insertion-order winner exists
+- [ ] duplicate correction IDs/actions reject
+- [ ] mixed accountant lineages reject
+
+## Privacy
+
+- [ ] public state does not expose query specification or released output digest
+- [ ] private receipt identity is a nonzero keyed commitment
+- [ ] commitment secret is never packaged in DNA/DHT
+
+## Remaining promotion blockers
+
+- [ ] P0 #72 exact cross-zome source-entry-definition proof is resolved or accepted with compensating conductor evidence
+- [ ] P0 #92 canonical accountant state discovery/materialization is implemented
+- [ ] protected binding from exact `PrivacyAccountantReceiptV1` to public keyed commitment is verifier-owned
+- [ ] interactive release consumes a trusted canonical accountant capability rather than caller-supplied receipts
+- [ ] conductor tests cover fork, replay, concurrent successors, correction race and stale state
+
+No interactive DP release should be described as trusted/canonical until the remaining blockers are closed.

--- a/docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_V1.md
+++ b/docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_V1.md
@@ -1,0 +1,96 @@
+# Clinical Population Accountant Trust v1
+
+## Purpose
+
+Turn privacy-accountant state from a caller-supplied serializable claim into a DNA-rooted, append-only trust lineage suitable for eventually gating interactive differential-privacy release.
+
+This tranche addresses the core threat in P0 #90: a structurally coherent `PrivacyAccountantReceiptV1` is not automatically institutionally trusted budget state.
+
+## Protected vs public state
+
+The full `PrivacyAccountantReceiptV1` remains protected. It may identify the exact query, DP mechanism, and output.
+
+The DHT stores only a privacy-minimized projection:
+
+- release-policy digest;
+- accountant instance digest;
+- accountant method digest;
+- sequence and query count;
+- cumulative epsilon/delta;
+- exact predecessor state action;
+- secret-keyed commitment to the protected receipt.
+
+The secret commitment key never appears on the DHT.
+
+## DNA-rooted authority
+
+`population_accountant.root_authorities` is packaged in DNA properties and is empty by default.
+
+A root may create only a short-lived `PopulationAccountantVerifierAuthorization` for:
+
+- one exact verifier;
+- one exact public state digest;
+- one exact release policy;
+- one exact accountant instance/method;
+- one exact sequence and predecessor;
+- one exact private-receipt commitment;
+- one bounded validity window.
+
+The integrity zome hard-caps authorization duration at 15 minutes.
+
+## Transition validation
+
+For non-genesis states the integrity zome requires:
+
+- the exact predecessor action to exist and decode as trusted accountant state;
+- same release-policy/accountant-instance/accountant-method lineage;
+- `sequence = predecessor.sequence + 1`;
+- `query_count = predecessor.query_count + 1`;
+- component-wise non-decreasing cumulative epsilon/delta;
+- a new private-receipt commitment;
+- exact match to a DNA-root-authorized public projection.
+
+Genesis requires sequence/query count/privacy loss all equal to zero and no predecessor.
+
+## Corrections
+
+Updates and deletes are forbidden. Corrections are append-only and root-authored.
+
+Typed reasons include:
+
+- `EnteredInError`;
+- `AccountantImplementationRevoked`;
+- `AccountantMethodRevoked`;
+- `PolicySuperseded`;
+- `DuplicateState`;
+- `Other` (requires protected rationale commitment).
+
+## Fork-preserving reducer
+
+`mycelix-clinical-population-accountant-state` never resolves by timestamp or insertion order.
+
+It returns bounded-read states including:
+
+- `ObservedCurrentWithinRead`;
+- `ConflictWithinRead` for multiple genesis states, sibling successors, or multiple live leaves;
+- `NoCurrentStateWithinRead` for corrected/superseded state;
+- `ReviewRequiredWithinRead` when a live descendant depends on semantically invalidated ancestry.
+
+Missing predecessors fail closed.
+
+## Non-claims
+
+This tranche does **not** yet prove global DHT completeness. The reducer can detect only states in the supplied read set.
+
+A high-assurance interactive release therefore still needs:
+
+1. canonical commitment/accountant-lineage state discovery;
+2. bounded stable materialization of every admitted state/correction;
+3. protected re-binding of the private `PrivacyAccountantReceiptV1` to the public keyed commitment;
+4. integration that requires the resulting trusted accountant capability before interactive release.
+
+Until those are complete, #90 remains a promotion blocker for interactive DP release.
+
+## Threat model principle
+
+A DHT-valid transition is evidence that a DNA-authorized verifier published one exact accountant-state projection. It is not proof that unseen sibling states do not exist, and the public keyed commitment is not independently reversible into the protected receipt.

--- a/zomes/population_accountant/coordinator/Cargo.toml
+++ b/zomes/population_accountant/coordinator/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "population_accountant"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Thin coordinator for DNA-rooted privacy accountant state"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { workspace = true }
+serde = { workspace = true }
+population_accountant_integrity = { path = "../integrity" }
+
+[features]
+default = []

--- a/zomes/population_accountant/coordinator/src/lib.rs
+++ b/zomes/population_accountant/coordinator/src/lib.rs
@@ -1,0 +1,164 @@
+#![deny(unsafe_code)]
+//! Thin coordinator for trusted privacy-accountant state.
+//!
+//! Budget/accountant reasoning happens in the protected pure layer. Trust enforcement
+//! happens in the integrity zome. This coordinator only commits exact entries/links
+//! and materializes bounded network-backed correction snapshots.
+
+use hdk::prelude::*;
+use population_accountant_integrity::{
+    EntryTypes, LinkTypes, PopulationAccountantStateCorrection,
+    PopulationAccountantVerifierAuthorization, TrustedPopulationAccountantState,
+};
+
+const MAX_CORRECTIONS_PER_STATE: usize = 256;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct ObservedPopulationAccountantCorrectionV1 {
+    pub action_hash: ActionHash,
+    pub correction: PopulationAccountantStateCorrection,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PopulationAccountantReadBoundaryV1 {
+    NetworkBackedStableDoubleRead,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PopulationAccountantStateSnapshotV1 {
+    pub state_action_hash: ActionHash,
+    pub state: TrustedPopulationAccountantState,
+    pub corrections: Vec<ObservedPopulationAccountantCorrectionV1>,
+    pub read_boundary: PopulationAccountantReadBoundaryV1,
+    pub observed_correction_target_count: usize,
+    pub observation_started_at: Timestamp,
+    pub observation_completed_at: Timestamp,
+}
+
+#[hdk_extern]
+pub fn create_population_accountant_verifier_authorization(
+    authorization: PopulationAccountantVerifierAuthorization,
+) -> ExternResult<Record> {
+    let hash = create_entry(EntryTypes::PopulationAccountantVerifierAuthorization(authorization))?;
+    get(hash, GetOptions::network())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed population accountant verifier authorization could not be read back".into()
+    )))
+}
+
+#[hdk_extern]
+pub fn publish_trusted_population_accountant_state(
+    state: TrustedPopulationAccountantState,
+) -> ExternResult<Record> {
+    let hash = create_entry(EntryTypes::TrustedPopulationAccountantState(state))?;
+    get(hash, GetOptions::network())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed trusted population accountant state could not be read back".into()
+    )))
+}
+
+#[hdk_extern]
+pub fn append_population_accountant_state_correction(
+    correction: PopulationAccountantStateCorrection,
+) -> ExternResult<Record> {
+    let state_hash = correction.state_hash.clone();
+    let correction_hash = create_entry(EntryTypes::PopulationAccountantStateCorrection(correction))?;
+    create_link(
+        state_hash,
+        correction_hash.clone(),
+        LinkTypes::StateToCorrections,
+        (),
+    )?;
+    get(correction_hash, GetOptions::network())?.ok_or(wasm_error!(WasmErrorInner::Guest(
+        "Committed population accountant correction could not be read back".into()
+    )))
+}
+
+/// Materialize one known trusted accountant state plus every correction target observed
+/// by this conductor, requiring the target set to be unchanged across two network reads.
+/// This is bounded observed state, not proof of global DHT completeness.
+#[hdk_extern]
+pub fn materialize_population_accountant_state_snapshot(
+    state_hash: ActionHash,
+) -> ExternResult<PopulationAccountantStateSnapshotV1> {
+    let observation_started_at = sys_time()?;
+    let record = get(state_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
+        WasmErrorInner::Guest("Trusted population accountant state was not found".into())
+    ))?;
+    let state: TrustedPopulationAccountantState =
+        decode_entry(&record, "trusted population accountant state")?;
+
+    let first_targets = observed_correction_targets(&state_hash)?;
+    let mut corrections = Vec::with_capacity(first_targets.len());
+    for correction_hash in &first_targets {
+        let correction_record = get(correction_hash.clone(), GetOptions::network())?.ok_or(
+            wasm_error!(WasmErrorInner::Guest(
+                "Observed population accountant correction could not be materialized".into()
+            )),
+        )?;
+        let correction: PopulationAccountantStateCorrection =
+            decode_entry(&correction_record, "population accountant correction")?;
+        if correction.state_hash != state_hash
+            || correction.private_receipt_commitment
+                != state.projection.private_receipt_commitment
+        {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Observed population accountant correction crosses state lineage".into()
+            )));
+        }
+        corrections.push(ObservedPopulationAccountantCorrectionV1 {
+            action_hash: correction_hash.clone(),
+            correction,
+        });
+    }
+
+    let second_targets = observed_correction_targets(&state_hash)?;
+    let observation_completed_at = sys_time()?;
+    if first_targets != second_targets {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Population accountant correction set changed during materialization; retry".into()
+        )));
+    }
+
+    Ok(PopulationAccountantStateSnapshotV1 {
+        state_action_hash: state_hash,
+        state,
+        corrections,
+        read_boundary: PopulationAccountantReadBoundaryV1::NetworkBackedStableDoubleRead,
+        observed_correction_target_count: first_targets.len(),
+        observation_started_at,
+        observation_completed_at,
+    })
+}
+
+fn observed_correction_targets(state_hash: &ActionHash) -> ExternResult<Vec<ActionHash>> {
+    let links = get_links(
+        LinkQuery::try_new(state_hash.clone(), LinkTypes::StateToCorrections)?,
+        GetStrategy::Network,
+    )?;
+    if links.len() > MAX_CORRECTIONS_PER_STATE {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Population accountant state has more than {MAX_CORRECTIONS_PER_STATE} observed corrections"
+        ))));
+    }
+    let mut targets = Vec::with_capacity(links.len());
+    for link in links {
+        let target = link.target.into_action_hash().ok_or(wasm_error!(
+            WasmErrorInner::Guest("Population accountant correction target must be ActionHash".into())
+        ))?;
+        if !targets.contains(&target) {
+            targets.push(target);
+        }
+    }
+    targets.sort_by(|left, right| left.get_raw_36().cmp(right.get_raw_36()));
+    Ok(targets)
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record.entry().to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}

--- a/zomes/population_accountant/integrity/Cargo.toml
+++ b/zomes/population_accountant/integrity/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "population_accountant_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "DNA-rooted privacy accountant state integrity zome"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+blake3 = "1.8.5"
+mycelix-clinical-integrity = { path = "../../../crates/clinical-integrity" }
+mycelix-clinical-population-release = { path = "../../../crates/clinical-population-release" }
+
+[features]
+default = []

--- a/zomes/population_accountant/integrity/src/lib.rs
+++ b/zomes/population_accountant/integrity/src/lib.rs
@@ -1,0 +1,629 @@
+#![deny(unsafe_code)]
+//! DNA-rooted trusted privacy-accountant state.
+//!
+//! Full accountant receipts and query/output identities remain protected off-DHT.
+//! The DHT stores only a keyed commitment to the private receipt plus the minimum
+//! state needed to detect lineage gaps/forks and enforce release-policy budgets.
+
+use hdi::prelude::*;
+use mycelix_clinical_integrity::StoredDigest;
+use mycelix_clinical_population_release::{
+    PopulationReleaseArtifactKindV1, PopulationReleaseDigestV1, PrivacyLossV1,
+    ReducedFractionV1,
+};
+
+const CONFIG_VERSION: u16 = 1;
+const MAX_ID_LEN: usize = 128;
+const MAX_ROOT_AUTHORITIES: usize = 64;
+const ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS: i64 = 900_000_000;
+const ATTESTATION_HASH_CONTEXT: &str = "mycelix.health.population-accountant-attestation.v1";
+const FRAME_VERSION: u8 = 1;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PopulationAccountantRootConfig {
+    pub schema_version: u16,
+    pub root_authorities: Vec<AgentPubKey>,
+    pub max_verifier_authorization_duration_micros: i64,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum AccountantCommitmentSchemeV1 {
+    HmacSha256,
+    Blake3Keyed,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[serde(deny_unknown_fields)]
+pub struct OpaqueAccountantReceiptCommitmentV1 {
+    pub scheme: AccountantCommitmentSchemeV1,
+    pub value: [u8; 32],
+}
+
+impl OpaqueAccountantReceiptCommitmentV1 {
+    fn validate(&self) -> ExternResult<ValidateCallbackResult> {
+        if self.value == [0u8; 32] {
+            return invalid("Privacy-accountant receipt commitment cannot be zero");
+        }
+        Ok(ValidateCallbackResult::Valid)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PopulationAccountantAttestationDigestV1 {
+    pub value: [u8; 32],
+}
+
+impl PopulationAccountantAttestationDigestV1 {
+    fn validate(&self) -> ExternResult<()> {
+        if self.value == [0u8; 32] {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Population accountant attestation digest cannot be zero".into()
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Public privacy-minimized projection of one protected accountant receipt.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PopulationAccountantStateProjectionV1 {
+    pub schema_version: u16,
+    pub state_id: String,
+    pub release_policy_digest: PopulationReleaseDigestV1,
+    pub accountant_instance_digest: StoredDigest,
+    pub accountant_method_digest: StoredDigest,
+    pub sequence: u64,
+    pub query_count: u64,
+    pub cumulative_privacy_loss: PrivacyLossV1,
+    pub previous_state_hash: Option<ActionHash>,
+    pub private_receipt_commitment: OpaqueAccountantReceiptCommitmentV1,
+}
+
+impl PopulationAccountantStateProjectionV1 {
+    pub fn validate_shape(&self) -> ExternResult<ValidateCallbackResult> {
+        if self.schema_version != 1 {
+            return invalid("Unsupported population accountant state version");
+        }
+        let id = validate_id("Population accountant state ID", &self.state_id)?;
+        if !matches!(id, ValidateCallbackResult::Valid) {
+            return Ok(id);
+        }
+        validate_release_policy_digest(self.release_policy_digest)?;
+        require_stored_digest(self.accountant_instance_digest, "accountant instance")?;
+        require_stored_digest(self.accountant_method_digest, "accountant method")?;
+        self.cumulative_privacy_loss
+            .validate()
+            .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+        let commitment = self.private_receipt_commitment.validate()?;
+        if !matches!(commitment, ValidateCallbackResult::Valid) {
+            return Ok(commitment);
+        }
+        match (self.sequence, self.previous_state_hash.as_ref()) {
+            (0, None) => {
+                if self.query_count != 0 || self.cumulative_privacy_loss != PrivacyLossV1::ZERO {
+                    return invalid("Accountant genesis must have zero queries and zero privacy loss");
+                }
+            }
+            (0, Some(_)) => return invalid("Accountant genesis cannot name a predecessor"),
+            (_, None) => return invalid("Non-genesis accountant state requires predecessor"),
+            (_, Some(_)) => {
+                if self.query_count != self.sequence {
+                    return invalid("Accountant sequence must equal query count in v1");
+                }
+                if self.cumulative_privacy_loss == PrivacyLossV1::ZERO {
+                    return invalid("Non-genesis accountant state cannot have zero cumulative loss");
+                }
+            }
+        }
+        Ok(ValidateCallbackResult::Valid)
+    }
+
+    pub fn digest(&self) -> ExternResult<PopulationAccountantAttestationDigestV1> {
+        let valid = self.validate_shape()?;
+        if !matches!(valid, ValidateCallbackResult::Valid) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Cannot hash invalid population accountant state projection".into()
+            )));
+        }
+        let encoded = serde_json::to_vec(self).map_err(|error| {
+            wasm_error!(WasmErrorInner::Guest(format!(
+                "Failed to serialize population accountant state projection: {error}"
+            )))
+        })?;
+        let mut hasher = blake3::Hasher::new_derive_key(ATTESTATION_HASH_CONTEXT);
+        hasher.update(&[FRAME_VERSION]);
+        hasher.update(&(encoded.len() as u64).to_be_bytes());
+        hasher.update(&encoded);
+        let value = *hasher.finalize().as_bytes();
+        if value == [0u8; 32] {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Population accountant attestation digest cannot be zero".into()
+            )));
+        }
+        Ok(PopulationAccountantAttestationDigestV1 { value })
+    }
+}
+
+/// One exact short-lived authorization from a DNA-pinned root.
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct PopulationAccountantVerifierAuthorization {
+    pub authorization_id: String,
+    pub grantee: AgentPubKey,
+    pub public_state_digest: PopulationAccountantAttestationDigestV1,
+    pub release_policy_digest: PopulationReleaseDigestV1,
+    pub accountant_instance_digest: StoredDigest,
+    pub accountant_method_digest: StoredDigest,
+    pub sequence: u64,
+    pub previous_state_hash: Option<ActionHash>,
+    pub private_receipt_commitment: OpaqueAccountantReceiptCommitmentV1,
+    pub valid_from: Timestamp,
+    pub valid_until: Timestamp,
+}
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct TrustedPopulationAccountantState {
+    pub projection: PopulationAccountantStateProjectionV1,
+    pub verifier_authorization_hash: ActionHash,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PopulationAccountantCorrectionReason {
+    EnteredInError,
+    AccountantImplementationRevoked,
+    AccountantMethodRevoked,
+    PolicySuperseded,
+    DuplicateState,
+    Other,
+}
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct PopulationAccountantStateCorrection {
+    pub correction_id: String,
+    pub state_hash: ActionHash,
+    pub private_receipt_commitment: OpaqueAccountantReceiptCommitmentV1,
+    pub reason: PopulationAccountantCorrectionReason,
+    pub rationale_commitment: Option<OpaqueAccountantReceiptCommitmentV1>,
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    PopulationAccountantVerifierAuthorization(PopulationAccountantVerifierAuthorization),
+    TrustedPopulationAccountantState(TrustedPopulationAccountantState),
+    PopulationAccountantStateCorrection(PopulationAccountantStateCorrection),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    StateToCorrections,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => {
+                validate_create_entry(EntryCreationAction::Create(action), app_entry)
+            }
+            OpEntry::UpdateEntry { .. } => invalid("Population accountant trust entries are append-only"),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterUpdate(_) => invalid("Population accountant trust entries cannot be updated"),
+        FlatOp::RegisterDelete(_) => invalid("Population accountant trust entries cannot be deleted; append a correction"),
+        FlatOp::RegisterCreateLink { link_type, base_address, target_address, action, .. } => {
+            validate_create_link(link_type, base_address, target_address, action)
+        }
+        FlatOp::RegisterDeleteLink { .. } => invalid("Population accountant correction links are append-only"),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_create_entry(
+    action: EntryCreationAction,
+    entry: EntryTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    match entry {
+        EntryTypes::PopulationAccountantVerifierAuthorization(value) => {
+            let shape = validate_authorization_shape(&value)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let config = population_accountant_root_config()?;
+            let root = require_root_authority(action.author(), &config)?;
+            if !matches!(root, ValidateCallbackResult::Valid) {
+                return Ok(root);
+            }
+            validate_authorization_window(action.timestamp(), &value, &config)
+        }
+        EntryTypes::TrustedPopulationAccountantState(value) => {
+            let shape = value.projection.validate_shape()?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let predecessor = require_predecessor_lineage(&value.projection)?;
+            if !matches!(predecessor, ValidateCallbackResult::Valid) {
+                return Ok(predecessor);
+            }
+            require_exact_verifier_authorization(action.author(), action.timestamp(), &value)
+        }
+        EntryTypes::PopulationAccountantStateCorrection(value) => {
+            let shape = validate_correction_shape(&value)?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let config = population_accountant_root_config()?;
+            let root = require_root_authority(action.author(), &config)?;
+            if !matches!(root, ValidateCallbackResult::Valid) {
+                return Ok(root);
+            }
+            require_correction_target(&value)
+        }
+    }
+}
+
+fn validate_authorization_shape(
+    value: &PopulationAccountantVerifierAuthorization,
+) -> ExternResult<ValidateCallbackResult> {
+    let id = validate_id("Population accountant authorization ID", &value.authorization_id)?;
+    if !matches!(id, ValidateCallbackResult::Valid) {
+        return Ok(id);
+    }
+    value.public_state_digest.validate()?;
+    validate_release_policy_digest(value.release_policy_digest)?;
+    require_stored_digest(value.accountant_instance_digest, "accountant instance")?;
+    require_stored_digest(value.accountant_method_digest, "accountant method")?;
+    let commitment = value.private_receipt_commitment.validate()?;
+    if !matches!(commitment, ValidateCallbackResult::Valid) {
+        return Ok(commitment);
+    }
+    match (value.sequence, value.previous_state_hash.as_ref()) {
+        (0, None) => {}
+        (0, Some(_)) => return invalid("Genesis accountant authorization cannot name predecessor"),
+        (_, None) => return invalid("Non-genesis accountant authorization requires predecessor"),
+        (_, Some(_)) => {}
+    }
+    if value.valid_until <= value.valid_from {
+        return invalid("Population accountant authorization validity window is invalid");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_authorization_window(
+    action_timestamp: Timestamp,
+    authorization: &PopulationAccountantVerifierAuthorization,
+    config: &PopulationAccountantRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    let duration = authorization.valid_until.as_micros() as i128
+        - authorization.valid_from.as_micros() as i128;
+    if duration <= 0
+        || duration > config.max_verifier_authorization_duration_micros as i128
+        || duration > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS as i128
+    {
+        return invalid("Population accountant authorization exceeds configured/hard duration");
+    }
+    if action_timestamp > authorization.valid_until {
+        return invalid("Population accountant authorization was expired when created");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_predecessor_lineage(
+    projection: &PopulationAccountantStateProjectionV1,
+) -> ExternResult<ValidateCallbackResult> {
+    let Some(previous_hash) = projection.previous_state_hash.as_ref() else {
+        return Ok(ValidateCallbackResult::Valid);
+    };
+    let record = must_get_valid_record(previous_hash.clone())?;
+    let previous: TrustedPopulationAccountantState =
+        decode_entry(&record, "trusted population accountant predecessor state")?;
+    let prior = &previous.projection;
+    if prior.release_policy_digest != projection.release_policy_digest
+        || prior.accountant_instance_digest != projection.accountant_instance_digest
+        || prior.accountant_method_digest != projection.accountant_method_digest
+    {
+        return invalid("Population accountant predecessor crosses policy/accountant lineage");
+    }
+    let expected_sequence = prior.sequence.checked_add(1).ok_or(wasm_error!(
+        WasmErrorInner::Guest("Population accountant sequence overflow".into())
+    ))?;
+    let expected_queries = prior.query_count.checked_add(1).ok_or(wasm_error!(
+        WasmErrorInner::Guest("Population accountant query-count overflow".into())
+    ))?;
+    if projection.sequence != expected_sequence || projection.query_count != expected_queries {
+        return invalid("Population accountant predecessor sequence/query count is not contiguous");
+    }
+    if !privacy_loss_non_decreasing(
+        projection.cumulative_privacy_loss,
+        prior.cumulative_privacy_loss,
+    ) {
+        return invalid("Population accountant cumulative privacy loss decreased");
+    }
+    if projection.private_receipt_commitment == prior.private_receipt_commitment {
+        return invalid("Population accountant successor reuses predecessor receipt commitment");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_exact_verifier_authorization(
+    author: &AgentPubKey,
+    action_timestamp: Timestamp,
+    state: &TrustedPopulationAccountantState,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(state.verifier_authorization_hash.clone())?;
+    let authorization: PopulationAccountantVerifierAuthorization =
+        decode_entry(&record, "population accountant verifier authorization")?;
+    let config = population_accountant_root_config()?;
+    let root = require_root_authority(record.action().author(), &config)?;
+    if !matches!(root, ValidateCallbackResult::Valid) {
+        return Ok(root);
+    }
+    let shape = validate_authorization_shape(&authorization)?;
+    if !matches!(shape, ValidateCallbackResult::Valid) {
+        return Ok(shape);
+    }
+    if &authorization.grantee != author {
+        return invalid("Population accountant state author is not authorization grantee");
+    }
+    if action_timestamp < authorization.valid_from || action_timestamp >= authorization.valid_until {
+        return invalid("Population accountant state action is outside authorization validity");
+    }
+    let projection = &state.projection;
+    if authorization.public_state_digest != projection.digest()?
+        || authorization.release_policy_digest != projection.release_policy_digest
+        || authorization.accountant_instance_digest != projection.accountant_instance_digest
+        || authorization.accountant_method_digest != projection.accountant_method_digest
+        || authorization.sequence != projection.sequence
+        || authorization.previous_state_hash != projection.previous_state_hash
+        || authorization.private_receipt_commitment != projection.private_receipt_commitment
+    {
+        return invalid("Population accountant state does not exactly match root authorization");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_correction_shape(
+    value: &PopulationAccountantStateCorrection,
+) -> ExternResult<ValidateCallbackResult> {
+    let id = validate_id("Population accountant correction ID", &value.correction_id)?;
+    if !matches!(id, ValidateCallbackResult::Valid) {
+        return Ok(id);
+    }
+    let commitment = value.private_receipt_commitment.validate()?;
+    if !matches!(commitment, ValidateCallbackResult::Valid) {
+        return Ok(commitment);
+    }
+    if let Some(rationale) = value.rationale_commitment {
+        let shape = rationale.validate()?;
+        if !matches!(shape, ValidateCallbackResult::Valid) {
+            return Ok(shape);
+        }
+    }
+    if matches!(value.reason, PopulationAccountantCorrectionReason::Other)
+        && value.rationale_commitment.is_none()
+    {
+        return invalid("Other population accountant correction requires rationale commitment");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_correction_target(
+    value: &PopulationAccountantStateCorrection,
+) -> ExternResult<ValidateCallbackResult> {
+    let record = must_get_valid_record(value.state_hash.clone())?;
+    let state: TrustedPopulationAccountantState =
+        decode_entry(&record, "trusted population accountant state")?;
+    if state.projection.private_receipt_commitment != value.private_receipt_commitment {
+        return invalid("Population accountant correction commitment does not match target state");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_create_link(
+    link_type: LinkTypes,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    action: CreateLink,
+) -> ExternResult<ValidateCallbackResult> {
+    match link_type {
+        LinkTypes::StateToCorrections => {
+            let state_hash = require_action_hash(base_address, "accountant correction base")?;
+            let correction_hash = require_action_hash(target_address, "accountant correction target")?;
+            let state_record = must_get_valid_record(state_hash.clone())?;
+            let state: TrustedPopulationAccountantState =
+                decode_entry(&state_record, "trusted population accountant state")?;
+            let correction_record = must_get_valid_record(correction_hash)?;
+            let correction: PopulationAccountantStateCorrection =
+                decode_entry(&correction_record, "population accountant correction")?;
+            if correction.state_hash != state_hash
+                || correction.private_receipt_commitment
+                    != state.projection.private_receipt_commitment
+            {
+                return invalid("Population accountant correction link crosses state lineage");
+            }
+            if correction_record.action().author() != &action.author {
+                return invalid("Population accountant correction link must be authored by correction author");
+            }
+            let config = population_accountant_root_config()?;
+            require_root_authority(&action.author, &config)
+        }
+    }
+}
+
+fn population_accountant_root_config() -> ExternResult<PopulationAccountantRootConfig> {
+    let info = dna_info()?;
+    let properties: serde_json::Value = serde_json::from_slice(info.modifiers.properties.bytes())
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(format!(
+            "DNA properties are not valid JSON for population accountant trust: {error}"
+        ))))?;
+    let value = properties.get("population_accountant").ok_or(wasm_error!(
+        WasmErrorInner::Guest("DNA properties do not configure population_accountant roots".into())
+    ))?;
+    let config: PopulationAccountantRootConfig = serde_json::from_value(value.clone())
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(format!(
+            "Invalid population_accountant DNA properties: {error}"
+        ))))?;
+    if config.schema_version != CONFIG_VERSION {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Unsupported population_accountant root config version {}",
+            config.schema_version
+        ))));
+    }
+    if config.root_authorities.len() > MAX_ROOT_AUTHORITIES {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Population accountant root list exceeds maximum".into()
+        )));
+    }
+    if config.max_verifier_authorization_duration_micros <= 0
+        || config.max_verifier_authorization_duration_micros
+            > ABSOLUTE_MAX_AUTHORIZATION_DURATION_MICROS
+    {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Population accountant authorization duration must be >0 and <=15 minutes".into()
+        )));
+    }
+    for (index, root) in config.root_authorities.iter().enumerate() {
+        if config.root_authorities[..index].contains(root) {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Population accountant root list contains duplicate AgentPubKeys".into()
+            )));
+        }
+    }
+    Ok(config)
+}
+
+fn require_root_authority(
+    author: &AgentPubKey,
+    config: &PopulationAccountantRootConfig,
+) -> ExternResult<ValidateCallbackResult> {
+    if !config.root_authorities.contains(author) {
+        return invalid("Population accountant authorization/correction requires DNA-pinned root");
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn validate_release_policy_digest(digest: PopulationReleaseDigestV1) -> ExternResult<()> {
+    digest.validate().map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+    if digest.kind != PopulationReleaseArtifactKindV1::ReleasePolicy {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Population accountant state requires a release-policy digest".into()
+        )));
+    }
+    Ok(())
+}
+
+fn require_stored_digest(digest: StoredDigest, label: &'static str) -> ExternResult<()> {
+    digest.validate_shape()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(format!("Invalid {label} digest: {error}"))))
+}
+
+fn privacy_loss_non_decreasing(next: PrivacyLossV1, previous: PrivacyLossV1) -> bool {
+    fraction_le(previous.epsilon, next.epsilon) && fraction_le(previous.delta, next.delta)
+}
+
+fn fraction_le(left: ReducedFractionV1, right: ReducedFractionV1) -> bool {
+    (left.numerator as u128) * (right.denominator as u128)
+        <= (right.numerator as u128) * (left.denominator as u128)
+}
+
+fn validate_id(label: &'static str, value: &str) -> ExternResult<ValidateCallbackResult> {
+    if value.trim().is_empty() {
+        return invalid(format!("{label} is required"));
+    }
+    if value.len() > MAX_ID_LEN {
+        return invalid(format!("{label} exceeds {MAX_ID_LEN} bytes"));
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+fn require_action_hash(hash: AnyLinkableHash, field: &'static str) -> ExternResult<ActionHash> {
+    hash.into_action_hash().ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+        "{field} must be an ActionHash"
+    ))))
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record.entry().to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain};
+
+    fn stored(domain: DigestDomain, seed: u8) -> StoredDigest {
+        StoredDigest { algorithm: DigestAlgorithm::Blake3_256, domain, value: [seed; 32] }
+    }
+
+    fn release_policy_digest(seed: u8) -> PopulationReleaseDigestV1 {
+        PopulationReleaseDigestV1 { kind: PopulationReleaseArtifactKindV1::ReleasePolicy, value: [seed; 32] }
+    }
+
+    fn projection(sequence: u64) -> PopulationAccountantStateProjectionV1 {
+        PopulationAccountantStateProjectionV1 {
+            schema_version: 1,
+            state_id: format!("accountant-state-{sequence}"),
+            release_policy_digest: release_policy_digest(2),
+            accountant_instance_digest: stored(DigestDomain::ClinicalArtifact, 3),
+            accountant_method_digest: stored(DigestDomain::ClinicalArtifact, 4),
+            sequence,
+            query_count: sequence,
+            cumulative_privacy_loss: if sequence == 0 { PrivacyLossV1::ZERO } else { PrivacyLossV1 { epsilon: ReducedFractionV1 { numerator: sequence, denominator: 10 }, delta: ReducedFractionV1::ZERO } },
+            previous_state_hash: if sequence == 0 { None } else { Some(ActionHash::from_raw_36(vec![5; 36])) },
+            private_receipt_commitment: OpaqueAccountantReceiptCommitmentV1 { scheme: AccountantCommitmentSchemeV1::Blake3Keyed, value: [6 + sequence as u8; 32] },
+        }
+    }
+
+    #[test]
+    fn genesis_requires_zero_budget_and_no_predecessor() {
+        assert!(matches!(projection(0).validate_shape().unwrap(), ValidateCallbackResult::Valid));
+        let mut bad = projection(0);
+        bad.query_count = 1;
+        assert!(matches!(bad.validate_shape().unwrap(), ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn non_genesis_requires_predecessor() {
+        let mut bad = projection(1);
+        bad.previous_state_hash = None;
+        assert!(matches!(bad.validate_shape().unwrap(), ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn state_id_changes_authorized_projection_digest() {
+        let first = projection(0);
+        let first_digest = first.digest().unwrap();
+        let mut second = first.clone();
+        second.state_id = "another-state".into();
+        assert_ne!(first_digest, second.digest().unwrap());
+    }
+
+    #[test]
+    fn zero_private_commitment_is_rejected() {
+        let mut bad = projection(0);
+        bad.private_receipt_commitment.value = [0; 32];
+        assert!(matches!(bad.validate_shape().unwrap(), ValidateCallbackResult::Invalid(_)));
+    }
+
+    #[test]
+    fn privacy_loss_comparison_is_exact_rational_arithmetic() {
+        let previous = PrivacyLossV1 { epsilon: ReducedFractionV1 { numerator: 1, denominator: 10 }, delta: ReducedFractionV1::ZERO };
+        let next = PrivacyLossV1 { epsilon: ReducedFractionV1 { numerator: 2, denominator: 10 }, delta: ReducedFractionV1::ZERO };
+        assert!(privacy_loss_non_decreasing(next, previous));
+        assert!(!privacy_loss_non_decreasing(previous, next));
+    }
+}


### PR DESCRIPTION
## Stack

Depends on #91 -> #88 -> #87 -> #86 -> #85 -> #84 -> #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

## Why

P0 #90 identified that a serializable `PrivacyAccountantReceiptV1` can be structurally coherent without being institutionally trusted. This tranche moves accountant state behind a DNA-rooted verifier boundary.

## Runtime trust model

The full accountant receipt remains protected. The DHT stores only:

- release-policy identity;
- accountant instance/method identities;
- sequence/query count;
- cumulative epsilon/delta;
- exact predecessor state action;
- keyed commitment to the private receipt.

`population_accountant.root_authorities` is packaged in DNA properties and is empty by default.

A root authorization is exact and short-lived: one verifier, one exact public-state digest, one policy/accountant lineage, one sequence/predecessor and one private-receipt commitment. Authorization duration is hard-capped at 15 minutes.

## Transition invariants

Non-genesis state requires:

- exact predecessor DHT action;
- same policy/accountant instance/method;
- contiguous sequence/query count;
- non-decreasing cumulative privacy loss;
- a new receipt commitment;
- exact DNA-root-authorized projection.

Genesis requires sequence/query count/privacy loss = 0 and no predecessor.

## Corrections

Updates/deletes are forbidden. Root-authored append-only corrections cover entered-in-error, accountant implementation/method revocation, policy supersession, duplicate publication and explicit other-with-rationale.

## Fork-preserving reducer

`mycelix-clinical-population-accountant-state` never resolves by timestamp or insertion order. Multiple genesis states, sibling successors, or multiple live leaves become explicit conflict. Missing predecessor history fails closed. Descendants of semantically invalidated ancestry cannot be promoted to current.

## Privacy

Public state excludes query specifications and released-output digests. Private receipt identity is a keyed commitment; the secret is never placed in DNA/DHT.

## Remaining blocker: #92

This PR can validate individual accountant states and detect forks in a supplied read set, but it does not yet prove that the read set discovered every admitted state. P0 #92 tracks canonical privacy-preserving state discovery/materialization. Therefore P0 #90 is only partially closed and interactive DP remains experimental/preflight-only.

## Qualification

See:
- `docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_V1.md`
- `docs/security/CLINICAL_POPULATION_ACCOUNTANT_TRUST_QUALIFICATION_CHECKLIST.md`

This PR remains draft until exact-head CI executes successfully and the remaining promotion blockers are closed.