### PR TITLE
privacy(population): split static authority from interactive preflight

### DIFF
--- a/crates/clinical-population-release/README.md
+++ b/crates/clinical-population-release/README.md
@@ -5,6 +5,14 @@ Experimental privacy-release preflight/qualification primitives for population e
 Supported v1 paths:
 
 - fixed/pre-specified static reports with primary + complementary suppression and composition-review evidence;
-- interactive differential-privacy releases with exact mechanism descriptors and chained accountant receipts.
+- interactive differential-privacy **preflight validation** with exact mechanism descriptors and chained accountant receipts.
+
+Authority is intentionally split:
+
+- `authorize_static_population_release()` may mint the base `PopulationReleaseCapabilityV1` only for static pre-specified reports;
+- interactive DP requests may validate here, but this crate refuses to mint base release authority for them;
+- production interactive release must use the separate trusted canonical-accountant gate (`mycelix-clinical-population-interactive-release`).
+
+The compatibility function `authorize_population_release()` is also static-only and returns `InteractiveReleaseRequiresTrustedGate` for interactive requests. There is no compatibility conversion from the base capability to trusted interactive authority.
 
 This crate does **not** itself establish institutional trust in suppression review, DP implementations, or privacy-accountant state. See `docs/security/CLINICAL_POPULATION_RELEASE_V1.md` and the qualification checklist.

--- a/crates/clinical-population-release/src/lib.rs
+++ b/crates/clinical-population-release/src/lib.rs
@@ -582,7 +582,9 @@ pub enum PopulationReleaseModeClassV1 {
     InteractiveDifferentialPrivacy,
 }
 
