### PR TITLE
privacy(population): bind interactive release to canonical accountant state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ members = [
     "crates/clinical-population-release",
     "crates/clinical-population-accountant-state",
     "crates/clinical-population-accountant-canonical-state",
+    "crates/clinical-population-interactive-release",
 
     # ── Tier 3: Behavioral Health (restored 2026-03-26) ──
     "zomes/mental_health/integrity",

--- a/crates/clinical-population-interactive-release/Cargo.toml
+++ b/crates/clinical-population-interactive-release/Cargo.toml
@@ -19,3 +19,6 @@ mycelix-clinical-population-release = { path = "../clinical-population-release" 
 mycelix-clinical-population-accountant-canonical-state = { path = "../clinical-population-accountant-canonical-state" }
 population_accountant_index = { path = "../../zomes/population_accountant_index/coordinator" }
 population_accountant_integrity = { path = "../../zomes/population_accountant/integrity" }
+
+[dev-dependencies]
+population_accountant_index_integrity = { path = "../../zomes/population_accountant_index/integrity" }

--- a/crates/clinical-population-interactive-release/Cargo.toml
+++ b/crates/clinical-population-interactive-release/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 holo_hash = { workspace = true }
 holochain_zome_types = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
 mycelix-clinical-population-release = { path = "../clinical-population-release" }
 mycelix-clinical-population-accountant-canonical-state = { path = "../clinical-population-accountant-canonical-state" }
 population_accountant_index = { path = "../../zomes/population_accountant_index/coordinator" }

--- a/crates/clinical-population-interactive-release/Cargo.toml
+++ b/crates/clinical-population-interactive-release/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mycelix-clinical-population-interactive-release"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "High-assurance interactive DP release gate bound to canonical trusted accountant state"
+
+[dependencies]
+blake3 = "1.8.5"
+hmac = "0.12"
+sha2 = "0.10"
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+holo_hash = { workspace = true }
+holochain_zome_types = { workspace = true }
+mycelix-clinical-population-release = { path = "../clinical-population-release" }
+mycelix-clinical-population-accountant-canonical-state = { path = "../clinical-population-accountant-canonical-state" }
+population_accountant_index = { path = "../../zomes/population_accountant_index/coordinator" }
+population_accountant_integrity = { path = "../../zomes/population_accountant/integrity" }

--- a/crates/clinical-population-interactive-release/README.md
+++ b/crates/clinical-population-interactive-release/README.md
@@ -1,0 +1,15 @@
+# mycelix-clinical-population-interactive-release
+
+High-assurance authorization boundary for interactive differential-privacy population releases.
+
+This crate does **not** generate DP noise and does not replace the population-release preflight. It composes three independently reviewed layers:
+
+1. exact DP request/mechanism/output + protected accountant-receipt validation;
+2. DNA-rooted trusted population-accountant states;
+3. canonically admitted, bounded conflict-preserving accountant-state discovery.
+
+Only after those layers agree does it mint `TrustedInteractivePopulationReleaseCapabilityV1`.
+
+The capability is intentionally a distinct Rust type from the lower-level `PopulationReleaseCapabilityV1`. Production interactive release sinks should accept only the trusted capability.
+
+See `docs/security/CLINICAL_POPULATION_INTERACTIVE_RELEASE_V1.md` and the qualification checklist for threat model and promotion requirements.

--- a/crates/clinical-population-interactive-release/src/lib.rs
+++ b/crates/clinical-population-interactive-release/src/lib.rs
@@ -1,0 +1,452 @@
+#![deny(unsafe_code)]
+//! High-assurance interactive differential-privacy release gate.
+//!
+//! The lower-level population-release crate validates DP request/accountant structure.
+//! This crate adds the trust conditions required before an interactive output can be
+//! treated as release-authorized: the protected accountant receipts must match the
+//! keyed commitments in DNA-qualified public accountant states, the `after` state must
+//! be the sole bounded-canonical current leaf, and its predecessor must be the exact
+//! trusted `before` state. No caller-supplied accountant vector is accepted here.
+
+use hmac::{Hmac, Mac};
+use holo_hash::ActionHash;
+use mycelix_clinical_population_accountant_canonical_state::{
+    reduce_canonical_population_accountant_snapshot,
+    BoundedCanonicalPopulationAccountantStateV1, CanonicalAccountantStateError,
+};
+use mycelix_clinical_population_release::{
+    InteractiveDpReleaseRequestV1, PopulationReleaseDigestV1, PopulationReleaseError,
+    PopulationReleaseModeV1, PopulationReleasePolicyV1, PopulationReleaseRequestV1,
+    PrivacyAccountantReceiptV1,
+};
+use population_accountant_index::CanonicalPopulationAccountantLineageSnapshotV1;
+use population_accountant_integrity::{
+    AccountantCommitmentSchemeV1, OpaqueAccountantReceiptCommitmentV1,
+    TrustedPopulationAccountantState,
+};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use thiserror::Error;
+
+const PRIVATE_RECEIPT_COMMITMENT_CONTEXT: &[u8] =
+    b"mycelix.health.population-accountant-private-receipt.v1";
+const TRUSTED_RELEASE_HASH_CONTEXT: &str =
+    "mycelix.health.population-interactive-release-receipt.v1";
+const FRAME_VERSION: u8 = 1;
+/// The canonical read must close within 60 seconds after the protected accountant
+/// transition's own observation timestamp. This is a software freshness ceiling,
+/// not a replacement for a trusted runtime clock.
+pub const MAX_CANONICAL_READ_LAG_MICROS: i64 = 60_000_000;
+/// A trusted capability is intended for immediate consumption. A runtime executor
+/// should pass its trusted `sys_time()` into `into_receipt` and reject anything later.
+pub const MAX_RELEASE_AFTER_CANONICAL_READ_MICROS: i64 = 60_000_000;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Non-serializable secret used to recompute protected accountant-receipt commitments.
+/// The bytes are zeroed on drop.
+pub struct AccountantReceiptCommitmentKeyV1 {
+    bytes: [u8; 32],
+}
+
+impl AccountantReceiptCommitmentKeyV1 {
+    pub fn new(bytes: [u8; 32]) -> Result<Self, TrustedInteractiveReleaseError> {
+        if bytes == [0u8; 32] {
+            return Err(TrustedInteractiveReleaseError::ZeroCommitmentKey);
+        }
+        Ok(Self { bytes })
+    }
+
+    fn as_bytes(&self) -> &[u8; 32] {
+        &self.bytes
+    }
+}
+
+impl Drop for AccountantReceiptCommitmentKeyV1 {
+    fn drop(&mut self) {
+        self.bytes.fill(0);
+    }
+}
+
+/// Recompute the public opaque commitment to one protected accountant receipt.
+/// Both DNA-root verifiers and the trusted release gate should use this exact helper.
+pub fn commit_private_accountant_receipt(
+    receipt: &PrivacyAccountantReceiptV1,
+    scheme: AccountantCommitmentSchemeV1,
+    key: &AccountantReceiptCommitmentKeyV1,
+) -> Result<OpaqueAccountantReceiptCommitmentV1, TrustedInteractiveReleaseError> {
+    let encoded = serde_json::to_vec(receipt)
+        .map_err(|error| TrustedInteractiveReleaseError::Serialization(error.to_string()))?;
+    let mut framed = Vec::with_capacity(
+        PRIVATE_RECEIPT_COMMITMENT_CONTEXT.len() + 1 + 8 + encoded.len(),
+    );
+    framed.extend_from_slice(PRIVATE_RECEIPT_COMMITMENT_CONTEXT);
+    framed.push(FRAME_VERSION);
+    framed.extend_from_slice(&(encoded.len() as u64).to_be_bytes());
+    framed.extend_from_slice(&encoded);
+
+    let value = match scheme {
+        AccountantCommitmentSchemeV1::HmacSha256 => {
+            let mut mac = HmacSha256::new_from_slice(key.as_bytes())
+                .map_err(|_| TrustedInteractiveReleaseError::InvalidHmacKey)?;
+            mac.update(&framed);
+            let bytes = mac.finalize().into_bytes();
+            let mut value = [0u8; 32];
+            value.copy_from_slice(&bytes);
+            value
+        }
+        AccountantCommitmentSchemeV1::Blake3Keyed => {
+            let mut hasher = blake3::Hasher::new_keyed(key.as_bytes());
+            hasher.update(&framed);
+            *hasher.finalize().as_bytes()
+        }
+    };
+
+    if value == [0u8; 32] {
+        return Err(TrustedInteractiveReleaseError::ZeroComputedCommitment);
+    }
+    Ok(OpaqueAccountantReceiptCommitmentV1 { scheme, value })
+}
+
+/// Distinct non-serializable authority for the high-assurance interactive path.
+/// The lower-level `PopulationReleaseCapabilityV1` is not accepted as equivalent.
+pub struct TrustedInteractivePopulationReleaseCapabilityV1 {
+    request_digest: PopulationReleaseDigestV1,
+    policy_digest: PopulationReleaseDigestV1,
+    source_finding_digest: mycelix_clinical_integrity::StoredDigest,
+    public_output_digest: mycelix_clinical_integrity::StoredDigest,
+    accountant_before_state_hash: ActionHash,
+    accountant_after_state_hash: ActionHash,
+    accountant_sequence: u64,
+    accountant_query_count: u64,
+    canonical_observation_started_at_micros: i64,
+    canonical_observation_completed_at_micros: i64,
+    requested_at_micros: i64,
+}
+
+pub fn authorize_trusted_interactive_population_release(
+    request: &PopulationReleaseRequestV1,
+    canonical_snapshot: &CanonicalPopulationAccountantLineageSnapshotV1,
+    commitment_key: &AccountantReceiptCommitmentKeyV1,
+) -> Result<TrustedInteractivePopulationReleaseCapabilityV1, TrustedInteractiveReleaseError> {
+    request.validate()?;
+    let dp = match &request.mode {
+        PopulationReleaseModeV1::InteractiveDifferentialPrivacy(value) => value,
+        PopulationReleaseModeV1::StaticPreSpecifiedReport(_) => {
+            return Err(TrustedInteractiveReleaseError::InteractiveModeRequired)
+        }
+    };
+
+    let policy_digest = request.policy.verified_digest()?;
+    validate_snapshot_lineage(&request.policy, policy_digest, canonical_snapshot)?;
+
+    let bounded = reduce_canonical_population_accountant_snapshot(canonical_snapshot)?;
+    let (after_hash, sequence, query_count) = match bounded {
+        BoundedCanonicalPopulationAccountantStateV1::ObservedCurrentWithinBoundedCanonicalRead {
+            action_hash,
+            sequence,
+            query_count,
+        } => (action_hash, sequence, query_count),
+        BoundedCanonicalPopulationAccountantStateV1::NoCanonicalStateObserved => {
+            return Err(TrustedInteractiveReleaseError::NoCanonicalAccountantState)
+        }
+        BoundedCanonicalPopulationAccountantStateV1::ConflictWithinBoundedCanonicalRead { .. } => {
+            return Err(TrustedInteractiveReleaseError::CanonicalAccountantConflict)
+        }
+        BoundedCanonicalPopulationAccountantStateV1::NoCurrentStateWithinBoundedCanonicalRead { .. }
+        | BoundedCanonicalPopulationAccountantStateV1::ReviewRequiredWithinBoundedCanonicalRead {
+            ..
+        } => return Err(TrustedInteractiveReleaseError::CanonicalAccountantNotUsable),
+    };
+
+    let after = canonical_snapshot
+        .admitted_states
+        .iter()
+        .find(|item| item.action_hash == after_hash)
+        .ok_or(TrustedInteractiveReleaseError::CanonicalCurrentStateMissing)?;
+    let before_hash = after
+        .state
+        .projection
+        .previous_state_hash
+        .clone()
+        .ok_or(TrustedInteractiveReleaseError::InteractiveAfterStateCannotBeGenesis)?;
+    let before = canonical_snapshot
+        .admitted_states
+        .iter()
+        .find(|item| item.action_hash == before_hash)
+        .ok_or(TrustedInteractiveReleaseError::TrustedPredecessorMissing)?;
+
+    bind_private_receipt_to_public_state(
+        &dp.accountant_before,
+        &before.state,
+        commitment_key,
+    )?;
+    bind_private_receipt_to_public_state(
+        &dp.accountant_after,
+        &after.state,
+        commitment_key,
+    )?;
+
+    if before.state.projection.private_receipt_commitment.scheme
+        != after.state.projection.private_receipt_commitment.scheme
+    {
+        return Err(TrustedInteractiveReleaseError::CommitmentSchemeChangedWithinTransition);
+    }
+
+    require_receipt_projection_match(&dp.accountant_before, &before.state)?;
+    require_receipt_projection_match(&dp.accountant_after, &after.state)?;
+
+    if sequence != dp.accountant_after.sequence
+        || query_count != dp.accountant_after.query_count
+        || after.state.projection.sequence != sequence
+        || after.state.projection.query_count != query_count
+    {
+        return Err(TrustedInteractiveReleaseError::CanonicalLeafDoesNotMatchPrivateAfterReceipt);
+    }
+    if after.state.projection.previous_state_hash.as_ref() != Some(&before.action_hash) {
+        return Err(TrustedInteractiveReleaseError::TrustedPredecessorMismatch);
+    }
+
+    validate_freshness(request, dp, canonical_snapshot)?;
+
+    let request_digest = request.verified_digest()?;
+    Ok(TrustedInteractivePopulationReleaseCapabilityV1 {
+        request_digest,
+        policy_digest,
+        source_finding_digest: dp.source_finding_digest,
+        public_output_digest: dp.public_output_digest,
+        accountant_before_state_hash: before.action_hash.clone(),
+        accountant_after_state_hash: after.action_hash.clone(),
+        accountant_sequence: sequence,
+        accountant_query_count: query_count,
+        canonical_observation_started_at_micros: canonical_snapshot
+            .observation_started_at
+            .as_micros(),
+        canonical_observation_completed_at_micros: canonical_snapshot
+            .observation_completed_at
+            .as_micros(),
+        requested_at_micros: request.requested_at_micros,
+    })
+}
+
+fn validate_snapshot_lineage(
+    policy: &PopulationReleasePolicyV1,
+    policy_digest: PopulationReleaseDigestV1,
+    snapshot: &CanonicalPopulationAccountantLineageSnapshotV1,
+) -> Result<(), TrustedInteractiveReleaseError> {
+    if snapshot.lineage.release_policy_digest != policy_digest {
+        return Err(TrustedInteractiveReleaseError::ReleasePolicyLineageMismatch);
+    }
+    if snapshot.lineage.accountant_instance_digest != policy.accountant_instance_digest
+        || snapshot.lineage.accountant_method_digest != policy.accountant_method_digest
+    {
+        return Err(TrustedInteractiveReleaseError::AccountantLineageMismatch);
+    }
+    Ok(())
+}
+
+fn bind_private_receipt_to_public_state(
+    receipt: &PrivacyAccountantReceiptV1,
+    public_state: &TrustedPopulationAccountantState,
+    commitment_key: &AccountantReceiptCommitmentKeyV1,
+) -> Result<(), TrustedInteractiveReleaseError> {
+    let expected = commit_private_accountant_receipt(
+        receipt,
+        public_state.projection.private_receipt_commitment.scheme,
+        commitment_key,
+    )?;
+    if expected != public_state.projection.private_receipt_commitment {
+        return Err(TrustedInteractiveReleaseError::PrivateReceiptCommitmentMismatch);
+    }
+    Ok(())
+}
+
+fn require_receipt_projection_match(
+    receipt: &PrivacyAccountantReceiptV1,
+    public_state: &TrustedPopulationAccountantState,
+) -> Result<(), TrustedInteractiveReleaseError> {
+    let projection = &public_state.projection;
+    if receipt.accountant_instance_digest != projection.accountant_instance_digest
+        || receipt.accountant_method_digest != projection.accountant_method_digest
+        || receipt.sequence != projection.sequence
+        || receipt.query_count != projection.query_count
+        || receipt.cumulative_privacy_loss != projection.cumulative_privacy_loss
+    {
+        return Err(TrustedInteractiveReleaseError::PrivateReceiptProjectionMismatch);
+    }
+    Ok(())
+}
+
+fn validate_freshness(
+    request: &PopulationReleaseRequestV1,
+    dp: &InteractiveDpReleaseRequestV1,
+    snapshot: &CanonicalPopulationAccountantLineageSnapshotV1,
+) -> Result<(), TrustedInteractiveReleaseError> {
+    let completed = snapshot.observation_completed_at.as_micros();
+    let started = snapshot.observation_started_at.as_micros();
+    if completed < started {
+        return Err(TrustedInteractiveReleaseError::InvalidCanonicalObservationWindow);
+    }
+    if dp.accountant_after.observed_at_micros > request.requested_at_micros
+        || request.requested_at_micros > completed
+    {
+        return Err(TrustedInteractiveReleaseError::RequestOutsideTrustedTransitionWindow);
+    }
+    let lag = completed
+        .checked_sub(dp.accountant_after.observed_at_micros)
+        .ok_or(TrustedInteractiveReleaseError::InvalidCanonicalObservationWindow)?;
+    if lag > MAX_CANONICAL_READ_LAG_MICROS {
+        return Err(TrustedInteractiveReleaseError::CanonicalSnapshotTooStale);
+    }
+    Ok(())
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct TrustedInteractivePopulationReleaseReceiptV1 {
+    pub schema_version: u16,
+    pub request_digest: PopulationReleaseDigestV1,
+    pub policy_digest: PopulationReleaseDigestV1,
+    pub source_finding_digest: mycelix_clinical_integrity::StoredDigest,
+    pub public_output_digest: mycelix_clinical_integrity::StoredDigest,
+    pub accountant_before_state_hash: ActionHash,
+    pub accountant_after_state_hash: ActionHash,
+    pub accountant_sequence: u64,
+    pub accountant_query_count: u64,
+    pub canonical_observation_started_at_micros: i64,
+    pub canonical_observation_completed_at_micros: i64,
+    pub requested_at_micros: i64,
+    pub released_at_micros: i64,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TrustedInteractivePopulationReleaseReceiptDigestV1 {
+    pub value: [u8; 32],
+}
+
+impl TrustedInteractivePopulationReleaseCapabilityV1 {
+    /// Consume the capability into an evidence receipt. Production executors should
+    /// supply a trusted runtime clock value; this pure method can only validate the
+    /// timestamp claim it receives.
+    pub fn into_receipt(
+        self,
+        released_at_micros: i64,
+    ) -> Result<TrustedInteractivePopulationReleaseReceiptV1, TrustedInteractiveReleaseError> {
+        if released_at_micros < self.requested_at_micros
+            || released_at_micros < self.canonical_observation_completed_at_micros
+        {
+            return Err(TrustedInteractiveReleaseError::ReleaseTimeBeforeQualification);
+        }
+        let latest = self
+            .canonical_observation_completed_at_micros
+            .checked_add(MAX_RELEASE_AFTER_CANONICAL_READ_MICROS)
+            .ok_or(TrustedInteractiveReleaseError::ReleaseWindowOverflow)?;
+        if released_at_micros > latest {
+            return Err(TrustedInteractiveReleaseError::TrustedReleaseWindowExpired);
+        }
+        Ok(TrustedInteractivePopulationReleaseReceiptV1 {
+            schema_version: 1,
+            request_digest: self.request_digest,
+            policy_digest: self.policy_digest,
+            source_finding_digest: self.source_finding_digest,
+            public_output_digest: self.public_output_digest,
+            accountant_before_state_hash: self.accountant_before_state_hash,
+            accountant_after_state_hash: self.accountant_after_state_hash,
+            accountant_sequence: self.accountant_sequence,
+            accountant_query_count: self.accountant_query_count,
+            canonical_observation_started_at_micros: self
+                .canonical_observation_started_at_micros,
+            canonical_observation_completed_at_micros: self
+                .canonical_observation_completed_at_micros,
+            requested_at_micros: self.requested_at_micros,
+            released_at_micros,
+        })
+    }
+}
+
+impl TrustedInteractivePopulationReleaseReceiptV1 {
+    pub fn verified_digest(
+        &self,
+    ) -> Result<TrustedInteractivePopulationReleaseReceiptDigestV1, TrustedInteractiveReleaseError>
+    {
+        if self.schema_version != 1 {
+            return Err(TrustedInteractiveReleaseError::UnsupportedReceiptVersion);
+        }
+        if self.released_at_micros < self.requested_at_micros
+            || self.released_at_micros < self.canonical_observation_completed_at_micros
+        {
+            return Err(TrustedInteractiveReleaseError::ReleaseTimeBeforeQualification);
+        }
+        let encoded = serde_json::to_vec(self)
+            .map_err(|error| TrustedInteractiveReleaseError::Serialization(error.to_string()))?;
+        let mut hasher = blake3::Hasher::new_derive_key(TRUSTED_RELEASE_HASH_CONTEXT);
+        hasher.update(&[FRAME_VERSION]);
+        hasher.update(&(encoded.len() as u64).to_be_bytes());
+        hasher.update(&encoded);
+        let value = *hasher.finalize().as_bytes();
+        if value == [0u8; 32] {
+            return Err(TrustedInteractiveReleaseError::ZeroTrustedReleaseDigest);
+        }
+        Ok(TrustedInteractivePopulationReleaseReceiptDigestV1 { value })
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TrustedInteractiveReleaseError {
+    #[error("accountant commitment key cannot be all zero")]
+    ZeroCommitmentKey,
+    #[error("HMAC key initialization failed")]
+    InvalidHmacKey,
+    #[error("computed accountant receipt commitment cannot be all zero")]
+    ZeroComputedCommitment,
+    #[error("trusted interactive release gate accepts only interactive DP requests")]
+    InteractiveModeRequired,
+    #[error("canonical accountant snapshot uses a different release policy")]
+    ReleasePolicyLineageMismatch,
+    #[error("canonical accountant snapshot uses a different accountant instance/method")]
+    AccountantLineageMismatch,
+    #[error("no canonical accountant state was observed")]
+    NoCanonicalAccountantState,
+    #[error("canonical accountant lineage is forked/conflicting")]
+    CanonicalAccountantConflict,
+    #[error("canonical accountant state requires review or has no usable current leaf")]
+    CanonicalAccountantNotUsable,
+    #[error("canonical reducer current action is missing from the snapshot")]
+    CanonicalCurrentStateMissing,
+    #[error("interactive DP after-state cannot be accountant genesis")]
+    InteractiveAfterStateCannotBeGenesis,
+    #[error("trusted accountant predecessor is missing from the canonical snapshot")]
+    TrustedPredecessorMissing,
+    #[error("protected accountant receipt does not match the public keyed commitment")]
+    PrivateReceiptCommitmentMismatch,
+    #[error("commitment scheme changed inside one interactive DP transition")]
+    CommitmentSchemeChangedWithinTransition,
+    #[error("protected accountant receipt fields do not match public trusted state")]
+    PrivateReceiptProjectionMismatch,
+    #[error("canonical current leaf does not match protected after receipt")]
+    CanonicalLeafDoesNotMatchPrivateAfterReceipt,
+    #[error("trusted after-state predecessor does not equal the exact trusted before-state action")]
+    TrustedPredecessorMismatch,
+    #[error("canonical accountant observation window is invalid")]
+    InvalidCanonicalObservationWindow,
+    #[error("release request is outside the trusted accountant transition/canonical-read window")]
+    RequestOutsideTrustedTransitionWindow,
+    #[error("canonical accountant snapshot is too stale for interactive release")]
+    CanonicalSnapshotTooStale,
+    #[error("release timestamp precedes request or canonical qualification")]
+    ReleaseTimeBeforeQualification,
+    #[error("trusted release time window overflow")]
+    ReleaseWindowOverflow,
+    #[error("trusted interactive release capability expired")]
+    TrustedReleaseWindowExpired,
+    #[error("unsupported trusted interactive release receipt version")]
+    UnsupportedReceiptVersion,
+    #[error("trusted interactive release receipt digest cannot be zero")]
+    ZeroTrustedReleaseDigest,
+    #[error("serialization failed: {0}")]
+    Serialization(String),
+    #[error(transparent)]
+    Release(#[from] PopulationReleaseError),
+    #[error(transparent)]
+    Canonical(#[from] CanonicalAccountantStateError),
+}

--- a/crates/clinical-population-interactive-release/tests/trusted_gate.rs
+++ b/crates/clinical-population-interactive-release/tests/trusted_gate.rs
@@ -1,0 +1,331 @@
+use holo_hash::ActionHash;
+use holochain_zome_types::prelude::Timestamp;
+use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain, StoredDigest};
+use mycelix_clinical_population_interactive_release::*;
+use mycelix_clinical_population_release::{
+    DifferentialPrivacyMechanismV1, DpMechanismKindV1, InteractiveDpReleaseRequestV1,
+    PopulationFindingKindV1, PopulationReleaseArtifactKindV1, PopulationReleaseDigestV1,
+    PopulationReleaseModeV1, PopulationReleasePolicyV1, PopulationReleaseRequestV1,
+    PrivacyAccountantReceiptV1, PrivacyLossV1, ReducedFractionV1,
+};
+use population_accountant_index::{
+    CanonicalAccountantObservedStateV1, CanonicalAccountantReadBoundaryV1,
+    CanonicalPopulationAccountantLineageSnapshotV1,
+};
+use population_accountant_index_integrity::PopulationAccountantLineageAnchorV1;
+use population_accountant_integrity::{
+    AccountantCommitmentSchemeV1, PopulationAccountantStateProjectionV1,
+    TrustedPopulationAccountantState,
+};
+
+fn action(seed: u8) -> ActionHash {
+    ActionHash::from_raw_36(vec![seed; 36])
+}
+
+fn digest(domain: DigestDomain, seed: u8) -> StoredDigest {
+    StoredDigest {
+        algorithm: DigestAlgorithm::Blake3_256,
+        domain,
+        value: [seed; 32],
+    }
+}
+
+fn fraction(n: u64, d: u64) -> ReducedFractionV1 {
+    ReducedFractionV1 {
+        numerator: n,
+        denominator: d,
+    }
+}
+
+fn loss(n: u64, d: u64) -> PrivacyLossV1 {
+    PrivacyLossV1 {
+        epsilon: fraction(n, d),
+        delta: ReducedFractionV1::ZERO,
+    }
+}
+
+fn policy() -> PopulationReleasePolicyV1 {
+    PopulationReleasePolicyV1 {
+        schema_version: 1,
+        policy_id: "interactive-release-policy-v1".into(),
+        static_minimum_cell_count: 11,
+        max_static_report_cells: 10_000,
+        allowed_dp_mechanisms: vec![DpMechanismKindV1::Gaussian],
+        max_per_release_privacy_loss: loss(1, 2),
+        max_cumulative_privacy_loss: loss(2, 1),
+        max_interactive_queries: 100,
+        accountant_instance_digest: digest(DigestDomain::ClinicalArtifact, 1),
+        accountant_method_digest: digest(DigestDomain::ClinicalArtifact, 2),
+    }
+}
+
+fn mechanism(policy: &PopulationReleasePolicyV1) -> DifferentialPrivacyMechanismV1 {
+    let value = DifferentialPrivacyMechanismV1 {
+        schema_version: 1,
+        mechanism_id: "gaussian-count-v1".into(),
+        mechanism_kind: DpMechanismKindV1::Gaussian,
+        implementation_version: "1.0.0".into(),
+        implementation_digest: digest(DigestDomain::ClinicalArtifact, 10),
+        privacy_unit_definition_digest: digest(DigestDomain::ClinicalArtifact, 11),
+        adjacency_definition_digest: digest(DigestDomain::ClinicalArtifact, 12),
+        contribution_bounds_digest: digest(DigestDomain::ClinicalArtifact, 13),
+        sensitivity_analysis_digest: digest(DigestDomain::ClinicalArtifact, 14),
+        randomness_source_evidence_digest: digest(DigestDomain::ClinicalArtifact, 15),
+        release_privacy_loss: loss(1, 10),
+    };
+    value.validate(policy).unwrap();
+    value
+}
+
+struct Fixture {
+    request: PopulationReleaseRequestV1,
+    snapshot: CanonicalPopulationAccountantLineageSnapshotV1,
+    key: AccountantReceiptCommitmentKeyV1,
+}
+
+fn fixture() -> Fixture {
+    let policy = policy();
+    let policy_digest = policy.verified_digest().unwrap();
+    let mechanism = mechanism(&policy);
+    let mechanism_digest = mechanism.verified_digest(&policy).unwrap();
+    let query = digest(DigestDomain::ClinicalArtifact, 20);
+    let output = digest(DigestDomain::ClinicalArtifact, 21);
+
+    let before_receipt = PrivacyAccountantReceiptV1 {
+        schema_version: 1,
+        accountant_instance_digest: policy.accountant_instance_digest,
+        accountant_method_digest: policy.accountant_method_digest,
+        sequence: 0,
+        previous_receipt_digest: None,
+        cumulative_privacy_loss: PrivacyLossV1::ZERO,
+        query_count: 0,
+        last_query_spec_digest: None,
+        last_mechanism_digest: None,
+        last_output_digest: None,
+        accountant_evidence_digest: digest(DigestDomain::ClinicalArtifact, 30),
+        observed_at_micros: 100,
+    };
+    let after_receipt = PrivacyAccountantReceiptV1 {
+        schema_version: 1,
+        accountant_instance_digest: policy.accountant_instance_digest,
+        accountant_method_digest: policy.accountant_method_digest,
+        sequence: 1,
+        previous_receipt_digest: Some(before_receipt.verified_digest(&policy).unwrap()),
+        cumulative_privacy_loss: loss(1, 10),
+        query_count: 1,
+        last_query_spec_digest: Some(query),
+        last_mechanism_digest: Some(mechanism_digest),
+        last_output_digest: Some(output),
+        accountant_evidence_digest: digest(DigestDomain::ClinicalArtifact, 31),
+        observed_at_micros: 110,
+    };
+
+    let key = AccountantReceiptCommitmentKeyV1::new([7; 32]).unwrap();
+    let before_commitment = commit_private_accountant_receipt(
+        &before_receipt,
+        AccountantCommitmentSchemeV1::Blake3Keyed,
+        &key,
+    )
+    .unwrap();
+    let after_commitment = commit_private_accountant_receipt(
+        &after_receipt,
+        AccountantCommitmentSchemeV1::Blake3Keyed,
+        &key,
+    )
+    .unwrap();
+
+    let before_hash = action(1);
+    let after_hash = action(2);
+    let before_state = TrustedPopulationAccountantState {
+        projection: PopulationAccountantStateProjectionV1 {
+            schema_version: 1,
+            state_id: "accountant-state-0".into(),
+            release_policy_digest: policy_digest,
+            accountant_instance_digest: policy.accountant_instance_digest,
+            accountant_method_digest: policy.accountant_method_digest,
+            sequence: 0,
+            query_count: 0,
+            cumulative_privacy_loss: PrivacyLossV1::ZERO,
+            previous_state_hash: None,
+            private_receipt_commitment: before_commitment,
+        },
+        verifier_authorization_hash: action(101),
+    };
+    let after_state = TrustedPopulationAccountantState {
+        projection: PopulationAccountantStateProjectionV1 {
+            schema_version: 1,
+            state_id: "accountant-state-1".into(),
+            release_policy_digest: policy_digest,
+            accountant_instance_digest: policy.accountant_instance_digest,
+            accountant_method_digest: policy.accountant_method_digest,
+            sequence: 1,
+            query_count: 1,
+            cumulative_privacy_loss: loss(1, 10),
+            previous_state_hash: Some(before_hash.clone()),
+            private_receipt_commitment: after_commitment,
+        },
+        verifier_authorization_hash: action(102),
+    };
+
+    let request = PopulationReleaseRequestV1 {
+        schema_version: 1,
+        release_id: "trusted-interactive-release-1".into(),
+        policy: policy.clone(),
+        mode: PopulationReleaseModeV1::InteractiveDifferentialPrivacy(
+            InteractiveDpReleaseRequestV1 {
+                source_finding_kind: PopulationFindingKindV1::CausalEffectEstimate,
+                source_finding_digest: digest(DigestDomain::ClinicalCausalEffectEstimate, 40),
+                query_specification_digest: query,
+                output_schema_digest: digest(DigestDomain::ClinicalArtifact, 41),
+                public_output_digest: output,
+                mechanism,
+                accountant_before: before_receipt,
+                accountant_after: after_receipt,
+            },
+        ),
+        requested_at_micros: 120,
+    };
+
+    let lineage = PopulationAccountantLineageAnchorV1::new(
+        policy_digest,
+        policy.accountant_instance_digest,
+        policy.accountant_method_digest,
+    )
+    .unwrap();
+    let states = vec![
+        CanonicalAccountantObservedStateV1 {
+            action_hash: before_hash,
+            state: before_state,
+            corrections: Vec::new(),
+            observed_correction_target_count: 0,
+        },
+        CanonicalAccountantObservedStateV1 {
+            action_hash: after_hash,
+            state: after_state,
+            corrections: Vec::new(),
+            observed_correction_target_count: 0,
+        },
+    ];
+    let snapshot = CanonicalPopulationAccountantLineageSnapshotV1 {
+        lineage,
+        observed_state_count: states.len(),
+        observed_total_correction_count: 0,
+        admitted_states: states,
+        read_boundary:
+            CanonicalAccountantReadBoundaryV1::NestedNetworkBackedStableReadsWithFinalClosureChecks,
+        observation_started_at: Timestamp::from_micros(115),
+        observation_completed_at: Timestamp::from_micros(130),
+    };
+
+    Fixture {
+        request,
+        snapshot,
+        key,
+    }
+}
+
+#[test]
+fn exact_canonical_transition_mints_distinct_trusted_capability() {
+    let fixture = fixture();
+    let receipt = authorize_trusted_interactive_population_release(
+        &fixture.request,
+        &fixture.snapshot,
+        &fixture.key,
+    )
+    .unwrap()
+    .into_receipt(140)
+    .unwrap();
+    assert_eq!(receipt.accountant_sequence, 1);
+    assert_eq!(receipt.accountant_query_count, 1);
+    assert_eq!(receipt.accountant_before_state_hash, action(1));
+    assert_eq!(receipt.accountant_after_state_hash, action(2));
+    assert_ne!(receipt.verified_digest().unwrap().value, [0; 32]);
+}
+
+#[test]
+fn wrong_commitment_key_fails_closed() {
+    let fixture = fixture();
+    let wrong = AccountantReceiptCommitmentKeyV1::new([8; 32]).unwrap();
+    assert!(matches!(
+        authorize_trusted_interactive_population_release(
+            &fixture.request,
+            &fixture.snapshot,
+            &wrong,
+        ),
+        Err(TrustedInteractiveReleaseError::PrivateReceiptCommitmentMismatch)
+    ));
+}
+
+#[test]
+fn admitted_sibling_successor_is_conflict_not_latest_wins() {
+    let mut fixture = fixture();
+    let after = fixture.snapshot.admitted_states[1].clone();
+    let mut sibling = after;
+    sibling.action_hash = action(3);
+    sibling.state.projection.state_id = "accountant-state-1-sibling".into();
+    sibling.state.projection.private_receipt_commitment.value = [55; 32];
+    fixture.snapshot.admitted_states.push(sibling);
+    fixture.snapshot.observed_state_count = 3;
+
+    assert!(matches!(
+        authorize_trusted_interactive_population_release(
+            &fixture.request,
+            &fixture.snapshot,
+            &fixture.key,
+        ),
+        Err(TrustedInteractiveReleaseError::CanonicalAccountantConflict)
+    ));
+}
+
+#[test]
+fn stale_canonical_snapshot_cannot_authorize_release() {
+    let mut fixture = fixture();
+    fixture.snapshot.observation_completed_at =
+        Timestamp::from_micros(110 + MAX_CANONICAL_READ_LAG_MICROS + 1);
+    assert!(matches!(
+        authorize_trusted_interactive_population_release(
+            &fixture.request,
+            &fixture.snapshot,
+            &fixture.key,
+        ),
+        Err(TrustedInteractiveReleaseError::CanonicalSnapshotTooStale)
+    ));
+}
+
+#[test]
+fn different_policy_lineage_fails_before_release_authority() {
+    let mut fixture = fixture();
+    fixture.snapshot.lineage.release_policy_digest = PopulationReleaseDigestV1 {
+        kind: PopulationReleaseArtifactKindV1::ReleasePolicy,
+        value: [99; 32],
+    };
+    assert!(matches!(
+        authorize_trusted_interactive_population_release(
+            &fixture.request,
+            &fixture.snapshot,
+            &fixture.key,
+        ),
+        Err(TrustedInteractiveReleaseError::ReleasePolicyLineageMismatch)
+    ));
+}
+
+#[test]
+fn hmac_and_blake3_commitments_are_domain_separated_by_scheme() {
+    let fixture = fixture();
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(dp) = &fixture.request.mode else {
+        unreachable!()
+    };
+    let hmac = commit_private_accountant_receipt(
+        &dp.accountant_after,
+        AccountantCommitmentSchemeV1::HmacSha256,
+        &fixture.key,
+    )
+    .unwrap();
+    let blake = commit_private_accountant_receipt(
+        &dp.accountant_after,
+        AccountantCommitmentSchemeV1::Blake3Keyed,
+        &fixture.key,
+    )
+    .unwrap();
+    assert_ne!(hmac.value, blake.value);
+}

--- a/docs/security/CLINICAL_POPULATION_INTERACTIVE_RELEASE_QUALIFICATION_CHECKLIST.md
+++ b/docs/security/CLINICAL_POPULATION_INTERACTIVE_RELEASE_QUALIFICATION_CHECKLIST.md
@@ -1,0 +1,60 @@
+# Clinical Population Interactive Release V1 — Qualification Checklist
+
+Status: **not qualified**
+
+## Pure gate
+
+- [ ] `cargo test -p mycelix-clinical-population-interactive-release` passes on the exact PR head.
+- [ ] `cargo clippy -p mycelix-clinical-population-interactive-release --all-targets -- -D warnings` passes.
+- [ ] exact canonical before -> after transition authorizes.
+- [ ] wrong commitment key fails closed.
+- [ ] HMAC-SHA-256 and keyed-BLAKE3 commitment helpers both execute and produce scheme-distinct commitments.
+- [ ] zero commitment key fails closed.
+- [ ] wrong release-policy lineage fails closed.
+- [ ] wrong accountant instance/method lineage fails closed.
+- [ ] no canonical state fails closed.
+- [ ] multiple admitted genesis states fail as conflict.
+- [ ] sibling successor states fail as conflict.
+- [ ] review-required/revoked ancestry cannot authorize.
+- [ ] missing trusted predecessor fails closed.
+- [ ] public/private sequence mismatch fails closed.
+- [ ] public/private query-count mismatch fails closed.
+- [ ] public/private cumulative privacy-loss mismatch fails closed.
+- [ ] after-state predecessor must be the exact trusted before-state action.
+- [ ] protected before receipt must match the public keyed commitment.
+- [ ] protected after receipt must match the public keyed commitment.
+- [ ] commitment scheme change inside one transition fails closed.
+- [ ] request query/mechanism/output substitution still fails through the lower-level validator.
+- [ ] canonical snapshot older than the software freshness ceiling fails closed.
+- [ ] capability consumption after its software release window fails closed.
+- [ ] static release requests cannot mint a trusted interactive capability.
+
+## Runtime / conductor
+
+- [ ] #92 canonical-accountant discovery race tests execute successfully.
+- [ ] canonical snapshot is materialized with network-backed reads on the exact lineage.
+- [ ] admitted sibling fork is visible to the gate after propagation and blocks release.
+- [ ] mid-read state/correction arrival forces retry rather than release authority.
+- [ ] production release executor supplies a trusted runtime timestamp to capability consumption.
+- [ ] release executor has no code path accepting the lower-level generic capability for interactive DP.
+- [ ] private receipt commitment key is held outside DHT/DNA/public logs and cannot be read through ordinary app APIs.
+- [ ] key rotation/migration behavior is separately qualified before use.
+
+## Privacy / cryptography review
+
+- [ ] commitment preimage framing is independently reviewed for unambiguous domain separation.
+- [ ] HMAC-SHA-256 implementation path is reviewed against the selected key-management policy.
+- [ ] keyed-BLAKE3 implementation path is reviewed against the selected key-management policy.
+- [ ] commitment keys are at least 256 bits of deployment-generated secret material.
+- [ ] no query/output/patient/cohort identifiers are added to public accountant-state discovery.
+- [ ] logs/errors do not emit commitment keys or full protected accountant receipts.
+
+## Release-authority migration blocker
+
+- [ ] legacy `authorize_population_release()` interactive capability is removed, deprecated, or made impossible for a production interactive executor to consume.
+- [ ] documentation consistently calls the lower-level interactive result preflight evidence, not final release authority.
+- [ ] only `TrustedInteractivePopulationReleaseCapabilityV1` can reach a production interactive release sink.
+
+## Promotion rule
+
+Do not promote broad interactive DP release until all executable tests above pass on the exact frozen head, #92 conductor evidence exists, the legacy/preflight authority ambiguity is closed, and the exact DP mechanism/accountant implementation used in deployment has its own qualification evidence.

--- a/docs/security/CLINICAL_POPULATION_INTERACTIVE_RELEASE_V1.md
+++ b/docs/security/CLINICAL_POPULATION_INTERACTIVE_RELEASE_V1.md
@@ -1,0 +1,117 @@
+# Clinical Population Interactive Release V1
+
+Status: **experimental / draft**
+
+This tranche closes the composition gap between the pure population-release preflight and the DNA-rooted/canonically discovered privacy-accountant state.
+
+## Authority boundary
+
+`mycelix-clinical-population-release` remains useful for validating request shape, DP mechanism metadata, exact query/output binding, and protected accountant-receipt continuity. Its `PopulationReleaseCapabilityV1` is **preflight evidence only for interactive DP**.
+
+A production interactive release executor MUST require `TrustedInteractivePopulationReleaseCapabilityV1` from `mycelix-clinical-population-interactive-release`. The two capability types are intentionally unrelated and non-interchangeable.
+
+Static pre-specified reports remain governed by their static suppression/composition path.
+
+## Required interactive chain
+
+```text
+protected accountant receipt before
+        +
+protected accountant receipt after
+        +
+exact DP query / mechanism / output
+        |
+        v
+recompute keyed receipt commitments
+        |
+        v
+DNA-qualified trusted public states
+        |
+        v
+same-author canonical admission
+        |
+        v
+nested bounded canonical snapshot
+        |
+        v
+sole ObservedCurrentWithinBoundedCanonicalRead leaf
+        |
+        v
+exact after.previous_state == trusted before action
+        |
+        v
+TrustedInteractivePopulationReleaseCapabilityV1
+```
+
+## Private-receipt commitment
+
+The commitment preimage is deterministic:
+
+1. fixed domain string `mycelix.health.population-accountant-private-receipt.v1`;
+2. frame version byte;
+3. big-endian encoded JSON length;
+4. serialized `PrivacyAccountantReceiptV1` bytes.
+
+The selected public scheme is then applied with a secret 32-byte key:
+
+- HMAC-SHA-256; or
+- keyed BLAKE3.
+
+The secret key is never serialized by the gate and is zeroed when the key wrapper is dropped. A zero key is rejected.
+
+Both the DNA-root verifier that authorizes the public accountant state and the trusted interactive release gate must use the same commitment helper/contract. The public DHT never receives the private receipt or commitment key.
+
+V1 rejects a commitment-scheme change inside a single interactive transition. Key/scheme rotation requires separately reviewed migration semantics rather than silent continuity.
+
+## Exact binding requirements
+
+The gate rejects unless all of the following hold:
+
+- the request is a structurally valid `InteractiveDifferentialPrivacy` request;
+- request policy digest equals the canonical accountant lineage policy;
+- accountant instance and method equal the canonical lineage;
+- the bounded canonical reducer returns exactly one usable current leaf;
+- that leaf is the request's protected `accountant_after` state;
+- the leaf's predecessor action exists in the same canonical snapshot;
+- the predecessor is the request's protected `accountant_before` state;
+- both protected receipts recompute to the public keyed commitments;
+- public/private sequence, query count, cumulative privacy loss, instance and method match exactly;
+- request-level query/mechanism/output binding remains valid through the lower-level release validator.
+
+A fork, review-required state, absent predecessor, wrong key, stale snapshot or cross-policy/accountant lineage fails closed.
+
+## Freshness
+
+V1 uses two conservative software ceilings:
+
+- canonical read must close no more than 60 seconds after the protected `accountant_after.observed_at_micros`;
+- a trusted capability may only be consumed within 60 seconds after canonical snapshot closure.
+
+These checks constrain evidence semantics but do **not** create a trusted clock. Production executors must pass a runtime-trusted clock (for example conductor `sys_time()`) when consuming the capability.
+
+## Receipt
+
+Consuming the trusted capability emits `TrustedInteractivePopulationReleaseReceiptV1`, binding:
+
+- exact request digest;
+- exact release-policy digest;
+- exact source finding and public output;
+- exact trusted before/after accountant action hashes;
+- accountant sequence/query count;
+- bounded canonical observation interval;
+- requested and released timestamps.
+
+The receipt is evidence, not reusable authority.
+
+## Non-claims
+
+This tranche does not claim:
+
+- global DHT completeness;
+- that queued CI is executable qualification;
+- that the DP mechanism mathematics have been independently audited;
+- that a caller-provided release timestamp is a trusted clock;
+- that #92 conductor race tests are complete;
+- that the lower-level generic interactive preflight capability has been removed from the API.
+
+Until the legacy generic interactive capability is removed/deprecated at the executor boundary and conductor qualification is complete, broad interactive release remains experimental.


### PR DESCRIPTION
## Stack

Depends on #94 -> #93 -> #91 -> #88 -> #87 -> #86 -> #85 -> #84 -> #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49 -> #48 -> #45 -> #44 -> #42 -> #40 -> #39 -> #38 -> #37 -> #36 -> #35 -> #33 -> #32 -> #31 -> #30.

## Why

#91 validates interactive DP request/accountant structure but predates trusted canonical accountant state. #93/#94 establish DNA-rooted state and bounded canonical discovery. This tranche composes them so the intended high-assurance interactive release path cannot authorize from caller-supplied accountant receipts alone.

## Trusted capability

Adds the distinct non-serializable `TrustedInteractivePopulationReleaseCapabilityV1`. It is intentionally not convertible from `PopulationReleaseCapabilityV1`.

Authorization requires:

- a valid interactive DP request;
- exact release-policy/accountant lineage match;
- bounded canonical accountant snapshot from #94;
- exactly one usable `ObservedCurrentWithinBoundedCanonicalRead` leaf;
- exact trusted predecessor action for the protected before receipt;
- exact public/private sequence, query count and cumulative privacy loss;
- keyed commitment recomputation for both protected receipts;
- exact request query/mechanism/output binding inherited from #91;
- bounded freshness between protected accountant transition and canonical read.

Forks, stale snapshots, wrong commitment keys, review-required state and cross-lineage state fail closed.

## Commitment binding

Adds one deterministic protected-receipt commitment contract with two supported schemes:

- HMAC-SHA-256;
- keyed BLAKE3.

The 32-byte secret key is non-serializable and zeroed on drop. V1 rejects commitment-scheme changes inside one interactive transition; key/scheme migration requires explicit future semantics.

## Evidence receipt

Consuming the trusted capability produces a receipt bound to the exact request/policy/output, trusted before/after accountant actions, sequence/query count, bounded canonical observation interval and release timestamp. The receipt is evidence, not reusable authority.

## Qualification / blockers

See:
- `docs/security/CLINICAL_POPULATION_INTERACTIVE_RELEASE_V1.md`
- `docs/security/CLINICAL_POPULATION_INTERACTIVE_RELEASE_QUALIFICATION_CHECKLIST.md`

P0 #92 remains open for conductor-level canonical discovery/race evidence.
P0 #95 tracks removal/deprecation of the older generic interactive preflight authority ambiguity. Production interactive executors must accept only the trusted capability.

This PR remains draft until exact-head CI executes successfully and those promotion blockers are closed.