### PR TITLE
privacy(population): bind accountant transition to exact release context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ members = [
     "crates/clinical-causality-canonical-state",
     "crates/clinical-population-evidence",
     "crates/clinical-population-release",
+    "crates/clinical-population-release-context",
     "crates/clinical-population-accountant-state",
     "crates/clinical-population-accountant-canonical-state",
     "crates/clinical-population-interactive-release",

--- a/crates/clinical-integrity/src/lib.rs
+++ b/crates/clinical-integrity/src/lib.rs
@@ -84,6 +84,7 @@ pub enum DigestDomain {
     CredentialStatusEvidence,
     IssuerAuthorityEvidence,
     WorkflowPolicy,
+    ClinicalPopulationReleaseContext,
 }
 
 impl DigestDomain {
@@ -154,6 +155,7 @@ impl DigestDomain {
             Self::CredentialStatusEvidence => b"credential-status-evidence",
             Self::IssuerAuthorityEvidence => b"issuer-authority-evidence",
             Self::WorkflowPolicy => b"workflow-policy",
+            Self::ClinicalPopulationReleaseContext => b"clinical-population-release-context",
         }
     }
 }
@@ -349,6 +351,7 @@ mod tests {
             DigestDomain::MedicationAdministrationOccurrenceBinding,
             DigestDomain::MedicationAdministrationOccurrenceAttestation,
             DigestDomain::AuthorityPolicy,
+            DigestDomain::ClinicalPopulationReleaseContext,
         ];
         let values: Vec<[u8; 32]> = domains
             .iter()

--- a/crates/clinical-population-interactive-release/Cargo.toml
+++ b/crates/clinical-population-interactive-release/Cargo.toml
@@ -16,6 +16,7 @@ holo_hash = { workspace = true }
 holochain_zome_types = { workspace = true }
 mycelix-clinical-integrity = { path = "../clinical-integrity" }
 mycelix-clinical-population-release = { path = "../clinical-population-release" }
+mycelix-clinical-population-release-context = { path = "../clinical-population-release-context" }
 mycelix-clinical-population-accountant-canonical-state = { path = "../clinical-population-accountant-canonical-state" }
 population_accountant_index = { path = "../../zomes/population_accountant_index/coordinator" }
 population_accountant_integrity = { path = "../../zomes/population_accountant/integrity" }

--- a/crates/clinical-population-interactive-release/src/lib.rs
+++ b/crates/clinical-population-interactive-release/src/lib.rs
@@ -10,6 +10,7 @@
 
 use hmac::{Hmac, Mac};
 use holo_hash::ActionHash;