-/// Non-serializable capability created only after all v1 release checks succeed.
+/// Non-serializable authority for static pre-specified report release only.
+/// Interactive requests may be validated by this crate, but they require the
+/// separate high-assurance trusted interactive release gate to mint authority.
 pub struct PopulationReleaseCapabilityV1 {
     request_digest: PopulationReleaseDigestV1,
     policy_digest: PopulationReleaseDigestV1,
@@ -592,32 +594,34 @@ pub struct PopulationReleaseCapabilityV1 {
     requested_at_micros: i64,
 }
 
-pub fn authorize_population_release(
+pub fn authorize_static_population_release(
     request: &PopulationReleaseRequestV1,
 ) -> Result<PopulationReleaseCapabilityV1, PopulationReleaseError> {
     request.validate()?;
+    let static_request = match &request.mode {
+        PopulationReleaseModeV1::StaticPreSpecifiedReport(value) => value,
+        PopulationReleaseModeV1::InteractiveDifferentialPrivacy(_) => {
+            return Err(PopulationReleaseError::InteractiveReleaseRequiresTrustedGate)
+        }
+    };
     let request_digest = request.verified_digest()?;
     let policy_digest = request.policy.verified_digest()?;
-    let (source_finding_digest, public_output_digest, mode) = match &request.mode {
-        PopulationReleaseModeV1::StaticPreSpecifiedReport(static_request) => (
-            static_request.suppression.source_finding_digest,
-            static_request.suppression.public_output_digest,
-            PopulationReleaseModeClassV1::StaticPreSpecifiedReport,
-        ),
-        PopulationReleaseModeV1::InteractiveDifferentialPrivacy(dp_request) => (
-            dp_request.source_finding_digest,
-            dp_request.public_output_digest,
-            PopulationReleaseModeClassV1::InteractiveDifferentialPrivacy,
-        ),
-    };
     Ok(PopulationReleaseCapabilityV1 {
         request_digest,
         policy_digest,
-        source_finding_digest,
-        public_output_digest,
-        mode,
+        source_finding_digest: static_request.suppression.source_finding_digest,
+        public_output_digest: static_request.suppression.public_output_digest,
+        mode: PopulationReleaseModeClassV1::StaticPreSpecifiedReport,
         requested_at_micros: request.requested_at_micros,
     })
+}
+
+/// Compatibility name retained for callers migrating from the original v1 API.
+/// It is intentionally static-only and cannot mint interactive release authority.
+pub fn authorize_population_release(
+    request: &PopulationReleaseRequestV1,
+) -> Result<PopulationReleaseCapabilityV1, PopulationReleaseError> {
+    authorize_static_population_release(request)
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -820,6 +824,8 @@ pub enum PopulationReleaseError {
     AccountantTimeWentBackwards,
     #[error("privacy-accountant transition does not bind this exact query/mechanism/output")]
     AccountantTransitionDoesNotBindRelease,
+    #[error("interactive DP release requires the trusted canonical-accountant gate")]
+    InteractiveReleaseRequiresTrustedGate,
     #[error("release time precedes request time")]
     ReleaseTimeBeforeRequest,
     #[error("serialization failed: {0}")]

--- a/crates/clinical-population-release/tests/boundaries.rs
+++ b/crates/clinical-population-release/tests/boundaries.rs
@@ -165,7 +165,7 @@ fn qualified_static_request_mints_consumable_release_receipt() {
         }),
         requested_at_micros: 100,
     };
-    let receipt = authorize_population_release(&request)
+    let receipt = authorize_static_population_release(&request)
         .unwrap()
         .into_receipt(101)
         .unwrap();
@@ -177,9 +177,23 @@ fn qualified_static_request_mints_consumable_release_receipt() {
 }
 
 #[test]
-fn interactive_release_binds_exact_accountant_query_mechanism_and_output() {
+fn valid_interactive_preflight_cannot_mint_base_release_capability() {
     let request = interactive_request();
-    authorize_population_release(&request).unwrap();
+    request.validate().unwrap();
+    assert!(matches!(
+        authorize_static_population_release(&request),
+        Err(PopulationReleaseError::InteractiveReleaseRequiresTrustedGate)
+    ));
+    assert!(matches!(
+        authorize_population_release(&request),
+        Err(PopulationReleaseError::InteractiveReleaseRequiresTrustedGate)
+    ));
+}
+
+#[test]
+fn interactive_preflight_binds_exact_accountant_query_mechanism_and_output() {
+    let request = interactive_request();
+    request.validate().unwrap();
 
     let mut substituted = request.clone();
     let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut dp) = substituted.mode
@@ -188,13 +202,13 @@ fn interactive_release_binds_exact_accountant_query_mechanism_and_output() {
     };
     dp.public_output_digest = digest(DigestDomain::ClinicalArtifact, 99);
     assert!(matches!(
-        authorize_population_release(&substituted),
+        substituted.validate(),
         Err(PopulationReleaseError::AccountantTransitionDoesNotBindRelease)
     ));
 }
 
 #[test]
-fn accountant_predecessor_substitution_fails_closed() {
+fn accountant_predecessor_substitution_fails_closed_in_preflight() {
     let mut request = interactive_request();
     let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut dp) = request.mode else {
         unreachable!()
@@ -204,20 +218,20 @@ fn accountant_predecessor_substitution_fails_closed() {
         value: [77; 32],
     });
     assert!(matches!(
-        authorize_population_release(&request),
+        request.validate(),
         Err(PopulationReleaseError::AccountantPredecessorMismatch)
     ));
 }
 
 #[test]
-fn wrong_source_finding_domain_fails_closed() {
+fn wrong_source_finding_domain_fails_closed_in_preflight() {
     let mut request = interactive_request();
     let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut dp) = request.mode else {
         unreachable!()
     };
     dp.source_finding_digest = digest(DigestDomain::ClinicalSafetySignalCandidate, 55);
     assert!(matches!(
-        authorize_population_release(&request),
+        request.validate(),
         Err(PopulationReleaseError::WrongSourceFindingDomain { .. })
     ));
 }
@@ -235,14 +249,14 @@ fn noncanonical_fraction_is_rejected() {
 }
 
 #[test]
-fn cumulative_budget_cannot_exceed_bound_policy() {
+fn cumulative_budget_cannot_exceed_bound_policy_in_preflight() {
     let mut request = interactive_request();
     let PopulationReleaseModeV1::InteractiveDifferentialPrivacy(ref mut dp) = request.mode else {
         unreachable!()
     };
     dp.accountant_after.cumulative_privacy_loss = loss(3, 1, 1, 1_000_000);
     assert!(matches!(
-        authorize_population_release(&request),
+        request.validate(),
         Err(PopulationReleaseError::CumulativePrivacyBudgetExceeded)
     ));
 }

--- a/docs/security/CLINICAL_POPULATION_RELEASE_V1.md
+++ b/docs/security/CLINICAL_POPULATION_RELEASE_V1.md
@@ -6,12 +6,14 @@ Experimental protected-boundary contract. Not a de-identification certification,
 
 ## Goal
 
-Population evidence can contain case counts, cohort counts, strata and analysis outputs that are useful for medicine/research but unsafe to expose by default. V1 creates a release gate with only two supported modes:
+Population evidence can contain case counts, cohort counts, strata and analysis outputs that are useful for medicine/research but unsafe to expose by default. V1 creates a release boundary with two supported evidence modes:
 
 1. `StaticPreSpecifiedReport`
 2. `InteractiveDifferentialPrivacy`
 
 There is intentionally no threshold-only interactive-query mode.
+
+Authority is asymmetric by design: this base crate may mint release authority only for static pre-specified reports. Interactive differential-privacy requests can be structurally validated here as preflight evidence, but actual interactive release authority requires the separate trusted canonical-accountant gate.
 
 ## Static pre-specified reports
 
@@ -32,7 +34,7 @@ Static threshold suppression is intentionally limited to a fixed/pre-specified r
 
 ## Interactive differential privacy
 
-An interactive release binds the exact:
+An interactive preflight binds the exact:
 
 - source population finding;
 - query specification;
@@ -58,7 +60,7 @@ NIST SP 800-226 is the design reference for treating differential privacy as a c
 
 V1 represents epsilon/delta as reduced rational numbers rather than floating-point values. This avoids NaN/infinity/serialization ambiguity and gives one canonical representation for artifact hashing.
 
-The release gate checks:
+The preflight checks:
 
 - delta is within `[0,1]`;
 - the mechanism is explicitly allowed by policy;
@@ -69,13 +71,13 @@ The release gate checks:
 - cumulative reported loss cannot decrease;
 - the successor accountant receipt binds the exact query, mechanism and public output.
 
-The gate does **not** implement a differential-privacy accountant or attempt to reproduce its mathematics. The accountant method/version/evidence are explicit inputs.
+The base crate does **not** implement a differential-privacy accountant or attempt to reproduce its mathematics. The accountant method/version/evidence are explicit inputs.
 
 ## Accountant trust boundary
 
 `PrivacyAccountantReceiptV1` is serializable evidence. A malicious caller can serialize a structurally plausible receipt.
 
-Therefore the pure v1 crate proves only:
+Therefore the pure base crate proves only:
 
 - canonical receipt shape;
 - exact policy binding;
@@ -83,13 +85,21 @@ Therefore the pure v1 crate proves only:
 - monotonic bounded counters/loss;
 - exact query/mechanism/output binding.
 
-Promotion requires a verifier-owned trust layer that establishes the deployment-selected accountant implementation/state root and prevents arbitrary genesis/state fabrication.
+The trusted interactive path is separate: DNA-rooted accountant state, canonical discovery, bounded conflict-preserving state reduction, protected-receipt commitment binding and exact scientific release-context binding are composed in the higher-assurance interactive release stack.
 
-## Release capability
+## Release authority split
 
-Only a validated request can create the non-serializable `PopulationReleaseCapabilityV1`. Consuming it creates a `PopulationReleaseReceiptV1` bound to the exact request/policy/source/output/mode and release time.
+`PopulationReleaseCapabilityV1` is now static-only.
 
-This reduces accidental bypass in safe code. It is not a defense against hostile code that can fabricate every upstream evidence artifact.
+- `authorize_static_population_release()` rejects interactive requests with `InteractiveReleaseRequiresTrustedGate`.
+- the compatibility name `authorize_population_release()` delegates to the same static-only path;
+- `PopulationReleaseRequestV1::validate()` remains available for interactive preflight validation;
+- no compatibility API converts `PopulationReleaseCapabilityV1` into trusted interactive authority;
+- production interactive release sinks must accept only `TrustedInteractivePopulationReleaseCapabilityV1` from `mycelix-clinical-population-interactive-release`.
+
+The historical wire enum retains `InteractiveDifferentialPrivacy` so historical evidence can remain readable; retaining a wire value is not authority to mint a new interactive release.
+
+Consuming a static base capability creates `PopulationReleaseReceiptV1` bound to the exact request/policy/source/output/mode and release time.
 
 ## Epistemic invariants
 
@@ -119,10 +129,11 @@ V1 does not claim:
 Before broad production release:
 
 1. qualify suppression/composition review authority;
-2. qualify trusted accountant admission/state roots;
+2. qualify trusted accountant admission/state roots and conductor-level fork/race behavior;
 3. execute exact-head CI;
 4. execute differencing and overlapping-query adversarial tests;
 5. execute accountant replay/fork/budget tests;
 6. independently review DP mechanism implementations and sensitivity/contribution bounds;
 7. review jurisdiction-specific disclosure requirements;
-8. ensure released outputs are the minimum necessary for the approved purpose.
+8. ensure released outputs are the minimum necessary for the approved purpose;
+9. retain the static-only base capability / trusted-interactive capability split at every release sink.


### PR DESCRIPTION
## Stack

Depends on #99 -> #96 -> #94 -> #93 -> #91 -> #88 -> #87 -> #86 -> #85 -> #84 -> #82 -> #81 -> #80 -> #74 -> #73 -> #71 -> #70 -> #69 -> #68 -> #66 -> #64 -> #62 -> #61 -> #60 -> #57 -> #55 -> #54 -> #53 -> #52 -> #51 -> #49.

## Why

P0 #95 identified a remaining authority ambiguity: the base `clinical-population-release` crate could validate interactive DP preflight and also mint the same generic `PopulationReleaseCapabilityV1`, even though trusted canonical accountant state now lives in #93/#94/#96/#99.

This PR removes that software bypass without breaking historical wire formats.

## Authority split

- `PopulationReleaseRequestV1::validate()` continues to validate both static and interactive preflight evidence.
- `authorize_static_population_release()` mints `PopulationReleaseCapabilityV1` only for `StaticPreSpecifiedReport`.
- the compatibility name `authorize_population_release()` delegates to the same static-only path.
- either authorizer rejects interactive DP with `InteractiveReleaseRequiresTrustedGate`.
- there is no conversion from the base capability into `TrustedInteractivePopulationReleaseCapabilityV1`.
- production interactive sinks must accept only the trusted capability from `mycelix-clinical-population-interactive-release`.

The historical `InteractiveDifferentialPrivacy` wire enum value is retained so old evidence can remain readable; it is no longer mintable as new base release authority.

## Tests

- static reports still mint and consume the base release capability;
- a structurally valid interactive request passes preflight validation but both base authorizers refuse authority;
- interactive query/mechanism/output, predecessor, source-domain and budget failures remain testable through `request.validate()`.

## Qualification

This remains draft until exact-head CI executes successfully. Broad interactive release still depends on #92 conductor/race qualification; #99 supplies the exact scientific release-context binding.