### PR TITLE
privacy(population): add canonical accountant discovery and bounded state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ members = [
     "crates/clinical-population-evidence",
     "crates/clinical-population-release",
     "crates/clinical-population-accountant-state",
+    "crates/clinical-population-accountant-canonical-state",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ members = [
     "zomes/clinical_causality_index/coordinator",
     "zomes/population_accountant/integrity",
     "zomes/population_accountant/coordinator",
+    "zomes/population_accountant_index/integrity",
+    "zomes/population_accountant_index/coordinator",
     "zomes/consent/integrity",
     "zomes/consent/coordinator",
     "zomes/bridge/integrity",

--- a/crates/clinical-population-accountant-canonical-state/Cargo.toml
+++ b/crates/clinical-population-accountant-canonical-state/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mycelix-clinical-population-accountant-canonical-state"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Bounded canonical accountant-state view over runtime-admitted snapshots"
+
+[dependencies]
+holo_hash = { workspace = true }
+mycelix-clinical-population-accountant-state = { path = "../clinical-population-accountant-state" }
+population_accountant_index = { path = "../../zomes/population_accountant_index/coordinator" }
+population_accountant_index_integrity = { path = "../../zomes/population_accountant_index/integrity" }
+thiserror = { workspace = true }

--- a/crates/clinical-population-accountant-canonical-state/Cargo.toml
+++ b/crates/clinical-population-accountant-canonical-state/Cargo.toml
@@ -11,3 +11,9 @@ mycelix-clinical-population-accountant-state = { path = "../clinical-population-
 population_accountant_index = { path = "../../zomes/population_accountant_index/coordinator" }
 population_accountant_index_integrity = { path = "../../zomes/population_accountant_index/integrity" }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+hdk = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
+mycelix-clinical-population-release = { path = "../clinical-population-release" }
+population_accountant_integrity = { path = "../../zomes/population_accountant/integrity" }

--- a/crates/clinical-population-accountant-canonical-state/src/lib.rs
+++ b/crates/clinical-population-accountant-canonical-state/src/lib.rs
@@ -1,0 +1,193 @@
+#![deny(unsafe_code)]
+//! Application boundary for canonical population-accountant state.
+//!
+//! This crate accepts only the nested runtime snapshot produced by the accountant
+//! canonical-index coordinator. It rechecks snapshot shape/lineage and then invokes
+//! the conflict-preserving reducer. Output names retain the bounded-read qualifier;
+//! no result is called globally/current without qualification.
+
+use mycelix_clinical_population_accountant_state::{
+    reduce_population_accountant_state, CanonicalPopulationAccountantStateV1,
+    ObservedPopulationAccountantCorrectionV1, ObservedPopulationAccountantStateV1,
+    PopulationAccountantStateError, PopulationAccountantStateLineageV1,
+};
+use population_accountant_index::{
+    CanonicalAccountantReadBoundaryV1, CanonicalPopulationAccountantLineageSnapshotV1,
+};
+use population_accountant_index_integrity::PopulationAccountantLineageAnchorV1;
+use thiserror::Error;
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum BoundedCanonicalPopulationAccountantStateV1 {
+    NoCanonicalStateObserved,
+    ObservedCurrentWithinBoundedCanonicalRead {
+        action_hash: holo_hash::ActionHash,
+        sequence: u64,
+        query_count: u64,
+    },
+    ConflictWithinBoundedCanonicalRead {
+        competing_state_hashes: Vec<holo_hash::ActionHash>,
+    },
+    NoCurrentStateWithinBoundedCanonicalRead {
+        lineage: Vec<PopulationAccountantStateLineageV1>,
+    },
+    ReviewRequiredWithinBoundedCanonicalRead {
+        lineage: Vec<PopulationAccountantStateLineageV1>,
+    },
+}
+
+pub fn reduce_canonical_population_accountant_snapshot(
+    snapshot: &CanonicalPopulationAccountantLineageSnapshotV1,
+) -> Result<BoundedCanonicalPopulationAccountantStateV1, CanonicalAccountantStateError> {
+    validate_snapshot(snapshot)?;
+
+    let observed: Vec<ObservedPopulationAccountantStateV1> = snapshot
+        .admitted_states
+        .iter()
+        .map(|item| ObservedPopulationAccountantStateV1 {
+            action_hash: item.action_hash.clone(),
+            state: item.state.clone(),
+            corrections: item
+                .corrections
+                .iter()
+                .map(|correction| ObservedPopulationAccountantCorrectionV1 {
+                    action_hash: correction.action_hash.clone(),
+                    correction: correction.correction.clone(),
+                })
+                .collect(),
+        })
+        .collect();
+
+    let reduced = reduce_population_accountant_state(&observed)?;
+    Ok(match reduced {
+        CanonicalPopulationAccountantStateV1::NoTrustedStateObserved => {
+            BoundedCanonicalPopulationAccountantStateV1::NoCanonicalStateObserved
+        }
+        CanonicalPopulationAccountantStateV1::ObservedCurrentWithinRead {
+            action_hash,
+            sequence,
+            query_count,
+        } => BoundedCanonicalPopulationAccountantStateV1::ObservedCurrentWithinBoundedCanonicalRead {
+            action_hash,
+            sequence,
+            query_count,
+        },
+        CanonicalPopulationAccountantStateV1::ConflictWithinRead {
+            competing_state_hashes,
+        } => BoundedCanonicalPopulationAccountantStateV1::ConflictWithinBoundedCanonicalRead {
+            competing_state_hashes,
+        },
+        CanonicalPopulationAccountantStateV1::NoCurrentStateWithinRead { lineage } => {
+            BoundedCanonicalPopulationAccountantStateV1::NoCurrentStateWithinBoundedCanonicalRead {
+                lineage,
+            }
+        }
+        CanonicalPopulationAccountantStateV1::ReviewRequiredWithinRead { lineage } => {
+            BoundedCanonicalPopulationAccountantStateV1::ReviewRequiredWithinBoundedCanonicalRead {
+                lineage,
+            }
+        }
+    })
+}
+
+fn validate_snapshot(
+    snapshot: &CanonicalPopulationAccountantLineageSnapshotV1,
+) -> Result<(), CanonicalAccountantStateError> {
+    if snapshot.read_boundary
+        != CanonicalAccountantReadBoundaryV1::NestedNetworkBackedStableReadsWithFinalClosureChecks
+    {
+        return Err(CanonicalAccountantStateError::UnexpectedReadBoundary);
+    }
+    if snapshot.observation_completed_at < snapshot.observation_started_at {
+        return Err(CanonicalAccountantStateError::InvalidObservationWindow);
+    }
+    if snapshot.observed_state_count != snapshot.admitted_states.len() {
+        return Err(CanonicalAccountantStateError::StateCountMismatch);
+    }
+
+    validate_lineage_anchor(&snapshot.lineage)?;
+
+    let mut correction_count = 0usize;
+    for (index, item) in snapshot.admitted_states.iter().enumerate() {
+        if snapshot.admitted_states[..index]
+            .iter()
+            .any(|previous| previous.action_hash == item.action_hash)
+        {
+            return Err(CanonicalAccountantStateError::DuplicateStateAction);
+        }
+        let expected = PopulationAccountantLineageAnchorV1::from_state(&item.state)
+            .map_err(|_| CanonicalAccountantStateError::InvalidStateLineage)?;
+        if expected != snapshot.lineage {
+            return Err(CanonicalAccountantStateError::CrossLineageState);
+        }
+        if item.observed_correction_target_count != item.corrections.len() {
+            return Err(CanonicalAccountantStateError::CorrectionCountMismatch);
+        }
+        correction_count = correction_count
+            .checked_add(item.corrections.len())
+            .ok_or(CanonicalAccountantStateError::CorrectionCountOverflow)?;
+        for (correction_index, correction) in item.corrections.iter().enumerate() {
+            if item.corrections[..correction_index]
+                .iter()
+                .any(|previous| previous.action_hash == correction.action_hash)
+            {
+                return Err(CanonicalAccountantStateError::DuplicateCorrectionAction);
+            }
+            if correction.correction.state_hash != item.action_hash
+                || correction.correction.private_receipt_commitment
+                    != item.state.projection.private_receipt_commitment
+            {
+                return Err(CanonicalAccountantStateError::CorrectionLineageMismatch);
+            }
+        }
+    }
+    if correction_count != snapshot.observed_total_correction_count {
+        return Err(CanonicalAccountantStateError::TotalCorrectionCountMismatch);
+    }
+    Ok(())
+}
+
+fn validate_lineage_anchor(
+    lineage: &PopulationAccountantLineageAnchorV1,
+) -> Result<(), CanonicalAccountantStateError> {
+    PopulationAccountantLineageAnchorV1::new(
+        lineage.release_policy_digest,
+        lineage.accountant_instance_digest,
+        lineage.accountant_method_digest,
+    )
+    .map_err(|_| CanonicalAccountantStateError::InvalidLineageAnchor)?;
+    if lineage.schema_version != 1 {
+        return Err(CanonicalAccountantStateError::InvalidLineageAnchor);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CanonicalAccountantStateError {
+    #[error("canonical accountant snapshot used an unexpected read boundary")]
+    UnexpectedReadBoundary,
+    #[error("canonical accountant snapshot observation window is invalid")]
+    InvalidObservationWindow,
+    #[error("canonical accountant snapshot state count mismatches its admitted states")]
+    StateCountMismatch,
+    #[error("canonical accountant snapshot contains duplicate state action")]
+    DuplicateStateAction,
+    #[error("canonical accountant lineage anchor is invalid")]
+    InvalidLineageAnchor,
+    #[error("canonical accountant state could not establish its lineage")]
+    InvalidStateLineage,
+    #[error("canonical accountant state crosses the requested lineage")]
+    CrossLineageState,
+    #[error("canonical accountant correction count mismatches materialized corrections")]
+    CorrectionCountMismatch,
+    #[error("canonical accountant correction count overflow")]
+    CorrectionCountOverflow,
+    #[error("canonical accountant snapshot contains duplicate correction action")]
+    DuplicateCorrectionAction,
+    #[error("canonical accountant correction crosses state lineage")]
+    CorrectionLineageMismatch,
+    #[error("canonical accountant total correction count mismatches snapshot metadata")]
+    TotalCorrectionCountMismatch,
+    #[error(transparent)]
+    Reducer(#[from] PopulationAccountantStateError),
+}

--- a/crates/clinical-population-accountant-canonical-state/tests/bounded.rs
+++ b/crates/clinical-population-accountant-canonical-state/tests/bounded.rs
@@ -1,0 +1,125 @@
+use hdk::prelude::Timestamp;
+use holo_hash::ActionHash;
+use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain, StoredDigest};
+use mycelix_clinical_population_accountant_canonical_state::{
+    reduce_canonical_population_accountant_snapshot,
+    BoundedCanonicalPopulationAccountantStateV1,
+};
+use mycelix_clinical_population_release::{
+    PopulationReleaseArtifactKindV1, PopulationReleaseDigestV1, PrivacyLossV1,
+};
+use population_accountant_index::{
+    CanonicalAccountantObservedStateV1, CanonicalAccountantReadBoundaryV1,
+    CanonicalPopulationAccountantLineageSnapshotV1,
+};
+use population_accountant_index_integrity::PopulationAccountantLineageAnchorV1;
+use population_accountant_integrity::{
+    AccountantCommitmentSchemeV1, OpaqueAccountantReceiptCommitmentV1,
+    PopulationAccountantStateProjectionV1, TrustedPopulationAccountantState,
+};
+
+fn action(seed: u8) -> ActionHash {
+    ActionHash::from_raw_36(vec![seed; 36])
+}
+
+fn stored(seed: u8) -> StoredDigest {
+    StoredDigest {
+        algorithm: DigestAlgorithm::Blake3_256,
+        domain: DigestDomain::ClinicalArtifact,
+        value: [seed; 32],
+    }
+}
+
+fn policy() -> PopulationReleaseDigestV1 {
+    PopulationReleaseDigestV1 {
+        kind: PopulationReleaseArtifactKindV1::ReleasePolicy,
+        value: [9; 32],
+    }
+}
+
+fn lineage() -> PopulationAccountantLineageAnchorV1 {
+    PopulationAccountantLineageAnchorV1::new(policy(), stored(2), stored(3)).unwrap()
+}
+
+fn admitted(seed: u8) -> CanonicalAccountantObservedStateV1 {
+    CanonicalAccountantObservedStateV1 {
+        action_hash: action(seed),
+        state: TrustedPopulationAccountantState {
+            projection: PopulationAccountantStateProjectionV1 {
+                schema_version: 1,
+                state_id: format!("state-{seed}"),
+                release_policy_digest: policy(),
+                accountant_instance_digest: stored(2),
+                accountant_method_digest: stored(3),
+                sequence: 0,
+                query_count: 0,
+                cumulative_privacy_loss: PrivacyLossV1::ZERO,
+                previous_state_hash: None,
+                private_receipt_commitment: OpaqueAccountantReceiptCommitmentV1 {
+                    scheme: AccountantCommitmentSchemeV1::Blake3Keyed,
+                    value: [seed; 32],
+                },
+            },
+            verifier_authorization_hash: action(seed.saturating_add(100)),
+        },
+        corrections: Vec::new(),
+        observed_correction_target_count: 0,
+    }
+}
+
+fn snapshot(states: Vec<CanonicalAccountantObservedStateV1>) -> CanonicalPopulationAccountantLineageSnapshotV1 {
+    CanonicalPopulationAccountantLineageSnapshotV1 {
+        lineage: lineage(),
+        observed_state_count: states.len(),
+        observed_total_correction_count: 0,
+        admitted_states: states,
+        read_boundary: CanonicalAccountantReadBoundaryV1::NestedNetworkBackedStableReadsWithFinalClosureChecks,
+        observation_started_at: Timestamp::from_micros(10),
+        observation_completed_at: Timestamp::from_micros(20),
+    }
+}
+
+#[test]
+fn empty_canonical_snapshot_is_not_an_invented_budget_state() {
+    let result = reduce_canonical_population_accountant_snapshot(&snapshot(Vec::new())).unwrap();
+    assert!(matches!(
+        result,
+        BoundedCanonicalPopulationAccountantStateV1::NoCanonicalStateObserved
+    ));
+}
+
+#[test]
+fn one_admitted_genesis_is_only_current_within_bounded_canonical_read() {
+    let result = reduce_canonical_population_accountant_snapshot(&snapshot(vec![admitted(1)])).unwrap();
+    assert!(matches!(
+        result,
+        BoundedCanonicalPopulationAccountantStateV1::ObservedCurrentWithinBoundedCanonicalRead {
+            sequence: 0,
+            query_count: 0,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn two_admitted_genesis_states_are_conflict_not_latest_wins() {
+    let result = reduce_canonical_population_accountant_snapshot(&snapshot(vec![admitted(1), admitted(2)])).unwrap();
+    assert!(matches!(
+        result,
+        BoundedCanonicalPopulationAccountantStateV1::ConflictWithinBoundedCanonicalRead { .. }
+    ));
+}
+
+#[test]
+fn snapshot_count_mismatch_fails_closed() {
+    let mut value = snapshot(vec![admitted(1)]);
+    value.observed_state_count = 2;
+    assert!(reduce_canonical_population_accountant_snapshot(&value).is_err());
+}
+
+#[test]
+fn cross_lineage_state_fails_closed() {
+    let mut value = snapshot(vec![admitted(1)]);
+    value.admitted_states[0].state.projection.accountant_method_digest = stored(7);
+    assert!(reduce_canonical_population_accountant_snapshot(&value).is_err());
+}

--- a/crates/clinical-population-accountant-state/tests/reducer.rs
+++ b/crates/clinical-population-accountant-state/tests/reducer.rs
@@ -136,11 +136,12 @@ fn missing_predecessor_fails_closed() {
 #[test]
 fn invalidated_ancestor_contaminates_descendant_current_claim() {
     let mut root = observed(1, 0, None);
-    root.corrections.push(correction(
+    let invalidation = correction(
         20,
         &root,
         PopulationAccountantCorrectionReason::AccountantImplementationRevoked,
-    ));
+    );
+    root.corrections.push(invalidation);
     let child = observed(2, 1, Some(root.action_hash.clone()));
     let result = reduce_population_accountant_state(&[root, child]).unwrap();
     assert!(matches!(

--- a/dna/dna.yaml
+++ b/dna/dna.yaml
@@ -93,6 +93,8 @@ integrity:
       path: ../target/wasm32-unknown-unknown/release/clinical_causality_index_integrity.wasm
     - name: population_accountant_integrity
       path: ../target/wasm32-unknown-unknown/release/population_accountant_integrity.wasm
+    - name: population_accountant_index_integrity
+      path: ../target/wasm32-unknown-unknown/release/population_accountant_index_integrity.wasm
     - name: consent_integrity
       path: ../target/wasm32-unknown-unknown/release/consent_integrity.wasm
     - name: bridge_integrity
@@ -151,6 +153,11 @@ coordinator:
     - name: population_accountant
       path: ../target/wasm32-unknown-unknown/release/population_accountant.wasm
       dependencies:
+        - name: population_accountant_integrity
+    - name: population_accountant_index
+      path: ../target/wasm32-unknown-unknown/release/population_accountant_index.wasm
+      dependencies:
+        - name: population_accountant_index_integrity
         - name: population_accountant_integrity
     - name: consent
       path: ../target/wasm32-unknown-unknown/release/consent.wasm

--- a/docs/security/CLINICAL_POPULATION_ACCOUNTANT_INDEX_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_POPULATION_ACCOUNTANT_INDEX_QUALIFICATION_CHECKLIST.md
@@ -1,0 +1,76 @@
+# Clinical Population Accountant Canonical Index v1 — Qualification Checklist
+
+This checklist defines required evidence. It is not qualification evidence itself.
+
+## Build/package
+
+- [ ] `cargo fmt -- --check`
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings`
+- [ ] workspace builds index integrity/coordinator and canonical-state crate
+- [ ] DNA packages both accountant-index zomes
+- [ ] exact-head CI completes successfully
+
+## Deterministic anchor
+
+- [ ] same release-policy/accountant-instance/accountant-method tuple -> same anchor
+- [ ] changing any tuple member -> different anchor
+- [ ] non-release-policy digest kind rejects
+- [ ] zero/malformed accountant digests reject
+- [ ] synthetic anchor entry itself cannot be committed
+
+## Canonical admission
+
+- [ ] admission target must be ActionHash to valid trusted accountant state
+- [ ] base must equal target state's deterministic lineage anchor
+- [ ] admission author must equal target state author
+- [ ] unrelated third-party admission rejects
+- [ ] cross-lineage admission rejects
+- [ ] admission-link deletion rejects
+
+## Nested materialization
+
+- [ ] admission membership stable across outer A/B reads
+- [ ] every state's correction membership stable across A/B reads
+- [ ] every correction set is checked once more after outer membership closure
+- [ ] state arriving mid-read causes retry/failure
+- [ ] correction arriving mid-read causes retry/failure
+- [ ] missing admitted-state target fails closed
+- [ ] missing correction target fails closed
+- [ ] cross-lineage state/correction fails closed
+- [ ] state/correction fan-out bounds execute
+
+## Canonical adapter
+
+- [ ] only nested canonical snapshot is accepted by high-assurance API
+- [ ] state/correction count drift rejects
+- [ ] duplicate state/correction actions reject
+- [ ] invalid observation window rejects
+- [ ] cross-lineage state rejects
+- [ ] two admitted genesis states -> conflict
+- [ ] sibling successors -> conflict
+- [ ] missing predecessor -> fail closed
+- [ ] one clean chain -> `ObservedCurrentWithinBoundedCanonicalRead`
+- [ ] no output type exposes an unqualified global `Current`
+
+## Privacy
+
+- [ ] index key contains no query/output/patient/cohort/private receipt identifier
+- [ ] public keyed receipt commitments stay only on the underlying trusted state
+- [ ] no cross-key commitment correlator is introduced by indexing
+
+## Runtime / adversarial
+
+- [ ] conductor test: omitted unadmitted state does not enter canonical result
+- [ ] conductor test: once conflicting state is admitted and propagated it becomes visible conflict
+- [ ] conductor test: outer membership race fails/retries
+- [ ] conductor test: inner correction race fails/retries
+- [ ] conductor test: third-party admission fails integrity validation
+- [ ] conductor test: link deletion fails integrity validation
+
+## Remaining promotion conditions
+
+- [ ] P0 #72 exact cross-zome source-entry-definition proof resolved or explicitly compensated with conductor evidence
+- [ ] protected exact receipt -> keyed commitment binding is verifier-owned and tested
+- [ ] interactive population release consumes the bounded canonical trusted accountant result, not caller-provided accountant receipts
+
+Do not close P0 #92 solely from source review. Close it only after the exact-head runtime/conductor evidence above exists.

--- a/docs/security/CLINICAL_POPULATION_ACCOUNTANT_INDEX_V1.md
+++ b/docs/security/CLINICAL_POPULATION_ACCOUNTANT_INDEX_V1.md
@@ -1,0 +1,86 @@
+# Clinical Population Accountant Canonical Index v1
+
+## Purpose
+
+Close the caller-supplied-read-set gap from P0 #92 without claiming that an eventually consistent DHT can prove global absence.
+
+The high-assurance path distinguishes:
+
+1. DHT-valid trusted accountant state;
+2. canonical admission into one exact accountant lineage;
+3. bounded nested runtime snapshot of admitted states and corrections;
+4. conflict-preserving canonical reduction.
+
+## Deterministic lineage identity
+
+The synthetic index anchor is derived only from the already-public tuple:
+
+- release-policy digest;
+- accountant-instance digest;
+- accountant-method digest.
+
+It contains no query, output, patient, cohort, or protected receipt identity.
+
+The synthetic anchor entry is never committed; only its deterministic `EntryHash` is used as the link base.
+
+## Canonical admission
+
+A trusted accountant state can exist without index admission, but the high-assurance canonical read model ignores unadmitted state.
+
+A `LineageToStates` link is valid only when:
+
+- the target resolves as a DHT-valid trusted accountant state;
+- the link base equals the deterministic anchor derived from that exact state's lineage;
+- the link author is the same agent that authored the target state.
+
+Third parties cannot canonize another verifier's state. Admission links are append-only.
+
+## Bounded nested materialization
+
+`materialize_canonical_population_accountant_lineage` performs:
+
+1. network-backed admitted-state read A;
+2. for every admitted state, correction-set read A, materialization, correction-set read B;
+3. network-backed admitted-state read B and requires A == B;
+4. final correction-set read C for every state and requires it still equals A/B.
+
+V1 bounds:
+
+- at most 4,096 admitted states per lineage;
+- at most 256 corrections per state;
+- at most 16,384 corrections across one snapshot.
+
+Any membership/correction race observed inside the window causes the materialization to fail and require retry.
+
+## Canonical application boundary
+
+`mycelix-clinical-population-accountant-canonical-state` accepts only the nested runtime snapshot type. It rechecks:
+
+- read-boundary marker;
+- observation time ordering;
+- state and correction counts;
+- duplicate state/correction actions;
+- exact lineage tuple for every state;
+- exact correction target and private-receipt commitment.
+
+It then invokes the fork-preserving reducer and renames the outward current state to:
+
+`ObservedCurrentWithinBoundedCanonicalRead`.
+
+There is deliberately no unqualified `Current` result.
+
+## Fork semantics
+
+Multiple admitted genesis states, sibling successors, or multiple live leaves become explicit conflict. Timestamp, action order, insertion order, and state ID never choose a winner.
+
+## Non-claims
+
+This design does not prove global DHT completeness. An unpropagated state/admission/correction can remain unseen by one conductor. The returned snapshot proves only that this conductor's network-backed observed membership remained stable through the bounded closure sequence.
+
+The pure canonical adapter trusts that its snapshot came from the runtime materializer; deserializing a compatible wire object is not cryptographic proof of runtime provenance.
+
+P0 #72 exact source-entry-definition proof remains a promotion concern for cross-zome addressable dependencies.
+
+## Security principle
+
+Canonical means **admitted under the canonical index**, not **globally complete truth**.

--- a/zomes/population_accountant_index/coordinator/Cargo.toml
+++ b/zomes/population_accountant_index/coordinator/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "population_accountant_index"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Canonical admission and bounded discovery for trusted population accountant state"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { workspace = true }
+serde = { workspace = true }
+population_accountant_index_integrity = { path = "../integrity" }
+population_accountant_integrity = { path = "../../population_accountant/integrity" }
+
+[features]
+default = []

--- a/zomes/population_accountant_index/coordinator/src/lib.rs
+++ b/zomes/population_accountant_index/coordinator/src/lib.rs
@@ -1,0 +1,234 @@
+#![deny(unsafe_code)]
+//! Canonical admission and bounded discovery for trusted population-accountant state.
+//!
+//! The high-assurance read path admits only integrity-validated index members and
+//! returns a nested network-backed snapshot whose observed state membership and
+//! every observed correction set remain stable through final closure checks.
+//! This is not a proof of global DHT completeness.
+
+use hdk::prelude::*;
+use population_accountant_index_integrity::{
+    accountant_lineage_anchor_hash, LinkTypes, PopulationAccountantLineageAnchorV1,
+};
+use population_accountant_integrity::{
+    LinkTypes as AccountantLinkTypes, PopulationAccountantStateCorrection,
+    TrustedPopulationAccountantState,
+};
+
+const MAX_STATES_PER_LINEAGE: usize = 4096;
+const MAX_CORRECTIONS_PER_STATE: usize = 256;
+const MAX_TOTAL_CORRECTIONS: usize = 16_384;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CanonicalAccountantObservedCorrectionV1 {
+    pub action_hash: ActionHash,
+    pub correction: PopulationAccountantStateCorrection,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CanonicalAccountantObservedStateV1 {
+    pub action_hash: ActionHash,
+    pub state: TrustedPopulationAccountantState,
+    pub corrections: Vec<CanonicalAccountantObservedCorrectionV1>,
+    pub observed_correction_target_count: usize,
+}
+
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CanonicalAccountantReadBoundaryV1 {
+    NestedNetworkBackedStableReadsWithFinalClosureChecks,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct CanonicalPopulationAccountantLineageSnapshotV1 {
+    pub lineage: PopulationAccountantLineageAnchorV1,
+    pub admitted_states: Vec<CanonicalAccountantObservedStateV1>,
+    pub observed_state_count: usize,
+    pub observed_total_correction_count: usize,
+    pub read_boundary: CanonicalAccountantReadBoundaryV1,
+    pub observation_started_at: Timestamp,
+    pub observation_completed_at: Timestamp,
+}
+
+#[hdk_extern]
+pub fn admit_population_accountant_state(state_hash: ActionHash) -> ExternResult<ActionHash> {
+    let record = get(state_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
+        WasmErrorInner::Guest("Trusted population accountant state was not found".into())
+    ))?;
+    let state: TrustedPopulationAccountantState =
+        decode_entry(&record, "trusted population accountant state")?;
+    let lineage = PopulationAccountantLineageAnchorV1::from_state(&state)?;
+    let anchor = accountant_lineage_anchor_hash(&lineage)?;
+    create_link(anchor, state_hash, LinkTypes::LineageToStates, ())
+}
+
+/// Materialize one exact accountant lineage from its deterministic canonical-admission index.
+///
+/// Closure sequence:
+/// 1. read admitted state set A;
+/// 2. for each state, stable-double-read and materialize corrections A/B;
+/// 3. read admitted state set B and require A == B;
+/// 4. re-read every state's correction set C and require it still equals A/B.
+///
+/// This proves only a bounded stable observed view at this conductor. It cannot prove
+/// absence of unpropagated DHT activity or future transitions.
+#[hdk_extern]
+pub fn materialize_canonical_population_accountant_lineage(
+    lineage: PopulationAccountantLineageAnchorV1,
+) -> ExternResult<CanonicalPopulationAccountantLineageSnapshotV1> {
+    let observation_started_at = sys_time()?;
+    let anchor = accountant_lineage_anchor_hash(&lineage)?;
+    let first_state_hashes = observed_state_hashes(&anchor)?;
+    let mut admitted_states = Vec::with_capacity(first_state_hashes.len());
+    let mut total_corrections = 0usize;
+
+    for state_hash in &first_state_hashes {
+        let record = get(state_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
+            WasmErrorInner::Guest(
+                "Observed accountant admission target could not be materialized".into()
+            )
+        ))?;
+        let state: TrustedPopulationAccountantState =
+            decode_entry(&record, "trusted population accountant state")?;
+        let actual_lineage = PopulationAccountantLineageAnchorV1::from_state(&state)?;
+        if actual_lineage != lineage {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Observed accountant admission crosses canonical lineage".into()
+            )));
+        }
+
+        let first_corrections = observed_correction_hashes(state_hash)?;
+        total_corrections = total_corrections
+            .checked_add(first_corrections.len())
+            .ok_or(wasm_error!(WasmErrorInner::Guest(
+                "Population accountant correction count overflow".into()
+            )))?;
+        if total_corrections > MAX_TOTAL_CORRECTIONS {
+            return Err(wasm_error!(WasmErrorInner::Guest(format!(
+                "Population accountant lineage has more than {MAX_TOTAL_CORRECTIONS} observed corrections"
+            ))));
+        }
+
+        let mut corrections = Vec::with_capacity(first_corrections.len());
+        for correction_hash in &first_corrections {
+            let correction_record =
+                get(correction_hash.clone(), GetOptions::network())?.ok_or(wasm_error!(
+                    WasmErrorInner::Guest(
+                        "Observed accountant correction could not be materialized".into()
+                    )
+                ))?;
+            let correction: PopulationAccountantStateCorrection =
+                decode_entry(&correction_record, "population accountant correction")?;
+            if correction.state_hash != *state_hash
+                || correction.private_receipt_commitment
+                    != state.projection.private_receipt_commitment
+            {
+                return Err(wasm_error!(WasmErrorInner::Guest(
+                    "Observed accountant correction crosses state lineage".into()
+                )));
+            }
+            corrections.push(CanonicalAccountantObservedCorrectionV1 {
+                action_hash: correction_hash.clone(),
+                correction,
+            });
+        }
+
+        let second_corrections = observed_correction_hashes(state_hash)?;
+        if first_corrections != second_corrections {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Accountant correction set changed during inner materialization; retry".into()
+            )));
+        }
+
+        admitted_states.push(CanonicalAccountantObservedStateV1 {
+            action_hash: state_hash.clone(),
+            state,
+            corrections,
+            observed_correction_target_count: first_corrections.len(),
+        });
+    }
+
+    let second_state_hashes = observed_state_hashes(&anchor)?;
+    if first_state_hashes != second_state_hashes {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Canonical accountant admission set changed during materialization; retry".into()
+        )));
+    }
+
+    for state in &admitted_states {
+        let final_corrections = observed_correction_hashes(&state.action_hash)?;
+        let expected: Vec<ActionHash> = state
+            .corrections
+            .iter()
+            .map(|value| value.action_hash.clone())
+            .collect();
+        if final_corrections != expected {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Accountant correction set changed before final snapshot closure; retry".into()
+            )));
+        }
+    }
+
+    let observation_completed_at = sys_time()?;
+    Ok(CanonicalPopulationAccountantLineageSnapshotV1 {
+        lineage,
+        admitted_states,
+        observed_state_count: first_state_hashes.len(),
+        observed_total_correction_count: total_corrections,
+        read_boundary: CanonicalAccountantReadBoundaryV1::NestedNetworkBackedStableReadsWithFinalClosureChecks,
+        observation_started_at,
+        observation_completed_at,
+    })
+}
+
+fn observed_state_hashes(anchor: &EntryHash) -> ExternResult<Vec<ActionHash>> {
+    let links = get_links(
+        LinkQuery::try_new(anchor.clone(), LinkTypes::LineageToStates)?,
+        GetStrategy::Network,
+    )?;
+    if links.len() > MAX_STATES_PER_LINEAGE {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Population accountant lineage has more than {MAX_STATES_PER_LINEAGE} admitted states"
+        ))));
+    }
+    canonical_action_targets(links, "accountant state admission")
+}
+
+fn observed_correction_hashes(state_hash: &ActionHash) -> ExternResult<Vec<ActionHash>> {
+    let links = get_links(
+        LinkQuery::try_new(state_hash.clone(), AccountantLinkTypes::StateToCorrections)?,
+        GetStrategy::Network,
+    )?;
+    if links.len() > MAX_CORRECTIONS_PER_STATE {
+        return Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "Population accountant state has more than {MAX_CORRECTIONS_PER_STATE} corrections"
+        ))));
+    }
+    canonical_action_targets(links, "accountant correction")
+}
+
+fn canonical_action_targets(links: Vec<Link>, label: &'static str) -> ExternResult<Vec<ActionHash>> {
+    let mut targets = Vec::with_capacity(links.len());
+    for link in links {
+        let target = link.target.into_action_hash().ok_or(wasm_error!(
+            WasmErrorInner::Guest(format!("{label} link target must be ActionHash"))
+        ))?;
+        if !targets.contains(&target) {
+            targets.push(target);
+        }
+    }
+    targets.sort_by(|left, right| left.get_raw_36().cmp(right.get_raw_36()));
+    Ok(targets)
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}

--- a/zomes/population_accountant_index/integrity/Cargo.toml
+++ b/zomes/population_accountant_index/integrity/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "population_accountant_index_integrity"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+description = "Canonical admission index for trusted population accountant state"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdi = { workspace = true }
+holochain_serialized_bytes = { workspace = true }
+serde = { workspace = true }
+population_accountant_integrity = { path = "../../population_accountant/integrity" }
+
+[features]
+default = []

--- a/zomes/population_accountant_index/integrity/Cargo.toml
+++ b/zomes/population_accountant_index/integrity/Cargo.toml
@@ -12,6 +12,8 @@ crate-type = ["cdylib", "rlib"]
 hdi = { workspace = true }
 holochain_serialized_bytes = { workspace = true }
 serde = { workspace = true }
+mycelix-clinical-integrity = { path = "../../../crates/clinical-integrity" }
+mycelix-clinical-population-release = { path = "../../../crates/clinical-population-release" }
 population_accountant_integrity = { path = "../../population_accountant/integrity" }
 
 [features]

--- a/zomes/population_accountant_index/integrity/src/lib.rs
+++ b/zomes/population_accountant_index/integrity/src/lib.rs
@@ -1,0 +1,243 @@
+#![deny(unsafe_code)]
+#![allow(clippy::collapsible_match)]
+//! Canonical admission index for DNA-trusted population accountant states.
+//!
+//! Individual accountant states may exist without admission. Only states linked
+//! through this integrity boundary participate in the high-assurance canonical
+//! lineage read model. The deterministic synthetic anchor is derived only from the
+//! already-public release-policy/accountant-instance/accountant-method tuple.
+
+use hdi::prelude::*;
+use mycelix_clinical_integrity::StoredDigest;
+use mycelix_clinical_population_release::{
+    PopulationReleaseArtifactKindV1, PopulationReleaseDigestV1,
+};
+use population_accountant_integrity::TrustedPopulationAccountantState;
+
+const INDEX_SCHEMA_VERSION: u16 = 1;
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq, Eq)]
+pub struct PopulationAccountantLineageAnchorV1 {
+    pub schema_version: u16,
+    pub release_policy_digest: PopulationReleaseDigestV1,
+    pub accountant_instance_digest: StoredDigest,
+    pub accountant_method_digest: StoredDigest,
+}
+
+impl PopulationAccountantLineageAnchorV1 {
+    pub fn new(
+        release_policy_digest: PopulationReleaseDigestV1,
+        accountant_instance_digest: StoredDigest,
+        accountant_method_digest: StoredDigest,
+    ) -> ExternResult<Self> {
+        release_policy_digest
+            .validate()
+            .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+        if release_policy_digest.kind != PopulationReleaseArtifactKindV1::ReleasePolicy {
+            return Err(wasm_error!(WasmErrorInner::Guest(
+                "Accountant lineage anchor requires release-policy digest".into()
+            )));
+        }
+        accountant_instance_digest
+            .validate_shape()
+            .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+        accountant_method_digest
+            .validate_shape()
+            .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?;
+        Ok(Self {
+            schema_version: INDEX_SCHEMA_VERSION,
+            release_policy_digest,
+            accountant_instance_digest,
+            accountant_method_digest,
+        })
+    }
+
+    pub fn from_state(state: &TrustedPopulationAccountantState) -> ExternResult<Self> {
+        Self::new(
+            state.projection.release_policy_digest,
+            state.projection.accountant_instance_digest,
+            state.projection.accountant_method_digest,
+        )
+    }
+}
+
+pub fn accountant_lineage_anchor_hash(
+    anchor: &PopulationAccountantLineageAnchorV1,
+) -> ExternResult<EntryHash> {
+    if anchor.schema_version != INDEX_SCHEMA_VERSION {
+        return Err(wasm_error!(WasmErrorInner::Guest(
+            "Unsupported population accountant lineage anchor version".into()
+        )));
+    }
+    hash_entry(anchor)
+}
+
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    LineageAnchor(PopulationAccountantLineageAnchorV1),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    LineageToStates,
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(_) => invalid(
+            "Population accountant lineage index has no committed entries; anchors are synthetic",
+        ),
+        FlatOp::RegisterUpdate(_) => invalid(
+            "Population accountant lineage index entries cannot be updated",
+        ),
+        FlatOp::RegisterDelete(_) => invalid(
+            "Population accountant lineage index entries cannot be deleted",
+        ),
+        FlatOp::RegisterCreateLink {
+            link_type,
+            base_address,
+            target_address,
+            action,
+            ..
+        } => validate_create_link(link_type, base_address, target_address, action),
+        FlatOp::RegisterDeleteLink { .. } => invalid(
+            "Canonical population accountant admission links are append-only",
+        ),
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_create_link(
+    link_type: LinkTypes,
+    base_address: AnyLinkableHash,
+    target_address: AnyLinkableHash,
+    action: CreateLink,
+) -> ExternResult<ValidateCallbackResult> {
+    match link_type {
+        LinkTypes::LineageToStates => {
+            let base = base_address.into_entry_hash().ok_or(wasm_error!(
+                WasmErrorInner::Guest(
+                    "Population accountant admission link base must be an EntryHash".into()
+                )
+            ))?;
+            let target = target_address.into_action_hash().ok_or(wasm_error!(
+                WasmErrorInner::Guest(
+                    "Population accountant admission link target must be an ActionHash".into()
+                )
+            ))?;
+
+            let record = must_get_valid_record(target)?;
+            let state: TrustedPopulationAccountantState =
+                decode_entry(&record, "trusted population accountant state")?;
+            let shape = state.projection.validate_shape()?;
+            if !matches!(shape, ValidateCallbackResult::Valid) {
+                return Ok(shape);
+            }
+            let anchor = PopulationAccountantLineageAnchorV1::from_state(&state)?;
+            let expected = accountant_lineage_anchor_hash(&anchor)?;
+            if base != expected {
+                return invalid(
+                    "Population accountant admission link base does not match state lineage",
+                );
+            }
+            if record.action().author() != &action.author {
+                return invalid(
+                    "Population accountant admission link must be authored by state author",
+                );
+            }
+            Ok(ValidateCallbackResult::Valid)
+        }
+    }
+}
+
+fn decode_entry<T>(record: &Record, label: &'static str) -> ExternResult<T>
+where
+    T: TryFrom<SerializedBytes, Error = SerializedBytesError>,
+{
+    record
+        .entry()
+        .to_app_option::<T>()
+        .map_err(|error| wasm_error!(WasmErrorInner::Guest(error.to_string())))?
+        .ok_or(wasm_error!(WasmErrorInner::Guest(format!(
+            "Referenced {label} entry is missing or wrong type"
+        ))))
+}
+
+fn invalid(message: impl Into<String>) -> ExternResult<ValidateCallbackResult> {
+    Ok(ValidateCallbackResult::Invalid(message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain};
+
+    fn stored(seed: u8) -> StoredDigest {
+        StoredDigest {
+            algorithm: DigestAlgorithm::Blake3_256,
+            domain: DigestDomain::ClinicalArtifact,
+            value: [seed; 32],
+        }
+    }
+
+    fn policy(seed: u8) -> PopulationReleaseDigestV1 {
+        PopulationReleaseDigestV1 {
+            kind: PopulationReleaseArtifactKindV1::ReleasePolicy,
+            value: [seed; 32],
+        }
+    }
+
+    fn anchor() -> PopulationAccountantLineageAnchorV1 {
+        PopulationAccountantLineageAnchorV1::new(policy(1), stored(2), stored(3)).unwrap()
+    }
+
+    #[test]
+    fn same_lineage_has_same_anchor() {
+        assert_eq!(
+            accountant_lineage_anchor_hash(&anchor()).unwrap(),
+            accountant_lineage_anchor_hash(&anchor()).unwrap()
+        );
+    }
+
+    #[test]
+    fn policy_is_part_of_anchor_identity() {
+        let a = anchor();
+        let b = PopulationAccountantLineageAnchorV1::new(policy(4), stored(2), stored(3)).unwrap();
+        assert_ne!(
+            accountant_lineage_anchor_hash(&a).unwrap(),
+            accountant_lineage_anchor_hash(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn accountant_instance_is_part_of_anchor_identity() {
+        let a = anchor();
+        let b = PopulationAccountantLineageAnchorV1::new(policy(1), stored(4), stored(3)).unwrap();
+        assert_ne!(
+            accountant_lineage_anchor_hash(&a).unwrap(),
+            accountant_lineage_anchor_hash(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn accountant_method_is_part_of_anchor_identity() {
+        let a = anchor();
+        let b = PopulationAccountantLineageAnchorV1::new(policy(1), stored(2), stored(4)).unwrap();
+        assert_ne!(
+            accountant_lineage_anchor_hash(&a).unwrap(),
+            accountant_lineage_anchor_hash(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn wrong_policy_digest_kind_is_rejected() {
+        let wrong = PopulationReleaseDigestV1 {
+            kind: PopulationReleaseArtifactKindV1::ReleaseReceipt,
+            value: [1; 32],
+        };
+        assert!(PopulationAccountantLineageAnchorV1::new(wrong, stored(2), stored(3)).is_err());
+    }
+}


### PR DESCRIPTION
## Stack

Depends on #93 -> #91 -> #88 -> #87 -> #86 -> #85 -> #84 -> #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

## Why

#93 establishes DNA-trusted individual accountant states and a reducer that detects forks in a supplied set. P0 #92 identified the remaining gap: a caller could omit a sibling successor or alternate genesis from that supplied set.

This tranche adds canonical admission/discovery for one exact `(release policy, accountant instance, accountant method)` lineage.

## Canonical admission

A deterministic synthetic anchor is derived only from the already-public lineage tuple. It contains no query/output/patient/cohort/private-receipt identifier.

A state participates in the high-assurance canonical read model only after an append-only `LineageToStates` admission link that:

- targets a valid trusted accountant-state action;
- uses the exact deterministic lineage anchor;
- is authored by the same verifier that authored the target state.

Third parties cannot canonize another verifier's state. No extra trust-root hierarchy is introduced.

## Nested bounded materialization

The runtime performs:

1. admitted-state read A;
2. for every state, correction read A -> materialize -> correction read B;
3. admitted-state read B and require A == B;
4. final correction-set read C for every state and require it still equals A/B.

Any observed membership/correction race forces retry. V1 caps state and correction fan-out.

## Canonical application boundary

`mycelix-clinical-population-accountant-canonical-state` accepts only the nested runtime snapshot, rechecks counts/lineage/timestamps, then invokes the fork-preserving reducer.

The outward success name is intentionally:

`ObservedCurrentWithinBoundedCanonicalRead`

There is no unqualified global `Current` result.

Two admitted genesis states or sibling successors become explicit conflict; timestamp/action/insertion order never picks a winner.

## Non-claim

This does not make an eventually consistent DHT globally complete. The snapshot proves only that this conductor's network-backed observed membership stayed stable through the bounded closure sequence. An unpropagated future/remote state may still be unseen.

P0 #72 exact cross-zome source-entry-definition proof remains a promotion concern.

## Qualification

See:
- `docs/security/CLINICAL_POPULATION_ACCOUNTANT_INDEX_V1.md`
- `docs/security/CLINICAL_POPULATION_ACCOUNTANT_INDEX_QUALIFICATION_CHECKLIST.md`

P0 #92 remains open until exact-head conductor evidence covers omitted/unadmitted states, admitted fork visibility, mid-read membership/correction races, third-party admission rejection, and link-delete rejection.

This PR remains draft until exact-head CI executes successfully.