+use mycelix_clinical_integrity::{DigestDomain, IntegrityError, StoredDigest};
 use mycelix_clinical_population_accountant_canonical_state::{
     reduce_canonical_population_accountant_snapshot,
     BoundedCanonicalPopulationAccountantStateV1, CanonicalAccountantStateError,
@@ -18,6 +19,9 @@ use mycelix_clinical_population_release::{
     InteractiveDpReleaseRequestV1, PopulationReleaseDigestV1, PopulationReleaseError,
     PopulationReleaseModeV1, PopulationReleasePolicyV1, PopulationReleaseRequestV1,
     PrivacyAccountantReceiptV1,
+};
+use mycelix_clinical_population_release_context::{
+    interactive_release_context_digest, PopulationReleaseContextError,
 };
 use population_accountant_index::CanonicalPopulationAccountantLineageSnapshotV1;
 use population_accountant_integrity::{
@@ -113,8 +117,9 @@ pub fn commit_private_accountant_receipt(
 pub struct TrustedInteractivePopulationReleaseCapabilityV1 {
     request_digest: PopulationReleaseDigestV1,
     policy_digest: PopulationReleaseDigestV1,
-    source_finding_digest: mycelix_clinical_integrity::StoredDigest,
-    public_output_digest: mycelix_clinical_integrity::StoredDigest,
+    release_context_digest: StoredDigest,
+    source_finding_digest: StoredDigest,
+    public_output_digest: StoredDigest,
     accountant_before_state_hash: ActionHash,
     accountant_after_state_hash: ActionHash,
     accountant_sequence: u64,
@@ -136,6 +141,11 @@ pub fn authorize_trusted_interactive_population_release(
             return Err(TrustedInteractiveReleaseError::InteractiveModeRequired)
         }
     };
+
+    let release_context_digest = interactive_release_context_digest(request)?;
+    if dp.accountant_after.accountant_evidence_digest != release_context_digest {
+        return Err(TrustedInteractiveReleaseError::AccountantReleaseContextMismatch);
+    }
 
     let policy_digest = request.policy.verified_digest()?;
     validate_snapshot_lineage(&request.policy, policy_digest, canonical_snapshot)?;
@@ -213,6 +223,7 @@ pub fn authorize_trusted_interactive_population_release(
     Ok(TrustedInteractivePopulationReleaseCapabilityV1 {
         request_digest,
         policy_digest,
+        release_context_digest,
         source_finding_digest: dp.source_finding_digest,
         public_output_digest: dp.public_output_digest,
         accountant_before_state_hash: before.action_hash.clone(),
@@ -307,8 +318,9 @@ pub struct TrustedInteractivePopulationReleaseReceiptV1 {
     pub schema_version: u16,
     pub request_digest: PopulationReleaseDigestV1,
     pub policy_digest: PopulationReleaseDigestV1,
-    pub source_finding_digest: mycelix_clinical_integrity::StoredDigest,
-    pub public_output_digest: mycelix_clinical_integrity::StoredDigest,
+    pub release_context_digest: StoredDigest,
+    pub source_finding_digest: StoredDigest,
+    pub public_output_digest: StoredDigest,
     pub accountant_before_state_hash: ActionHash,
     pub accountant_after_state_hash: ActionHash,
     pub accountant_sequence: u64,
@@ -348,6 +360,7 @@ impl TrustedInteractivePopulationReleaseCapabilityV1 {
             schema_version: 1,
             request_digest: self.request_digest,
             policy_digest: self.policy_digest,
+            release_context_digest: self.release_context_digest,
             source_finding_digest: self.source_finding_digest,
             public_output_digest: self.public_output_digest,
             accountant_before_state_hash: self.accountant_before_state_hash,
@@ -371,6 +384,10 @@ impl TrustedInteractivePopulationReleaseReceiptV1 {
     {
         if self.schema_version != 1 {
             return Err(TrustedInteractiveReleaseError::UnsupportedReceiptVersion);
+        }
+        self.release_context_digest.validate_shape()?;
+        if self.release_context_digest.domain != DigestDomain::ClinicalPopulationReleaseContext {
+            return Err(TrustedInteractiveReleaseError::WrongReleaseContextDigestDomain);
         }
         if self.released_at_micros < self.requested_at_micros
             || self.released_at_micros < self.canonical_observation_completed_at_micros
@@ -401,6 +418,10 @@ pub enum TrustedInteractiveReleaseError {
     ZeroComputedCommitment,
     #[error("trusted interactive release gate accepts only interactive DP requests")]
     InteractiveModeRequired,
+    #[error("protected accountant transition does not bind the exact scientific release context")]
+    AccountantReleaseContextMismatch,
+    #[error("trusted interactive release receipt has wrong scientific context digest domain")]
+    WrongReleaseContextDigestDomain,
     #[error("canonical accountant snapshot uses a different release policy")]
     ReleasePolicyLineageMismatch,
     #[error("canonical accountant snapshot uses a different accountant instance/method")]
@@ -448,5 +469,9 @@ pub enum TrustedInteractiveReleaseError {
     #[error(transparent)]
     Release(#[from] PopulationReleaseError),
     #[error(transparent)]
+    ReleaseContext(#[from] PopulationReleaseContextError),
+    #[error(transparent)]
     Canonical(#[from] CanonicalAccountantStateError),
+    #[error(transparent)]
+    Integrity(#[from] IntegrityError),
 }

--- a/crates/clinical-population-interactive-release/tests/trusted_gate.rs
+++ b/crates/clinical-population-interactive-release/tests/trusted_gate.rs
@@ -8,6 +8,7 @@ use mycelix_clinical_population_release::{
     PopulationReleaseModeV1, PopulationReleasePolicyV1, PopulationReleaseRequestV1,
     PrivacyAccountantReceiptV1, PrivacyLossV1, ReducedFractionV1,
 };
+use mycelix_clinical_population_release_context::interactive_release_context_digest;
 use population_accountant_index::{
     CanonicalAccountantObservedStateV1, CanonicalAccountantReadBoundaryV1,
     CanonicalPopulationAccountantLineageSnapshotV1,
@@ -105,7 +106,7 @@ fn fixture() -> Fixture {
         accountant_evidence_digest: digest(DigestDomain::ClinicalArtifact, 30),
         observed_at_micros: 100,
     };
-    let after_receipt = PrivacyAccountantReceiptV1 {
+    let mut after_receipt = PrivacyAccountantReceiptV1 {
         schema_version: 1,
         accountant_instance_digest: policy.accountant_instance_digest,
         accountant_method_digest: policy.accountant_method_digest,
@@ -119,6 +120,32 @@ fn fixture() -> Fixture {
         accountant_evidence_digest: digest(DigestDomain::ClinicalArtifact, 31),
         observed_at_micros: 110,
     };
+
+    let mut request = PopulationReleaseRequestV1 {
+        schema_version: 1,
+        release_id: "trusted-interactive-release-1".into(),
+        policy: policy.clone(),
+        mode: PopulationReleaseModeV1::InteractiveDifferentialPrivacy(
+            InteractiveDpReleaseRequestV1 {
+                source_finding_kind: PopulationFindingKindV1::CausalEffectEstimate,
+                source_finding_digest: digest(DigestDomain::ClinicalCausalEffectEstimate, 40),
+                query_specification_digest: query,
+                output_schema_digest: digest(DigestDomain::ClinicalArtifact, 41),
+                public_output_digest: output,
+                mechanism,
+                accountant_before: before_receipt.clone(),
+                accountant_after: after_receipt.clone(),
+            },
+        ),
+        requested_at_micros: 120,
+    };
+    let release_context_digest = interactive_release_context_digest(&request).unwrap();
+    after_receipt.accountant_evidence_digest = release_context_digest;
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut interactive) = request.mode
+    else {
+        unreachable!()
+    };
+    interactive.accountant_after = after_receipt.clone();
 
     let key = AccountantReceiptCommitmentKeyV1::new([7; 32]).unwrap();
     let before_commitment = commit_private_accountant_receipt(
@@ -165,25 +192,6 @@ fn fixture() -> Fixture {
             private_receipt_commitment: after_commitment,
         },
         verifier_authorization_hash: action(102),
-    };
-
-    let request = PopulationReleaseRequestV1 {
-        schema_version: 1,
-        release_id: "trusted-interactive-release-1".into(),
-        policy: policy.clone(),
-        mode: PopulationReleaseModeV1::InteractiveDifferentialPrivacy(
-            InteractiveDpReleaseRequestV1 {
-                source_finding_kind: PopulationFindingKindV1::CausalEffectEstimate,
-                source_finding_digest: digest(DigestDomain::ClinicalCausalEffectEstimate, 40),
-                query_specification_digest: query,
-                output_schema_digest: digest(DigestDomain::ClinicalArtifact, 41),
-                public_output_digest: output,
-                mechanism,
-                accountant_before: before_receipt,
-                accountant_after: after_receipt,
-            },
-        ),
-        requested_at_micros: 120,
     };
 
     let lineage = PopulationAccountantLineageAnchorV1::new(
@@ -239,6 +247,10 @@ fn exact_canonical_transition_mints_distinct_trusted_capability() {
     assert_eq!(receipt.accountant_query_count, 1);
     assert_eq!(receipt.accountant_before_state_hash, action(1));
     assert_eq!(receipt.accountant_after_state_hash, action(2));
+    assert_eq!(
+        receipt.release_context_digest.domain,
+        DigestDomain::ClinicalPopulationReleaseContext
+    );
     assert_ne!(receipt.verified_digest().unwrap().value, [0; 32]);
 }
 
@@ -306,6 +318,45 @@ fn different_policy_lineage_fails_before_release_authority() {
             &fixture.key,
         ),
         Err(TrustedInteractiveReleaseError::ReleasePolicyLineageMismatch)
+    ));
+}
+
+#[test]
+fn source_finding_substitution_breaks_accountant_context_binding() {
+    let mut fixture = fixture();
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut interactive) =
+        fixture.request.mode
+    else {
+        unreachable!()
+    };
+    interactive.source_finding_digest =
+        digest(DigestDomain::ClinicalCausalEffectEstimate, 77);
+    assert!(matches!(
+        authorize_trusted_interactive_population_release(
+            &fixture.request,
+            &fixture.snapshot,
+            &fixture.key,
+        ),
+        Err(TrustedInteractiveReleaseError::AccountantReleaseContextMismatch)
+    ));
+}
+
+#[test]
+fn output_schema_substitution_breaks_accountant_context_binding() {
+    let mut fixture = fixture();
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut interactive) =
+        fixture.request.mode
+    else {
+        unreachable!()
+    };
+    interactive.output_schema_digest = digest(DigestDomain::ClinicalArtifact, 78);
+    assert!(matches!(
+        authorize_trusted_interactive_population_release(
+            &fixture.request,
+            &fixture.snapshot,
+            &fixture.key,
+        ),
+        Err(TrustedInteractiveReleaseError::AccountantReleaseContextMismatch)
     ));
 }
 

--- a/crates/clinical-population-release-context/Cargo.toml
+++ b/crates/clinical-population-release-context/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "mycelix-clinical-population-release-context"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Domain-separated scientific context binding for interactive population releases"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+mycelix-clinical-integrity = { path = "../clinical-integrity" }
+mycelix-clinical-population-release = { path = "../clinical-population-release" }

--- a/crates/clinical-population-release-context/src/lib.rs
+++ b/crates/clinical-population-release-context/src/lib.rs
@@ -1,0 +1,85 @@
+#![deny(unsafe_code)]
+//! Exact scientific-context binding for interactive population releases.
+//!
+//! This crate intentionally does not decide whether a release is authorized. It
+//! computes one domain-separated identity for the exact scientific context that
+//! an already-validated interactive DP accountant transition claims to release.
+
+use mycelix_clinical_integrity::{hash_canonical_bytes, DigestDomain, IntegrityError, StoredDigest};
+use mycelix_clinical_population_release::{
+    PopulationFindingKindV1, PopulationReleaseDigestV1, PopulationReleaseError,
+    PopulationReleaseModeV1, PopulationReleaseRequestV1,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct InteractivePopulationReleaseContextV1 {
+    pub schema_version: u16,
+    pub release_policy_digest: PopulationReleaseDigestV1,
+    pub source_finding_kind: PopulationFindingKindV1,
+    pub source_finding_digest: StoredDigest,
+    pub query_specification_digest: StoredDigest,
+    pub output_schema_digest: StoredDigest,
+    pub public_output_digest: StoredDigest,
+    pub mechanism_digest: PopulationReleaseDigestV1,
+}
+
+impl InteractivePopulationReleaseContextV1 {
+    pub fn from_request(
+        request: &PopulationReleaseRequestV1,
+    ) -> Result<Self, PopulationReleaseContextError> {
+        request.validate()?;
+        let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(interactive) = &request.mode
+        else {
+            return Err(PopulationReleaseContextError::NotInteractiveRelease);
+        };
+
+        Ok(Self {
+            schema_version: 1,
+            release_policy_digest: request.policy.verified_digest()?,
+            source_finding_kind: interactive.source_finding_kind,
+            source_finding_digest: interactive.source_finding_digest,
+            query_specification_digest: interactive.query_specification_digest,
+            output_schema_digest: interactive.output_schema_digest,
+            public_output_digest: interactive.public_output_digest,
+            mechanism_digest: interactive.mechanism.verified_digest(&request.policy)?,
+        })
+    }
+
+    pub fn verified_digest(&self) -> Result<StoredDigest, PopulationReleaseContextError> {
+        if self.schema_version != 1 {
+            return Err(PopulationReleaseContextError::UnsupportedVersion(
+                self.schema_version,
+            ));
+        }
+        let canonical = serde_json::to_vec(self)
+            .map_err(|error| PopulationReleaseContextError::Serialization(error.to_string()))?;
+        Ok(hash_canonical_bytes(
+            DigestDomain::ClinicalPopulationReleaseContext,
+            &canonical,
+        )?
+        .stored())
+    }
+}
+
+pub fn interactive_release_context_digest(
+    request: &PopulationReleaseRequestV1,
+) -> Result<StoredDigest, PopulationReleaseContextError> {
+    InteractivePopulationReleaseContextV1::from_request(request)?.verified_digest()
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum PopulationReleaseContextError {
+    #[error("population release request is not interactive differential privacy")]
+    NotInteractiveRelease,
+    #[error("unsupported population release context version {0}")]
+    UnsupportedVersion(u16),
+    #[error("population release context serialization failed: {0}")]
+    Serialization(String),
+    #[error(transparent)]
+    Release(#[from] PopulationReleaseError),
+    #[error(transparent)]
+    Integrity(#[from] IntegrityError),
+}

--- a/crates/clinical-population-release-context/tests/context.rs
+++ b/crates/clinical-population-release-context/tests/context.rs
@@ -1,0 +1,180 @@
+use mycelix_clinical_integrity::{DigestAlgorithm, DigestDomain, StoredDigest};
+use mycelix_clinical_population_release::{
+    DifferentialPrivacyMechanismV1, DpMechanismKindV1, InteractiveDpReleaseRequestV1,
+    PopulationFindingKindV1, PopulationReleaseArtifactKindV1, PopulationReleaseDigestV1,
+    PopulationReleaseModeV1, PopulationReleasePolicyV1, PopulationReleaseRequestV1,
+    PrivacyAccountantReceiptV1, PrivacyLossV1, ReducedFractionV1,
+};
+use mycelix_clinical_population_release_context::{
+    interactive_release_context_digest, InteractivePopulationReleaseContextV1,
+    PopulationReleaseContextError,
+};
+
+fn digest(domain: DigestDomain, seed: u8) -> StoredDigest {
+    StoredDigest {
+        algorithm: DigestAlgorithm::Blake3_256,
+        domain,
+        value: [seed; 32],
+    }
+}
+
+fn fraction(numerator: u64, denominator: u64) -> ReducedFractionV1 {
+    ReducedFractionV1 {
+        numerator,
+        denominator,
+    }
+}
+
+fn loss(epsilon_n: u64, epsilon_d: u64, delta_n: u64, delta_d: u64) -> PrivacyLossV1 {
+    PrivacyLossV1 {
+        epsilon: fraction(epsilon_n, epsilon_d),
+        delta: fraction(delta_n, delta_d),
+    }
+}
+
+fn policy() -> PopulationReleasePolicyV1 {
+    PopulationReleasePolicyV1 {
+        schema_version: 1,
+        policy_id: "population-release-policy-v1".into(),
+        static_minimum_cell_count: 11,
+        max_static_report_cells: 10_000,
+        allowed_dp_mechanisms: vec![DpMechanismKindV1::Gaussian],
+        max_per_release_privacy_loss: loss(1, 2, 1, 100_000),
+        max_cumulative_privacy_loss: loss(2, 1, 1, 1_000),
+        max_interactive_queries: 100,
+        accountant_instance_digest: digest(DigestDomain::ClinicalArtifact, 1),
+        accountant_method_digest: digest(DigestDomain::ClinicalArtifact, 2),
+    }
+}
+
+fn mechanism(policy: &PopulationReleasePolicyV1) -> DifferentialPrivacyMechanismV1 {
+    DifferentialPrivacyMechanismV1 {
+        schema_version: 1,
+        mechanism_id: "gaussian-count-v1".into(),
+        mechanism_kind: DpMechanismKindV1::Gaussian,
+        implementation_version: "1.0.0".into(),
+        implementation_digest: digest(DigestDomain::ClinicalArtifact, 20),
+        privacy_unit_definition_digest: digest(DigestDomain::ClinicalArtifact, 21),
+        adjacency_definition_digest: digest(DigestDomain::ClinicalArtifact, 22),
+        contribution_bounds_digest: digest(DigestDomain::ClinicalArtifact, 23),
+        sensitivity_analysis_digest: digest(DigestDomain::ClinicalArtifact, 24),
+        randomness_source_evidence_digest: digest(DigestDomain::ClinicalArtifact, 25),
+        release_privacy_loss: loss(1, 10, 1, 1_000_000),
+    }
+}
+
+fn request() -> PopulationReleaseRequestV1 {
+    let policy = policy();
+    let mechanism = mechanism(&policy);
+    let query = digest(DigestDomain::ClinicalArtifact, 31);
+    let output = digest(DigestDomain::ClinicalArtifact, 32);
+    let mechanism_digest = mechanism.verified_digest(&policy).unwrap();
+    let before = PrivacyAccountantReceiptV1 {
+        schema_version: 1,
+        accountant_instance_digest: policy.accountant_instance_digest,
+        accountant_method_digest: policy.accountant_method_digest,
+        sequence: 0,
+        previous_receipt_digest: None,
+        cumulative_privacy_loss: PrivacyLossV1::ZERO,
+        query_count: 0,
+        last_query_spec_digest: None,
+        last_mechanism_digest: None,
+        last_output_digest: None,
+        accountant_evidence_digest: digest(DigestDomain::ClinicalArtifact, 30),
+        observed_at_micros: 100,
+    };
+    let after = PrivacyAccountantReceiptV1 {
+        schema_version: 1,
+        accountant_instance_digest: policy.accountant_instance_digest,
+        accountant_method_digest: policy.accountant_method_digest,
+        sequence: 1,
+        previous_receipt_digest: Some(before.verified_digest(&policy).unwrap()),
+        cumulative_privacy_loss: loss(1, 10, 1, 1_000_000),
+        query_count: 1,
+        last_query_spec_digest: Some(query),
+        last_mechanism_digest: Some(mechanism_digest),
+        last_output_digest: Some(output),
+        accountant_evidence_digest: digest(DigestDomain::ClinicalArtifact, 33),
+        observed_at_micros: 110,
+    };
+
+    PopulationReleaseRequestV1 {
+        schema_version: 1,
+        release_id: "interactive-release-1".into(),
+        policy,
+        mode: PopulationReleaseModeV1::InteractiveDifferentialPrivacy(
+            InteractiveDpReleaseRequestV1 {
+                source_finding_kind: PopulationFindingKindV1::CausalEffectEstimate,
+                source_finding_digest: digest(DigestDomain::ClinicalCausalEffectEstimate, 34),
+                query_specification_digest: query,
+                output_schema_digest: digest(DigestDomain::ClinicalArtifact, 35),
+                public_output_digest: output,
+                mechanism,
+                accountant_before: before,
+                accountant_after: after,
+            },
+        ),
+        requested_at_micros: 120,
+    }
+}
+
+#[test]
+fn context_uses_dedicated_integrity_domain() {
+    let digest = interactive_release_context_digest(&request()).unwrap();
+    assert_eq!(digest.domain, DigestDomain::ClinicalPopulationReleaseContext);
+}
+
+#[test]
+fn source_finding_substitution_changes_context_identity() {
+    let original = request();
+    let original_digest = interactive_release_context_digest(&original).unwrap();
+    let mut substituted = original;
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut interactive) =
+        substituted.mode
+    else {
+        unreachable!()
+    };
+    interactive.source_finding_digest =
+        digest(DigestDomain::ClinicalCausalEffectEstimate, 99);
+    let substituted_digest = interactive_release_context_digest(&substituted).unwrap();
+    assert_ne!(original_digest, substituted_digest);
+}
+
+#[test]
+fn output_schema_substitution_changes_context_identity() {
+    let original = request();
+    let original_digest = interactive_release_context_digest(&original).unwrap();
+    let mut substituted = original;
+    let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut interactive) =
+        substituted.mode
+    else {
+        unreachable!()
+    };
+    interactive.output_schema_digest = digest(DigestDomain::ClinicalArtifact, 98);
+    let substituted_digest = interactive_release_context_digest(&substituted).unwrap();
+    assert_ne!(original_digest, substituted_digest);
+}
+
+#[test]
+fn static_request_is_not_an_interactive_release_context() {
+    let context = InteractivePopulationReleaseContextV1 {
+        schema_version: 2,
+        release_policy_digest: PopulationReleaseDigestV1 {
+            kind: PopulationReleaseArtifactKindV1::ReleasePolicy,
+            value: [1; 32],
+        },
+        source_finding_kind: PopulationFindingKindV1::CausalEffectEstimate,
+        source_finding_digest: digest(DigestDomain::ClinicalCausalEffectEstimate, 2),
+        query_specification_digest: digest(DigestDomain::ClinicalArtifact, 3),
+        output_schema_digest: digest(DigestDomain::ClinicalArtifact, 4),
+        public_output_digest: digest(DigestDomain::ClinicalArtifact, 5),
+        mechanism_digest: PopulationReleaseDigestV1 {
+            kind: PopulationReleaseArtifactKindV1::DpMechanismDescriptor,
+            value: [6; 32],
+        },
+    };
+    assert!(matches!(
+        context.verified_digest(),
+        Err(PopulationReleaseContextError::UnsupportedVersion(2))
+    ));
+}

--- a/docs/security/CLINICAL_POPULATION_RELEASE_CONTEXT_V1.md
+++ b/docs/security/CLINICAL_POPULATION_RELEASE_CONTEXT_V1.md
@@ -1,0 +1,68 @@
+# Clinical Population Interactive Release Context V1
+
+## Purpose
+
+Interactive differential-privacy accounting and scientific attribution are separate concerns.
+A privacy accountant can correctly charge an exact query/output while the application later
+mislabels that output as belonging to a different source finding or output schema. V1 closes
+that substitution gap with one domain-separated protected release-context identity.
+
+## Context identity
+
+`InteractivePopulationReleaseContextV1` binds exactly:
+
+- release-policy digest;
+- source-finding epistemic class;
+- exact source-finding digest;
+- query-specification digest;
+- output-schema digest;
+- public-output digest;
+- exact DP-mechanism descriptor digest.
+
+The canonical bytes are hashed under `DigestDomain::ClinicalPopulationReleaseContext`.
+The variant was appended to the shared digest-domain enum so existing variant ordering is
+not changed.
+
+## Accountant binding
+
+For the high-assurance interactive path, the protected `accountant_after` receipt MUST set
+`accountant_evidence_digest` to the exact release-context digest. The trusted release gate
+recomputes the context from the request and refuses authorization on any mismatch.
+
+Therefore changing only the source finding, output schema, query, mechanism, public output,
+or release policy requires a different accountant evidence commitment.
+
+## Trust boundary
+
+This binding proves attribution consistency between the protected accountant transition and
+the interactive release request. It does NOT prove:
+
+- that the source finding itself is scientifically correct;
+- that the output schema is clinically appropriate;
+- that the DP implementation is correctly implemented;
+- that the canonical DHT read is globally complete;
+- that a serialized trusted-release receipt is reusable authority.
+
+Those remain separate evidence/qualification boundaries.
+
+## Privacy
+
+The exact release-context digest stays in the protected accountant receipt and trusted release
+receipt. The public accountant-state projection continues to expose only a keyed commitment to
+the full protected receipt; it does not reveal the source finding, query, schema, or output.
+
+## Adversarial invariants
+
+- source-finding substitution changes the release-context digest;
+- output-schema substitution changes the release-context digest;
+- a trusted interactive release fails if `accountant_after.accountant_evidence_digest` does not
+  equal the recomputed context digest;
+- a deserialized trusted release receipt rejects a context digest outside the dedicated domain;
+- the context digest is preserved in the consumed trusted release receipt.
+
+## Promotion blockers
+
+This tranche remains draft until exact-head CI executes successfully. Broad interactive release
+also remains blocked on the conductor/race qualification tracked in #92 and the legacy interactive
+authority ambiguity tracked in #95. Canonical publication/deduplication remains separately tracked
+in #98.


### PR DESCRIPTION
## Stack

Depends on #96 -> #94 -> #93 -> #91 -> #88 -> #87 -> #86 -> #85 -> #84 -> #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49.

## Why

#96 proves that an interactive DP output consumes an exact trusted canonical privacy-accountant transition. However, the protected accountant transition previously bound query/mechanism/output but did not cryptographically bind the exact scientific source finding or output schema under which the output is released.

This PR implements P0 #97.

## Exact release context

Adds `DigestDomain::ClinicalPopulationReleaseContext` and the pure `mycelix-clinical-population-release-context` crate. The context binds exactly:

- release-policy digest;
- source-finding epistemic class;
- exact source-finding digest;
- query-specification digest;
- output-schema digest;
- public-output digest;
- exact DP-mechanism descriptor digest.

The new digest-domain variant is appended so existing enum ordering is preserved.

## Trusted gate hardening

`authorize_trusted_interactive_population_release()` now recomputes the exact context and requires:

`accountant_after.accountant_evidence_digest == release_context_digest`

before any trusted release capability can be minted.

The trusted release capability/receipt preserves that context digest, and deserialized receipt verification requires the dedicated domain.

## Adversarial coverage

- source-finding substitution changes context identity;
- output-schema substitution changes context identity;
- source-finding substitution at the trusted gate fails with `AccountantReleaseContextMismatch`;
- output-schema substitution at the trusted gate fails with `AccountantReleaseContextMismatch`;
- successful trusted receipts retain the dedicated context domain.

## Non-claims / blockers

This is scientific-attribution binding, not evidence-class promotion or proof that the underlying source finding is correct.

Broad interactive release remains draft pending exact-head CI, #92 conductor/race qualification, and #95 legacy interactive authority closure. #98 separately tracks canonical publication identity/deduplication.